### PR TITLE
fix: restore authkestra-op lost in bad merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "authkestra-op"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "authkestra-engine",
+ "authkestra-resource",
+ "chrono",
+ "jsonwebtoken",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "authkestra-providers"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "authkestra-resource",
     "authkestra",
     "authkestra-examples",
+    "authkestra-op",
 ]
 
 [workspace.package]
@@ -31,3 +32,4 @@ authkestra-actix = { version = "0.1.3", path = "authkestra-actix" }
 authkestra-resource = { version = "0.1.0", path = "authkestra-resource" }
 authkestra = { version = "0.1.2", path = "authkestra" }
 authkestra-examples = { version = "0.1.0", path = "authkestra-examples" }
+authkestra-op = { version = "0.1.0", path = "authkestra-op" }

--- a/authkestra-op/Cargo.toml
+++ b/authkestra-op/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "authkestra-op"
+version = "0.1.0"
+edition.workspace = true
+description = "OpenID Provider (OP) support for the authkestra framework — issue tokens and run the authorization code grant, rather than only consuming an external IdP"
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+authkestra-engine = { workspace = true, features = ["token"] }
+authkestra-resource = { workspace = true }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "2.0.18"
+async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1.0", features = ["v4"] }
+jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["full"] }

--- a/authkestra-op/src/client.rs
+++ b/authkestra-op/src/client.rs
@@ -1,0 +1,103 @@
+use crate::error::OpError;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+/// OAuth2/OIDC grant types a client may be permitted to use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GrantType {
+    /// Standard authorization code grant (with or without PKCE).
+    AuthorizationCode,
+    /// Refresh token grant.
+    RefreshToken,
+    /// Client credentials grant (machine-to-machine). See RFC-003 §9, `OP.7`.
+    ClientCredentials,
+}
+
+/// A registered OAuth2/OIDC client application.
+///
+/// `redirect_uris` are matched **exactly** (no prefix/wildcard matching) —
+/// see RFC-003 §7. This is the single most important invariant in this
+/// type; do not relax it for convenience.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClientRegistration {
+    /// Public client identifier.
+    pub client_id: String,
+    /// Hash of the client secret. Never store or log the plaintext secret.
+    /// `None` for public clients (e.g. SPAs, native apps using PKCE).
+    pub client_secret_hash: Option<String>,
+    /// Exact-match redirect URIs this client is permitted to use.
+    pub redirect_uris: Vec<String>,
+    /// Grant types this client is permitted to use.
+    pub grant_types: Vec<GrantType>,
+    /// Scopes this client is permitted to request.
+    pub scopes: Vec<String>,
+    /// Whether this client must use PKCE (mandatory for public clients,
+    /// recommended for all — see RFC-003 §7 / OAuth 2.1).
+    pub require_pkce: bool,
+}
+
+impl ClientRegistration {
+    /// Returns true if `redirect_uri` exactly matches one of this client's
+    /// registered URIs. Intentionally a plain `==` comparison — no
+    /// normalization, no prefix matching.
+    pub fn allows_redirect_uri(&self, redirect_uri: &str) -> bool {
+        self.redirect_uris.iter().any(|u| u == redirect_uri)
+    }
+
+    /// Returns true if this client is permitted to use `grant_type`.
+    pub fn allows_grant_type(&self, grant_type: GrantType) -> bool {
+        self.grant_types.contains(&grant_type)
+    }
+}
+
+/// Storage interface for registered clients.
+///
+/// Mirrors the existing `SessionStore` pattern in `authkestra-engine`:
+/// async trait, pluggable backends, in-memory implementation ships first.
+#[async_trait]
+pub trait ClientStore: Send + Sync {
+    /// Look up a client by its `client_id`. Returns `Ok(None)` (not an
+    /// error) if the client does not exist — callers map that to
+    /// `OpError::UnknownClient`.
+    async fn find_client(&self, client_id: &str) -> Result<Option<ClientRegistration>, OpError>;
+}
+
+/// A minimal in-memory `ClientStore`, intended for development and tests —
+/// not for production use (no persistence, no distribution across
+/// instances). Production deployments should implement `ClientStore`
+/// against their own database, the same way `authkestra-session-sql` does
+/// for `SessionStore`.
+#[derive(Default)]
+pub struct InMemoryClientStore {
+    clients: RwLock<HashMap<String, ClientRegistration>>,
+}
+
+impl InMemoryClientStore {
+    /// Creates an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers a client, replacing any existing registration with the
+    /// same `client_id`.
+    pub fn register(&self, client: ClientRegistration) {
+        self.clients
+            .write()
+            .expect("client store lock poisoned")
+            .insert(client.client_id.clone(), client);
+    }
+}
+
+#[async_trait]
+impl ClientStore for InMemoryClientStore {
+    async fn find_client(&self, client_id: &str) -> Result<Option<ClientRegistration>, OpError> {
+        Ok(self
+            .clients
+            .read()
+            .map_err(|_| OpError::Storage)?
+            .get(client_id)
+            .cloned())
+    }
+}

