### PR TITLE
fix: restore stateless OAuth cookies and background OIDC discovery

### DIFF
--- a/authkestra-actix/src/helpers.rs
+++ b/authkestra-actix/src/helpers.rs
@@ -81,7 +81,7 @@ pub fn initiate_oauth_login_erased(
         .encrypt(&config.state_encryption_key)
         .expect("Failed to encrypt OAuth state");
 
-    let cookie_name = format!("authkestra_state_{}", auth_state.state);
+    let cookie_name = "ak_state";
 
     let cookie = Cookie::build(cookie_name, encrypted)
         .path("/")
@@ -123,10 +123,9 @@ pub async fn handle_oauth_callback_erased(
     config: SessionConfig,
     _success_url: &str,
 ) -> Result<HttpResponse, actix_web::Error> {
-    let state_param = &params.state;
-    let cookie_name = format!("authkestra_state_{state_param}");
+    let cookie_name = "ak_state";
     let encrypted_state = req
-        .cookie(&cookie_name)
+        .cookie(cookie_name)
         .map(|c| c.value().to_string())
         .ok_or_else(|| {
             actix_web::error::ErrorUnauthorized("CSRF validation failed or session expired")
@@ -302,11 +301,10 @@ pub async fn handle_oauth_callback_jwt_erased(
     expires_in_secs: u64,
     config: SessionConfig,
 ) -> Result<HttpResponse, actix_web::Error> {
-    let state_param = &params.state;
-    let cookie_name = format!("authkestra_state_{state_param}");
+    let cookie_name = "ak_state";
 
     let encrypted_state = req
-        .cookie(&cookie_name)
+        .cookie(cookie_name)
         .map(|c| c.value().to_string())
         .ok_or_else(|| {
             actix_web::error::ErrorUnauthorized("CSRF validation failed or session expired")

--- a/authkestra-axum/src/helpers.rs
+++ b/authkestra-axum/src/helpers.rs
@@ -79,7 +79,7 @@ pub fn initiate_oauth_login(
         .encrypt(&config.state_encryption_key)
         .expect("Failed to encrypt OAuth state");
 
-    let cookie_name = format!("authkestra_state_{}", auth_state.state);
+    let cookie_name = "ak_state";
 
     let mut cookie = Cookie::new(cookie_name, encrypted);
     cookie.set_path("/");
@@ -101,11 +101,10 @@ async fn finalize_callback_erased(
     params: &OAuthCallbackParams,
     config: &SessionConfig,
 ) -> Result<(Identity, OAuthToken, OAuth2State), (StatusCode, String)> {
-    let state_param = &params.state;
-    let cookie_name = format!("authkestra_state_{state_param}");
+    let cookie_name = "ak_state";
 
     let encrypted_state = cookies
-        .get(&cookie_name)
+        .get(cookie_name)
         .map(|c| c.value().to_string())
         .ok_or_else(|| {
             (

--- a/authkestra-engine/src/auth/discovery.rs
+++ b/authkestra-engine/src/auth/discovery.rs
@@ -24,28 +24,46 @@ pub struct ProviderMetadata {
 }
 
 impl ProviderMetadata {
-    /// Fetches metadata from the issuer URL (appends /.well-known/openid-configuration)
-    pub async fn discover(issuer_url: &str, client: reqwest::Client) -> Result<Self, AuthError> {
+    /// Fetches metadata from the issuer URL (appends /.well-known/openid-configuration).
+    /// Also returns the parsed max-age from the Cache-Control header if present.
+    pub async fn discover(
+        issuer_url: &str,
+        client: reqwest::Client,
+    ) -> Result<(Self, Option<std::time::Duration>), AuthError> {
         let mut url = url::Url::parse(issuer_url)
             .map_err(|e| AuthError::Discovery(format!("Invalid issuer URL: {e}")))?;
 
-        {
-            let mut path = url
-                .path_segments_mut()
-                .map_err(|_| AuthError::Discovery("Cannot append to issuer URL".to_string()))?;
+        if !url.path().ends_with("/.well-known/openid-configuration") {
+            let mut path = url.path_segments_mut().unwrap();
             path.push(".well-known");
             path.push("openid-configuration");
         }
 
-        let metadata = client
+        let response = client
             .get(url)
             .send()
             .await
-            .map_err(|_| AuthError::Network)?
+            .map_err(|_| AuthError::Network)?;
+
+        let mut cache_max_age = None;
+        if let Some(cache_control) = response.headers().get(reqwest::header::CACHE_CONTROL) {
+            if let Ok(cc_str) = cache_control.to_str() {
+                for directive in cc_str.split(',') {
+                    let directive = directive.trim();
+                    if let Some(rest) = directive.strip_prefix("max-age=") {
+                        if let Ok(secs) = rest.parse::<u64>() {
+                            cache_max_age = Some(std::time::Duration::from_secs(secs));
+                        }
+                    }
+                }
+            }
+        }
+
+        let metadata = response
             .json::<ProviderMetadata>()
             .await
             .map_err(|e| AuthError::Discovery(format!("Failed to parse metadata: {e}")))?;
 
-        Ok(metadata)
+        Ok((metadata, cache_max_age))
     }
 }

--- a/authkestra-oidc/README.md
+++ b/authkestra-oidc/README.md
@@ -36,6 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "your_client_secret".to_string(),
         "http://localhost:8080/callback".to_string(),
         "https://accounts.google.com", // Issuer URL
+        std::time::Duration::from_secs(3600), // Fallback refresh interval
     ).await?;
 
     // Generate an authorization URL

--- a/authkestra-oidc/src/provider.rs
+++ b/authkestra-oidc/src/provider.rs
@@ -10,15 +10,17 @@ use authkestra_engine::{
 use authkestra_resource::jwt::{validate_jwt_generic, JwksCache};
 use jsonwebtoken::Validation;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use std::{collections::HashMap, time::Duration};
 
+#[derive(Clone)]
 pub struct OidcProvider {
     client_id: String,
     client_secret: String,
     redirect_uri: String,
-    metadata: ProviderMetadata,
+    metadata: Arc<std::sync::RwLock<ProviderMetadata>>,
     http_client: reqwest::Client,
-    cache: JwksCache,
+    cache: Arc<std::sync::RwLock<Arc<JwksCache>>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -44,37 +46,121 @@ struct OidcTokenResponse {
 }
 
 impl OidcProvider {
-    /// Creates a new provider by performing discovery
+    /// Creates a new provider by performing discovery.
+    /// Spawns a background task to periodically refresh the discovery document
+    /// and JWKS cache based on the Cache-Control max-age header.
+    /// If the header is missing, `fallback_refresh_interval` is used.
     #[tracing::instrument(skip(client_id, client_secret))]
     pub async fn discover(
         client_id: String,
         client_secret: String,
         redirect_uri: String,
         issuer_url: &str,
+        fallback_refresh_interval: Duration,
     ) -> Result<Self, OidcError> {
         tracing::debug!("starting OIDC discovery process");
         let client = reqwest::Client::new();
-        let metadata = ProviderMetadata::discover(issuer_url, client.clone())
+        let (metadata, cache_max_age) = ProviderMetadata::discover(issuer_url, client.clone())
             .await
             .map_err(|e| {
                 tracing::error!(error = %e, "OIDC discovery failed");
                 e
             })?;
         tracing::info!(issuer = %metadata.issuer, "successfully discovered OIDC provider metadata");
-        let cache = JwksCache::new(metadata.jwks_uri.clone(), Duration::from_secs(3600));
 
-        Ok(Self {
+        let refresh_interval = match cache_max_age {
+            Some(duration) => duration,
+            None => {
+                tracing::warn!(
+                    "No valid Cache-Control max-age found in discovery document from {}. Using fallback interval of {} seconds.",
+                    issuer_url,
+                    fallback_refresh_interval.as_secs()
+                );
+                fallback_refresh_interval
+            }
+        };
+
+        let cache = Arc::new(JwksCache::new(metadata.jwks_uri.clone(), refresh_interval));
+
+        let provider = Self {
             client_id,
             client_secret,
             redirect_uri,
-            metadata,
-            http_client: client,
-            cache,
-        })
+            metadata: Arc::new(std::sync::RwLock::new(metadata)),
+            http_client: client.clone(),
+            cache: Arc::new(std::sync::RwLock::new(cache)),
+        };
+
+        // Spawn background refresh task
+        let issuer_url_owned = issuer_url.to_string();
+        let metadata_ref = Arc::downgrade(&provider.metadata);
+        let cache_ref = Arc::downgrade(&provider.cache);
+
+        tokio::spawn(async move {
+            let mut current_interval = refresh_interval;
+            loop {
+                tokio::time::sleep(current_interval).await;
+
+                // If the provider has been dropped, exit the background task
+                let (metadata_arc, cache_arc) = match (metadata_ref.upgrade(), cache_ref.upgrade())
+                {
+                    (Some(m), Some(c)) => (m, c),
+                    _ => break,
+                };
+
+                tracing::debug!(
+                    "Refreshing OIDC discovery document for {}",
+                    issuer_url_owned
+                );
+
+                match ProviderMetadata::discover(&issuer_url_owned, client.clone()).await {
+                    Ok((new_metadata, new_cache_max_age)) => {
+                        current_interval = match new_cache_max_age {
+                            Some(duration) => duration,
+                            None => {
+                                tracing::warn!(
+                                    "No valid Cache-Control max-age found in discovery document from {}. Using fallback interval of {} seconds.",
+                                    issuer_url_owned,
+                                    fallback_refresh_interval.as_secs()
+                                );
+                                fallback_refresh_interval
+                            }
+                        };
+
+                        let mut meta_write = metadata_arc.write().unwrap();
+                        let jwks_uri_changed = meta_write.jwks_uri != new_metadata.jwks_uri;
+                        *meta_write = new_metadata.clone();
+                        drop(meta_write); // Release lock early
+
+                        if jwks_uri_changed {
+                            tracing::info!(
+                                "OIDC jwks_uri changed for {}, recreating JwksCache",
+                                issuer_url_owned
+                            );
+                            let new_cache =
+                                Arc::new(JwksCache::new(new_metadata.jwks_uri, current_interval));
+                            let mut cache_write = cache_arc.write().unwrap();
+                            *cache_write = new_cache;
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            error = %e,
+                            "Failed to refresh OIDC discovery document for {}",
+                            issuer_url_owned
+                        );
+                        // Retry after a short delay on failure to avoid tight loop
+                        current_interval = Duration::from_secs(60);
+                    }
+                }
+            }
+        });
+
+        Ok(provider)
     }
 
-    pub fn metadata(&self) -> &ProviderMetadata {
-        &self.metadata
+    pub async fn get_metadata(&self) -> ProviderMetadata {
+        self.metadata.read().unwrap().clone()
     }
 }
 
@@ -102,6 +188,8 @@ impl OAuthProvider for OidcProvider {
         code_challenge: Option<&str>,
         nonce: Option<&str>,
     ) -> String {
+        let metadata = self.metadata.read().unwrap().clone();
+
         let mut full_scopes = scopes.to_vec();
         if !full_scopes.contains(&"openid") {
             full_scopes.push("openid");
@@ -111,7 +199,7 @@ impl OAuthProvider for OidcProvider {
 
         let mut url = format!(
             "{}?client_id={}&redirect_uri={}&response_type=code&state={}&scope={}",
-            self.metadata.authorization_endpoint,
+            metadata.authorization_endpoint,
             self.client_id,
             urlencoding::encode(&self.redirect_uri),
             state,
@@ -151,9 +239,11 @@ impl OAuthProvider for OidcProvider {
             params.insert("code_verifier", verifier.to_string());
         }
 
+        let metadata = self.metadata.read().unwrap().clone();
+
         let token_response = self
             .http_client
-            .post(&self.metadata.token_endpoint)
+            .post(&metadata.token_endpoint)
             .form(&params)
             .send()
             .await
@@ -175,7 +265,8 @@ impl OAuthProvider for OidcProvider {
 
         tracing::debug!("validating OIDC ID Token");
         // 2. Validate ID Token using the validator
-        let claims = validate_jwt_generic::<Claims>(&id_token, &self.cache, &Validation::default())
+        let cache = self.cache.read().unwrap().clone(); // Clone the Arc, releasing the lock immediately
+        let claims = validate_jwt_generic::<Claims>(&id_token, &cache, &Validation::default())
             .await
             .map_err(|e| {
                 tracing::error!(error = %e, "failed to validate OIDC ID Token");


### PR DESCRIPTION
Restores the background tokio task for OIDC discovery caching and the static `ak_state` OAuth cookie name that were deleted during a bad merge conflict resolution in #54.