### PR TITLE
fix: restore asymmetric token signing lost in bad merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,7 @@ dependencies = [
  "jsonwebtoken",
  "rand 0.9.4",
  "reqwest",
+ "rsa",
  "serde",
  "serde_json",
  "sha2",

--- a/authkestra-engine/Cargo.toml
+++ b/authkestra-engine/Cargo.toml
@@ -28,6 +28,7 @@ tracing = "0.1"
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 tokio = { version = "1.0", features = ["full"] }
 aes-gcm = "0.10.3"
+rsa = "0.9.6"
 
 [features]
 default = ["token", "flow"]

--- a/authkestra-engine/src/token/jwk.rs
+++ b/authkestra-engine/src/token/jwk.rs
@@ -1,0 +1,33 @@
+use crate::auth::error::AuthError;
+use jsonwebtoken::DecodingKey;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Jwk {
+    pub kid: Option<String>,
+    pub kty: String,
+    pub alg: Option<String>,
+    pub n: Option<String>,
+    pub e: Option<String>,
+}
+
+impl Jwk {
+    pub fn to_decoding_key(&self) -> Result<DecodingKey, AuthError> {
+        if self.kty != "RSA" {
+            return Err(AuthError::Token(
+                "Only RSA keys are supported currently".to_string(),
+            ));
+        }
+
+        let n = self
+            .n
+            .as_ref()
+            .ok_or_else(|| AuthError::Token("Missing 'n' component in JWK".to_string()))?;
+        let e = self
+            .e
+            .as_ref()
+            .ok_or_else(|| AuthError::Token("Missing 'e' component in JWK".to_string()))?;
+
+        DecodingKey::from_rsa_components(n, e).map_err(|e| AuthError::Token(e.to_string()))
+    }
+}

--- a/authkestra-engine/src/token/mod.rs
+++ b/authkestra-engine/src/token/mod.rs
@@ -43,15 +43,75 @@ pub struct TokenManager {
     encoding_key: EncodingKey,
     decoding_key: DecodingKey,
     issuer: Option<String>,
+    kid: Option<String>,
+    alg: Algorithm,
+    public_jwk: Option<crate::token::jwk::Jwk>,
 }
 
 impl TokenManager {
+    /// Creates a TokenManager for symmetric signing (HS256).
     pub fn new(secret: &[u8], issuer: Option<String>) -> Self {
         Self {
             encoding_key: EncodingKey::from_secret(secret),
             decoding_key: DecodingKey::from_secret(secret),
             issuer,
+            kid: None,
+            alg: Algorithm::HS256,
+            public_jwk: None,
         }
+    }
+
+    /// Creates a TokenManager for asymmetric signing (RS256).
+    /// `private_key_pem` must be a valid RSA private key in PEM format.
+    /// OP/external verification should use this path; internal resource servers
+    /// can continue to use `new` (HS256).
+    pub fn new_asymmetric(
+        private_key_pem: &[u8],
+        issuer: Option<String>,
+        kid: Option<String>,
+    ) -> Result<Self, AuthError> {
+        let encoding_key = EncodingKey::from_rsa_pem(private_key_pem)
+            .map_err(|e| AuthError::Token(e.to_string()))?;
+        let decoding_key = DecodingKey::from_rsa_pem(private_key_pem)
+            .map_err(|e| AuthError::Token(e.to_string()))?;
+
+        let pem_str = std::str::from_utf8(private_key_pem)
+            .map_err(|_| AuthError::Token("Invalid PEM UTF-8".into()))?;
+
+        use rsa::pkcs1::DecodeRsaPrivateKey;
+        use rsa::pkcs8::DecodePrivateKey;
+        let rsa_key = rsa::RsaPrivateKey::from_pkcs8_pem(pem_str)
+            .or_else(|_| rsa::RsaPrivateKey::from_pkcs1_pem(pem_str))
+            .map_err(|e| AuthError::Token(format!("Failed to parse RSA key: {}", e)))?;
+
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        use rsa::traits::PublicKeyParts;
+
+        let n = URL_SAFE_NO_PAD.encode(rsa_key.n().to_bytes_be());
+        let e = URL_SAFE_NO_PAD.encode(rsa_key.e().to_bytes_be());
+
+        let kid_val = kid.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+        let jwk = crate::token::jwk::Jwk {
+            kid: Some(kid_val.clone()),
+            kty: "RSA".to_string(),
+            alg: Some("RS256".to_string()),
+            n: Some(n),
+            e: Some(e),
+        };
+
+        Ok(Self {
+            encoding_key,
+            decoding_key,
+            issuer,
+            kid: Some(kid_val),
+            alg: Algorithm::RS256,
+            public_jwk: Some(jwk),
+        })
+    }
+
+    pub fn public_jwk(&self) -> Option<crate::token::jwk::Jwk> {
+        self.public_jwk.clone()
     }
 
     pub fn with_issuer(mut self, issuer: String) -> Self {
@@ -82,8 +142,12 @@ impl TokenManager {
             extra: HashMap::new(),
         };
 
-        encode(&Header::default(), &claims, &self.encoding_key)
-            .map_err(|e| AuthError::Token(e.to_string()))
+        let mut header = Header::new(self.alg);
+        if let Some(ref kid) = self.kid {
+            header.kid = Some(kid.clone());
+        }
+
+        encode(&header, &claims, &self.encoding_key).map_err(|e| AuthError::Token(e.to_string()))
     }
 
     /// Issues a machine-to-machine (M2M) token for a client.
@@ -109,12 +173,16 @@ impl TokenManager {
             extra: HashMap::new(),
         };
 
-        encode(&Header::default(), &claims, &self.encoding_key)
-            .map_err(|e| AuthError::Token(e.to_string()))
+        let mut header = Header::new(self.alg);
+        if let Some(ref kid) = self.kid {
+            header.kid = Some(kid.clone());
+        }
+
+        encode(&header, &claims, &self.encoding_key).map_err(|e| AuthError::Token(e.to_string()))
     }
 
     pub fn validate_token(&self, token: &str) -> Result<Claims, AuthError> {
-        let mut validation = Validation::new(Algorithm::HS256);
+        let mut validation = Validation::new(self.alg);
         if let Some(ref iss) = self.issuer {
             validation.set_issuer(&[iss]);
         }
@@ -200,4 +268,67 @@ mod tests {
         assert!(claims.jti.is_some());
         assert!(claims.nbf.is_some());
     }
+
+    #[test]
+    fn test_token_manager_asymmetric_issuance() {
+        let pem = b"-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDA5hJIcQ+2rxMz
+VM8ZH5WAmguCr0xmNDAdy0IzzsUeFLG7BebB7izOkU36J4t8t5tUaQwrBMnx2Fvt
+VqJjbdE242UDpvWF/8m9zJ2HR5298cbwT5cGMKLB0HWzDMahugs+Bbh2lCgwyLZk
+Tr3Diwxp5SwFew/Wb+Ke9cNG9Hu5IFH3BCuJ839d9hfqisIeYrBPfb52xxckM37R
+7zSGu/eDP/HZAeLkQuptZJW4A3u7xni14u4qyqXDqsHsYFNgJaxMSAwWgBRY6HNu
+TnvBArTXCiVfL+F73B2L6mdYr64g+QS9nK9v97MlJu/E3mSduz54pren4mpCHc9m
+/S2+VjCZAgMBAAECggEAASC9qQbGnL7XuExRDOIn/m4bWx92ehjo0lCTibhpY3LW
+umbSbpfbhmmuSj3CjW9VZsaM3hBTgSjoTX72lbY/eIUXD7c0memUK5pV4XcEIrQw
+AZlPIye6ckx4I7ZGnKasO8FoAel9dd7DXw36AuBK3LBzJwtzkEFsBc0e3/wixqmG
+UJBbbt/+5ya7CxyjuePaQhKtkLD5R6DpvN2XnCYq5nHJNJdvSVg1pOzsTHYIf+Ee
+2Rz42fGsfFKqeEQCcBFRZaGb/ELeP4c6UZdktZAvmHb1p1fursVZc6X9JXmiJ2OJ
+Kv2H2tMKuysP8L0fXFOMgkH2SVt6rcdHkO6xhlhWsQKBgQDqR8rAJeEE5BFoXA8T
+VVW6CLMlW51x4ey7PEGOaYh39dTG2Q+GZQBZ9G+SZk3f5Y85UCACSyc//4qaz/c3
+0nWsegZ+JPyymmuc79wzIAFFvXB7pL6wyn0Ed1P620kOZTtA8iBcXrsuxL+KP7iu
+MXfWmU1QiZpbndILtyDnY+70uwKBgQDSyCljWkydQCaPU+fiAXLxP8CvcJTSSNQD
+mVUlwJ+OpHnU+Alsi1rBavMgUtLlYbFqzH7NmYrLC8Yadq3ZOwLt0VEK0r8qstAL
+7QCDUD2WNuQjpZupRnXuMUl3iXB96i2gb+VQKGuUAJvVWjdIbYa4+Gu+sBMfcDcX
+dBihDLuEuwKBgAgX4tEwfc2Fc3R/eaXZVNTQaB/qQk4k1+C//CPHUYeTXn5gEUE7
+S//PiesszZPmgkQgmHp7zidP1KH0fT3Yb2g97ut8q54f54fMYXcCrAiUusYKsuu4
+kwkMdkI8QRHWPW3I74VBYIYFFfjYqrCZ1OH8+cbGeiagFRmCggh8U0zxAoGAVW3u
+6Ge22Z0gg8LcHsu7jG/sZq7Ygool8/d3fT+e669Z+ak2GJo6hF4WgClRdMqtn72W
+PzpV+ImjFyK2v26dd0n48MwN0v56N/ss1Av3iiRhPtlmR6tZLNspDZvUzhPVvkrb
+xCs9vtSoVEamVWKe0eVNthGjDoDqs0TInq2MavUCgYB6REavSJs/CLkSS7iimjxZ
+G7g5YQi9/p1lXLOEUDiwEmvRr0XTwzzxUsIc535IXhh/ZUYpthenW+qBBzn85pEC
+TowIqciHu5redqlQ8rITA8/AOY98vaDIhppDg1rfpnHHaZHFbXD/keYAEbhBtbvf
+a0QMqKUcs8+YTy5R5K6qtw==
+-----END PRIVATE KEY-----";
+
+        let manager = TokenManager::new_asymmetric(
+            pem,
+            Some("issuer".to_string()),
+            Some("my-kid-123".to_string()),
+        )
+        .unwrap();
+
+        let identity = Identity {
+            provider_id: "mock".to_string(),
+            external_id: "user123".to_string(),
+            email: None,
+            username: None,
+            attributes: HashMap::new(),
+        };
+
+        let token = manager.issue_user_token(identity, 3600, None).unwrap();
+
+        // Decode directly via jsonwebtoken to prove independent verification
+        let jwk = manager.public_jwk().unwrap();
+        assert_eq!(jwk.kid.as_deref(), Some("my-kid-123"));
+
+        let decoding_key = jwk.to_decoding_key().unwrap();
+        let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::RS256);
+        validation.set_issuer(&["issuer"]);
+
+        let token_data =
+            jsonwebtoken::decode::<Claims>(&token, &decoding_key, &validation).unwrap();
+        assert_eq!(token_data.claims.sub, "user123");
+        assert_eq!(token_data.header.kid.as_deref(), Some("my-kid-123"));
+    }
 }