--- a/authkestra-op/src/code.rs
+++ b/authkestra-op/src/code.rs
@@ -1,0 +1,111 @@
+use crate::error::OpError;
+use async_trait::async_trait;
+use authkestra_engine::auth::state::Identity;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+/// An authorization code issued at `/authorize`, pending exchange at
+/// `/token`.
+///
+/// Codes are single-use (`used`) and short-lived (`expires_at`) — see
+/// RFC-003 §7. `AuthorizationCodeStore::consume_code` is responsible for
+/// enforcing single-use atomically; this struct is deliberately a plain
+/// data holder with no enforcement logic of its own.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthorizationCode {
+    /// The opaque code value handed to the client.
+    pub code: String,
+    /// The client this code was issued to.
+    pub client_id: String,
+    /// The exact redirect_uri presented at `/authorize`; `/token` must
+    /// receive the same value.
+    pub redirect_uri: String,
+    /// Space-delimited scopes granted.
+    pub scope: String,
+    /// PKCE code_challenge, if the client used PKCE.
+    pub code_challenge: Option<String>,
+    /// PKCE code_challenge_method (`plain` or `S256`).
+    pub code_challenge_method: Option<String>,
+    /// The authenticated identity this code represents.
+    pub identity: Identity,
+    /// When this code expires. Recommend issuing with a short lifetime
+    /// (≤60s per RFC-003 §7).
+    pub expires_at: DateTime<Utc>,
+    /// Whether this code has already been exchanged. Storage
+    /// implementations must treat consuming an already-used code as an
+    /// error, not a silent no-op.
+    pub used: bool,
+}
+
+impl AuthorizationCode {
+    /// Returns true if this code is expired as of `now`.
+    pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
+        now >= self.expires_at
+    }
+}
+
+/// Storage interface for authorization codes.
+///
+/// `consume_code` **must** be atomic: check `used`, mark it used, and
+/// return the code as a single indivisible operation. A
+/// check-then-mark implemented as two separate storage calls is a
+/// TOCTOU race that permits code replay — this is the single most
+/// important correctness property in this crate. Implementations backed
+/// by SQL should use a single `UPDATE ... WHERE used = false RETURNING *`
+/// (or equivalent compare-and-swap) rather than a `SELECT` followed by an
+/// `UPDATE`.
+#[async_trait]
+pub trait AuthorizationCodeStore: Send + Sync {
+    /// Persists a newly issued code.
+    async fn store_code(&self, code: AuthorizationCode) -> Result<(), OpError>;
+
+    /// Atomically retrieves and invalidates a code by its value. Returns
+    /// `Ok(None)` if the code does not exist, is already used, or is
+    /// expired — callers map that to `OpError::InvalidCode` without
+    /// distinguishing which case occurred, to avoid leaking timing/existence
+    /// information to a potential attacker.
+    async fn consume_code(&self, code: &str) -> Result<Option<AuthorizationCode>, OpError>;
+}
+
+/// A minimal in-memory `AuthorizationCodeStore` for development and tests.
+/// Not suitable for production (no persistence, no cross-instance sharing,
+/// no expiry sweep — expired-but-unconsumed codes are only checked lazily
+/// on lookup, not proactively evicted).
+#[derive(Default)]
+pub struct InMemoryAuthorizationCodeStore {
+    codes: RwLock<HashMap<String, AuthorizationCode>>,
+}
+
+impl InMemoryAuthorizationCodeStore {
+    /// Creates an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl AuthorizationCodeStore for InMemoryAuthorizationCodeStore {
+    async fn store_code(&self, code: AuthorizationCode) -> Result<(), OpError> {
+        self.codes
+            .write()
+            .map_err(|_| OpError::Storage)?
+            .insert(code.code.clone(), code);
+        Ok(())
+    }
+
+    async fn consume_code(&self, code: &str) -> Result<Option<AuthorizationCode>, OpError> {
+        let mut codes = self.codes.write().map_err(|_| OpError::Storage)?;
+        // `get_mut` + check + mutate while holding the write lock is the
+        // atomic step this trait's contract requires — do not replace this
+        // with a separate read followed by a separate write.
+        match codes.get_mut(code) {
+            Some(entry) if !entry.used && !entry.is_expired(Utc::now()) => {
+                entry.used = true;
+                Ok(Some(entry.clone()))
+            }
+            _ => Ok(None),
+        }
+    }
+}

