### PR TITLE
docs: fix Provider trait drift in RFC 001

### DIFF
--- a/docs/rfc-001-architecture-migration.md
+++ b/docs/rfc-001-architecture-migration.md
@@ -90,8 +90,9 @@ pub trait Flow {
 An external identity source (e.g., Google, GitHub). Providers should contain zero business logic—only configuration and mapping.
 
 ```rust
-pub trait Provider {
-    fn config(&self) -> ProviderConfig;
+#[async_trait]
+pub trait Provider: Send + Sync {
+    async fn config(&self) -> ProviderConfig;
 }
 ```
 


### PR DESCRIPTION
Updates the Provider trait in RFC 001 to match the merged code.