### PR TITLE
chore: add tracing to OP skeleton

### DIFF
--- a/authkestra-op/Cargo.toml
+++ b/authkestra-op/Cargo.toml
@@ -18,6 +18,7 @@ async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4"] }
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
+tracing = "0.1.44"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }

--- a/authkestra-op/src/client.rs
+++ b/authkestra-op/src/client.rs
@@ -83,6 +83,7 @@ impl InMemoryClientStore {
     /// Registers a client, replacing any existing registration with the
     /// same `client_id`.
     pub fn register(&self, client: ClientRegistration) {
+        tracing::debug!(client_id = %client.client_id, "registering client in memory");
         self.clients
             .write()
             .expect("client store lock poisoned")
@@ -93,10 +94,14 @@ impl InMemoryClientStore {
 #[async_trait]
 impl ClientStore for InMemoryClientStore {
     async fn find_client(&self, client_id: &str) -> Result<Option<ClientRegistration>, OpError> {
+        tracing::trace!(client_id, "looking up client");
         Ok(self
             .clients
             .read()
-            .map_err(|_| OpError::Storage)?
+            .map_err(|_| {
+                tracing::error!("client store lock poisoned");
+                OpError::Storage
+            })?
             .get(client_id)
             .cloned())
     }

--- a/authkestra-op/src/code.rs
+++ b/authkestra-op/src/code.rs
@@ -88,24 +88,44 @@ impl InMemoryAuthorizationCodeStore {
 #[async_trait]
 impl AuthorizationCodeStore for InMemoryAuthorizationCodeStore {
     async fn store_code(&self, code: AuthorizationCode) -> Result<(), OpError> {
+        tracing::debug!(client_id = %code.client_id, "storing authorization code in memory");
         self.codes
             .write()
-            .map_err(|_| OpError::Storage)?
+            .map_err(|_| {
+                tracing::error!("authorization code store lock poisoned");
+                OpError::Storage
+            })?
             .insert(code.code.clone(), code);
         Ok(())
     }
 
     async fn consume_code(&self, code: &str) -> Result<Option<AuthorizationCode>, OpError> {
-        let mut codes = self.codes.write().map_err(|_| OpError::Storage)?;
+        tracing::trace!("attempting to consume authorization code");
+        let mut codes = self.codes.write().map_err(|_| {
+            tracing::error!("authorization code store lock poisoned");
+            OpError::Storage
+        })?;
         // `get_mut` + check + mutate while holding the write lock is the
         // atomic step this trait's contract requires — do not replace this
         // with a separate read followed by a separate write.
         match codes.get_mut(code) {
             Some(entry) if !entry.used && !entry.is_expired(Utc::now()) => {
+                tracing::debug!(client_id = %entry.client_id, "successfully consumed authorization code");
                 entry.used = true;
                 Ok(Some(entry.clone()))
             }
-            _ => Ok(None),
+            Some(entry) if entry.used => {
+                tracing::warn!(client_id = %entry.client_id, "attempted to consume an already-used authorization code");
+                Ok(None)
+            }
+            Some(entry) => {
+                tracing::debug!(client_id = %entry.client_id, "attempted to consume an expired authorization code");
+                Ok(None)
+            }
+            None => {
+                tracing::debug!("authorization code not found");
+                Ok(None)
+            }
         }
     }
 }


### PR DESCRIPTION
Adds tracing to client and code stores in authkestra-op.