--- a/authkestra-op/src/config.rs
+++ b/authkestra-op/src/config.rs
@@ -1,0 +1,57 @@
+use serde::{Deserialize, Serialize};
+
+/// Provider-level configuration used to answer discovery requests and
+/// validate incoming `/authorize` and `/token` requests.
+///
+/// This is deliberately separate from any single `ClientRegistration` —
+/// it describes what the *provider* supports, not what one client is
+/// permitted to use (that's `ClientRegistration::scopes`/`grant_types`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpConfig {
+    /// The issuer URL, used as the `iss` claim on issued tokens and as the
+    /// base for discovery/JWKS endpoint URLs. No trailing slash.
+    pub issuer: String,
+    /// Scopes this provider is willing to grant, across all clients. A
+    /// client's own `scopes` list (see `ClientRegistration`) is further
+    /// restricted to a subset of this.
+    pub scopes_supported: Vec<String>,
+    /// Response types supported at `/authorize`. Start with `["code"]`
+    /// only — no implicit or hybrid flows, per OAuth 2.1.
+    pub response_types_supported: Vec<String>,
+    /// Grant types supported at `/token`.
+    pub grant_types_supported: Vec<String>,
+    /// Signing algorithm for ID tokens. Must be an asymmetric algorithm
+    /// (e.g. `"RS256"`) — see RFC-003 §4. Symmetric algorithms (`HS256`)
+    /// are intentionally not valid here.
+    pub id_token_signing_alg: String,
+    /// Lifetime, in seconds, of issued authorization codes. Keep short
+    /// (RFC-003 §7 recommends ≤60).
+    pub authorization_code_ttl_secs: i64,
+}
+
+impl OpConfig {
+    /// Builds the well-known discovery document URL for this issuer.
+    pub fn discovery_url(&self) -> String {
+        format!("{}/.well-known/openid-configuration", self.issuer)
+    }
+
+    /// Builds the JWKS endpoint URL for this issuer.
+    pub fn jwks_url(&self) -> String {
+        format!("{}/jwks.json", self.issuer)
+    }
+
+    /// Builds the authorization endpoint URL for this issuer.
+    pub fn authorization_endpoint(&self) -> String {
+        format!("{}/authorize", self.issuer)
+    }
+
+    /// Builds the token endpoint URL for this issuer.
+    pub fn token_endpoint(&self) -> String {
+        format!("{}/token", self.issuer)
+    }
+
+    /// Builds the userinfo endpoint URL for this issuer.
+    pub fn userinfo_endpoint(&self) -> String {
+        format!("{}/userinfo", self.issuer)
+    }
+}