+pub mod jwk;

--- a/authkestra-resource/src/jwt.rs
+++ b/authkestra-resource/src/jwt.rs
@@ -5,7 +5,7 @@ use authkestra_engine::{
     token::Claims,
 };
 use http::request::Parts;
-use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
+use jsonwebtoken::{decode, decode_header, Algorithm, Validation};
 use serde::Deserialize;
 use std::time::{Duration, Instant};
 use thiserror::Error;
@@ -32,33 +32,7 @@ pub enum ValidationError {
     Validation(String),
 }
 
-#[derive(Debug, Clone, Deserialize)]
-pub struct Jwk {
-    pub kid: Option<String>,
-    pub kty: String,
-    pub alg: Option<String>,
-    pub n: Option<String>,
-    pub e: Option<String>,
-}
-
-impl Jwk {
-    pub fn to_decoding_key(&self) -> Result<DecodingKey, ValidationError> {
-        if self.kty != "RSA" {
-            return Err(ValidationError::Validation(
-                "Only RSA keys are supported currently".to_string(),
-            ));
-        }
-
-        let n = self.n.as_ref().ok_or_else(|| {
-            ValidationError::Validation("Missing 'n' component in JWK".to_string())
-        })?;
-        let e = self.e.as_ref().ok_or_else(|| {
-            ValidationError::Validation("Missing 'e' component in JWK".to_string())
-        })?;
-
-        DecodingKey::from_rsa_components(n, e).map_err(ValidationError::Jwt)
-    }
-}
+pub use authkestra_engine::token::jwk::Jwk;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Jwks {


### PR DESCRIPTION
Restores `TokenManager::new_asymmetric` and the JWK support that was deleted along with `authkestra-op` during a bad merge conflict resolution in #54.