--- a/authkestra-op/src/error.rs
+++ b/authkestra-op/src/error.rs
@@ -1,0 +1,41 @@
+use thiserror::Error;
+
+/// Errors that can occur during OpenID Provider operations.
+#[derive(Debug, Error)]
+pub enum OpError {
+    /// The requested client_id is not registered.
+    #[error("unknown client: {0}")]
+    UnknownClient(String),
+
+    /// The provided redirect_uri does not exactly match a registered URI
+    /// for this client. Always treat this as a hard failure — never fall
+    /// back to a "closest match" or prefix comparison.
+    #[error("redirect_uri does not match a registered URI for this client")]
+    RedirectUriMismatch,
+
+    /// The authorization code was not found, already used, or expired.
+    #[error("invalid or expired authorization code")]
+    InvalidCode,
+
+    /// PKCE verification failed.
+    #[error("PKCE verification failed")]
+    PkceMismatch,
+
+    /// The client_secret did not match the stored hash.
+    #[error("invalid client credentials")]
+    InvalidClientCredentials,
+
+    /// The requested grant_type is not enabled for this client.
+    #[error("grant_type not permitted for this client")]
+    GrantTypeNotPermitted,
+
+    /// Underlying storage error, opaque to the caller by design — storage
+    /// backends should not leak implementation details (e.g. SQL errors)
+    /// into OAuth error responses.
+    #[error("storage error")]
+    Storage,
+
+    /// Token issuance failed at the `authkestra_engine::TokenService` layer.
+    #[error("token issuance failed: {0}")]
+    TokenIssuance(String),
+}

--- a/authkestra-op/src/lib.rs
+++ b/authkestra-op/src/lib.rs
@@ -1,0 +1,37 @@
+//! # Authkestra OP
+//!
+//! `authkestra-op` implements the OpenID Provider (OP) side of OIDC: issuing
+//! tokens and running the authorization code grant, as opposed to
+//! `authkestra-oidc`, which consumes an *external* OP as a relying party.
+//!
+//! This crate is intentionally handler-logic-only — it has no dependency on
+//! any web framework. `authkestra-axum` and `authkestra-actix` (behind an
+//! `op` feature flag) wrap these types into framework-native routes.
+//!
+//! ## Status
+//! This crate is a skeleton (RFC-003, PR `OP.0`). No handler logic has
+//! landed yet — see `docs/rfc-003-oidc-provider.md` for the full plan.
+
+#![warn(missing_docs)]
+
+/// Errors returned by OP operations.
+pub mod error;
+pub use error::OpError;
+
+/// Registered OAuth2/OIDC client applications.
+pub mod client;
+pub use client::{ClientRegistration, ClientStore, GrantType};
+
+/// Authorization codes issued during the `/authorize` step and consumed at
+/// `/token`.
+pub mod code;
+pub use code::{AuthorizationCode, AuthorizationCodeStore};
+
+/// Provider-level configuration (issuer URL, supported scopes/response
+/// types).
+pub mod config;
+pub use config::OpConfig;
+
+// `handlers` lands in OP.2 onward (discovery, jwks, authorize, token,
+// userinfo). Left out of this skeleton PR deliberately — see RFC-003 §5 for
+// the planned module layout.

--- a/docs/rfc-003-oidc-provider.md
+++ b/docs/rfc-003-oidc-provider.md
@@ -1,0 +1,167 @@
+# RFC-003: OpenID Provider (OP) Support
+
+## 1. Summary
+
+This RFC proposes adding OpenID Provider (OP) capability to Authkestra: the
+ability for an application built on Authkestra to *issue* tokens and run the
+authorization code grant, rather than only consuming an external IdP as a
+relying party (RP). This is the feature that makes RFC-001's stated goal of
+"standalone server deployment (similar to Keycloak)" concretely true.
+
+## 2. Motivation
+
+Today, `authkestra-oidc` and `authkestra-providers-*` only implement the RP
+side: discovering an external provider's metadata, redirecting to its
+`/authorize`, exchanging codes at its `/token`, and validating its JWKS.
+There is no code anywhere in the workspace that *serves* those endpoints.
+
+Without OP support, Authkestra can protect an application (resource server)
+or log a user in via Google/GitHub/etc, but it cannot itself be the identity
+source for other applications — e.g. a company wanting one login for
+multiple internal services, or an app wanting to offer "Sign in with
+<product>" to third parties. Adding OP support turns Authkestra from an
+auth *client* toolkit into a full auth *platform*, matching the RFC-001
+Layer 4 vision (Admin API, dashboard) which needs something to administer.
+
+## 3. Non-goals
+
+- Dynamic client registration (RFC 7591) — clients are registered out of
+  band (config, DB migration, or future admin API) for the first version.
+- A consent screen UI — the authorize handler exposes a hook/callback for
+  the host application to render consent; Authkestra does not ship UI.
+- GNAP — tracked separately per the roadmap; this RFC is OAuth 2.1/OIDC
+  Core only.
+
+## 4. Prerequisite: asymmetric token signing
+
+`TokenManager` (in `authkestra-engine/src/token/mod.rs`) currently signs
+exclusively with `Algorithm::HS256` over a symmetric secret
+(`EncodingKey::from_secret`). This is appropriate when the same process (or
+a set of processes that share the secret out of band) both issues and
+validates tokens — the current resource-server use case.
+
+It does not work for an OP: external relying parties must be able to verify
+an ID token's signature *without* knowing your signing secret, via a
+published public key (the JWKS endpoint). This requires:
+
+- `TokenService`/`TokenManager` gaining an asymmetric mode (`RS256` to
+  start — reuses the existing `jsonwebtoken` dependency and matches what
+  `authkestra-resource`'s `Jwk::to_decoding_key` already expects on the
+  *consuming* side, since it currently only supports RSA components).
+- A `kid` (key ID) on issued tokens' JWT header so the JWKS endpoint can
+  publish multiple keys during rotation and clients can select the right
+  one.
+- Key rotation is out of scope for the first version but the `kid` field
+  must exist from the start — retrofitting it later is a breaking change
+  to every issued token.
+
+This is scoped as its own PR (`OP.0a`) landing before `OP.2` (JWKS
+endpoint), since the JWKS endpoint has nothing meaningful to publish
+otherwise.
+
+## 5. Target architecture
+
+New crate: **`authkestra-op`** (Layer 2: Extensions, alongside
+`authkestra-oidc`, `authkestra-session-*`). Kept separate from
+`authkestra-oidc` because that crate's identity is "RP that consumes an
+external OP" — merging OP logic in would make `Provider` and `OidcProvider`
+ambiguous (yours vs. someone else's).
+
+```
+authkestra-op/
+├── src/
+│   ├── lib.rs
+│   ├── client.rs        # ClientRegistration, ClientStore trait
+│   ├── code.rs           # AuthorizationCode, AuthorizationCodeStore trait
+│   ├── config.rs         # OpConfig (issuer, supported scopes/response types)
+│   └── handlers/          # framework-agnostic handler *logic*, returns
+│                           # plain structs/Results — adapters wrap these
+│       ├── discovery.rs   # GET /.well-known/openid-configuration
+│       ├── jwks.rs        # GET /jwks.json
+│       ├── authorize.rs   # GET /authorize
+│       ├── token.rs       # POST /token
+│       └── userinfo.rs    # GET /userinfo
+```
+
+`authkestra-axum` and `authkestra-actix` each get a new `op` feature flag
+exposing a router/scope that wires the framework-agnostic handler logic to
+each framework's request/response types — mirroring how `guard`/`session`/
+`flow` are already feature-gated today.
+
+## 6. Core types (sketch)
+
+```rust
+/// A registered OAuth2/OIDC client application.
+pub struct ClientRegistration {
+    pub client_id: String,
+    pub client_secret_hash: String, // never store plaintext
+    pub redirect_uris: Vec<String>, // exact-match only; no wildcard/prefix matching
+    pub grant_types: Vec<GrantType>,
+    pub scopes: Vec<String>,
+}
+
+/// An issued authorization code, pending exchange at /token.
+pub struct AuthorizationCode {
+    pub code: String,
+    pub client_id: String,
+    pub redirect_uri: String,
+    pub scope: String,
+    pub code_challenge: Option<String>,     // PKCE, mandatory for public clients
+    pub code_challenge_method: Option<String>,
+    pub identity: Identity,                 // re-uses authkestra_engine::Identity
+    pub expires_at: chrono::DateTime<chrono::Utc>,
+    pub used: bool,                         // single-use enforcement
+}
+
+#[async_trait]
+pub trait ClientStore: Send + Sync {
+    async fn find_client(&self, client_id: &str) -> Result<Option<ClientRegistration>, OpError>;
+}
+
+#[async_trait]
+pub trait AuthorizationCodeStore: Send + Sync {
+    async fn store_code(&self, code: AuthorizationCode) -> Result<(), OpError>;
+    async fn consume_code(&self, code: &str) -> Result<Option<AuthorizationCode>, OpError>;
+    // consume_code MUST be atomic (check `used`, mark used, return) to prevent
+    // code-replay races — this is the single highest-value correctness
+    // property in the whole OP and should have a dedicated test.
+}
+```
+
+Both traits mirror the existing `SessionStore` pattern (async trait,
+pluggable backends, in-memory implementation ships first).
+
+## 7. Security notes (non-exhaustive, expand during implementation)
+
+- `redirect_uri` at `/authorize` and `/token` must be validated by **exact
+  string match** against the client's registered URIs — no partial or
+  prefix matching. This is the single most common OAuth implementation bug
+  (open redirect).
+- PKCE (`code_challenge`/`code_verifier`) is mandatory for public clients
+  and recommended for all clients, per OAuth 2.1.
+- Authorization codes are single-use and short-lived (recommend ≤60s); the
+  `AuthorizationCodeStore::consume_code` atomicity requirement above exists
+  specifically to prevent replay.
+- Client secrets are never stored or logged in plaintext — hash at
+  registration time, compare hashes at `/token`.
+
+## 8. Migration impact
+
+- `authkestra-engine`: `TokenService`/`TokenManager` gain asymmetric signing
+  (prerequisite, `OP.0a`).
+- `authkestra-resource`: `Jwk` struct gains `Serialize` (today it's
+  `Deserialize`-only, built for consuming someone else's JWKS) so `OP.2` can
+  reuse it to publish rather than duplicating the type.
+- New crate `authkestra-op`.
+- `authkestra-axum`, `authkestra-actix`: new `op` feature flag.
+
+## 9. Timeline (see companion PR plan for full sequencing)
+
+- **OP.0a**: Asymmetric (RS256) signing in `TokenService`, with `kid`.
+- **OP.0 / OP.1**: Crate skeleton + `ClientStore`/`AuthorizationCodeStore`
+  traits + in-memory impls.
+- **OP.2**: Discovery + JWKS endpoints (lowest risk, no user input).
+- **OP.3 / OP.4**: `/authorize` and `/token` (authorization code + PKCE).
+- **OP.5**: `/userinfo`.
+- **OP.6**: Axum/Actix adapter wiring + examples.
+- **OP.7** (follow-up): client_credentials/refresh_token grants at `/token`.

--- a/plans/ticket-op-0a-plan.md
+++ b/plans/ticket-op-0a-plan.md
@@ -1,0 +1,77 @@
+# Ticket #OP.0a: Asymmetric (RS256) signing in TokenService
+
+## Goal
+
+Add an asymmetric signing path to `TokenService`/`TokenManager` so tokens
+issued by an OpenID Provider (`authkestra-op`, RFC-003) can be verified by
+external relying parties via a published JWKS, without requiring them to
+know a shared secret. This is a prerequisite for `OP.2` (JWKS endpoint) and
+`OP.4` (`/token` endpoint) — do not begin those tickets until this merges.
+
+Do NOT touch `authkestra-op` in this ticket. This ticket is scoped to
+`authkestra-engine` (and `authkestra-resource` if the `Jwk` type needs a
+`Serialize` impl to represent the new public key). Keep it that way.
+
+## Non-goals
+
+- Key rotation / multiple simultaneous signing keys (single key + `kid` is
+  enough for this ticket; rotation is a follow-up).
+- Any change to the existing HS256 path — it must keep working unchanged
+  for existing resource-server use cases. This is additive, not a
+  replacement.
+
+## Steps
+
+### 1. Extend `TokenManager` construction
+
+- Add a variant of `TokenManager::new` (or a new constructor,
+  `TokenManager::new_asymmetric` / builder method) that accepts an RSA
+  keypair (`EncodingKey::from_rsa_pem`, `DecodingKey::from_rsa_pem`) instead
+  of a raw secret.
+- Store a `kid: String` alongside the keys (generate one, e.g. a UUID or a
+  hash of the public key, if the caller doesn't supply one).
+- Keep the existing HMAC fields/constructor untouched; the struct should
+  support either mode, not force a choice at the type level unless that's
+  clearly simpler — use your judgment, but don't break existing callers.
+
+### 2. Set the `alg` and `kid` in the JWT header on issuance
+
+- When issuing via the asymmetric path, use `Header::new(Algorithm::RS256)`
+  and set `header.kid = Some(self.kid.clone())` before calling `encode`.
+- Verify the existing HMAC path is unaffected (still `HS256`, no `kid`
+  unless you decide to add one there too for consistency — optional, note
+  your choice in the PR description either way).
+
+### 3. Expose the public key in a JWKS-ready shape
+
+- Add a method (e.g. `TokenManager::public_jwk(&self) -> Jwk`) that returns
+  the RSA public key as a `Jwk` (n, e, kid, kty="RSA", alg="RS256").
+- Check whether `authkestra_resource::jwt::Jwk` (currently
+  `Deserialize`-only) can be reused by adding `Serialize` to it, rather than
+  defining a second JWK type. Prefer reuse — a duplicate `Jwk` type in two
+  crates is exactly the kind of drift RFC-001 was written to avoid.
+
+### 4. Tests
+
+- Round-trip test: issue a token via the asymmetric path, verify it with
+  `jsonwebtoken::decode` using the public key directly (not via
+  `TokenManager`, to prove the token is independently verifiable — this is
+  the whole point of the change).
+- Confirm the existing HMAC round-trip test still passes unmodified.
+- Confirm `header.kid` is present and matches `TokenManager`'s stored `kid`
+  on asymmetric-path tokens.
+
+### 5. Docs
+
+- Doc-comment the new constructor/method explaining when to use asymmetric
+  vs HMAC (OP/external verification vs internal resource server).
+- No RFC changes needed — RFC-003 §4 already describes this; just link back
+  to it from the doc comment if convenient.
+
+## Definition of done
+
+- `cargo test --workspace` green.
+- `cargo clippy --workspace -- -D warnings` clean.
+- Existing HS256 behavior unchanged (no breaking change to current callers).
+- A round-trip test proves a token issued via the new path can be verified
+  using only the public key, without `TokenManager`.


### PR DESCRIPTION
Restores the `authkestra-op` crate and its associated documentation (`rfc-003-oidc-provider.md`, `ticket-op-0a-plan.md`) that were silently dropped during a merge conflict resolution in #54.