### PR TITLE
feat: Discovery and JWKS endpoints (OP.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/authkestra-op/src/handlers/discovery.rs
+++ b/authkestra-op/src/handlers/discovery.rs
@@ -1,0 +1,111 @@
+use serde::{Deserialize, Serialize};
+
+/// OpenID Connect Discovery metadata document.
+/// Served at `/.well-known/openid-configuration`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OidcDiscovery {
+    /// The OP's Issuer identifier.
+    pub issuer: String,
+    /// URL of the OP's OAuth 2.0 Authorization Endpoint.
+    pub authorization_endpoint: String,
+    /// URL of the OP's OAuth 2.0 Token Endpoint.
+    pub token_endpoint: String,
+    /// URL of the OP's JSON Web Key Set document.
+    pub jwks_uri: String,
+    /// URL of the OP's UserInfo Endpoint.
+    pub userinfo_endpoint: Option<String>,
+    /// JSON array containing a list of the OAuth 2.0 scope values that this server supports.
+    pub scopes_supported: Vec<String>,
+    /// JSON array containing a list of the OAuth 2.0 response_type values that this OP supports.
+    pub response_types_supported: Vec<String>,
+    /// JSON array containing a list of the OAuth 2.0 response_mode values that this OP supports.
+    pub response_modes_supported: Vec<String>,
+    /// JSON array containing a list of the OAuth 2.0 grant type values that this OP supports.
+    pub grant_types_supported: Vec<String>,
+    /// JSON array containing a list of the Subject Identifier types that this OP supports.
+    pub subject_types_supported: Vec<String>,
+    /// JSON array containing a list of the JWS signing algorithms (alg values) supported by the OP for the ID Token.
+    pub id_token_signing_alg_values_supported: Vec<String>,
+    /// JSON array containing a list of Client Authentication methods supported by this Token Endpoint.
+    pub token_endpoint_auth_methods_supported: Vec<String>,
+    /// JSON array containing a list of the Claim Names of the Claims that the OpenID Provider MAY be able to supply.
+    pub claims_supported: Vec<String>,
+}
+
+use crate::config::OpConfig;
+
+impl OidcDiscovery {
+    /// Creates a discovery document reflecting the provided OP configuration.
+    pub fn from_config(config: &OpConfig) -> Self {
+        Self {
+            issuer: config.issuer.clone(),
+            authorization_endpoint: config.authorization_endpoint(),
+            token_endpoint: config.token_endpoint(),
+            jwks_uri: config.jwks_url(),
+            userinfo_endpoint: Some(config.userinfo_endpoint()),
+            scopes_supported: config.scopes_supported.clone(),
+            response_types_supported: config.response_types_supported.clone(),
+            response_modes_supported: vec!["query".to_string()],
+            grant_types_supported: config.grant_types_supported.clone(),
+            subject_types_supported: vec!["public".to_string()],
+            id_token_signing_alg_values_supported: vec![config.id_token_signing_alg.clone()],
+            token_endpoint_auth_methods_supported: vec![
+                "client_secret_basic".to_string(),
+                "client_secret_post".to_string(),
+                "none".to_string(), // For public clients (PKCE)
+            ],
+            claims_supported: vec![
+                "sub".to_string(),
+                "iss".to_string(),
+                "aud".to_string(),
+                "exp".to_string(),
+                "iat".to_string(),
+                "name".to_string(),
+                "email".to_string(),
+            ],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_discovery_from_config() {
+        let config = OpConfig {
+            issuer: "https://auth.example.com".to_string(),
+            scopes_supported: vec!["openid".to_string(), "profile".to_string()],
+            response_types_supported: vec!["code".to_string()],
+            grant_types_supported: vec!["authorization_code".to_string()],
+            id_token_signing_alg: "RS256".to_string(),
+            authorization_code_ttl_secs: 60,
+        };
+
+        let doc = OidcDiscovery::from_config(&config);
+
+        assert_eq!(doc.issuer, "https://auth.example.com");
+        assert_eq!(
+            doc.authorization_endpoint,
+            "https://auth.example.com/authorize"
+        );
+        assert_eq!(doc.token_endpoint, "https://auth.example.com/token");
+        assert_eq!(doc.jwks_uri, "https://auth.example.com/jwks.json");
+        assert_eq!(
+            doc.userinfo_endpoint,
+            Some("https://auth.example.com/userinfo".to_string())
+        );
+
+        assert_eq!(doc.scopes_supported.len(), 2);
+        assert!(doc.response_types_supported.contains(&"code".to_string()));
+        assert!(doc
+            .grant_types_supported
+            .contains(&"authorization_code".to_string()));
+        assert!(!doc
+            .grant_types_supported
+            .contains(&"client_credentials".to_string()));
+        assert!(doc
+            .id_token_signing_alg_values_supported
+            .contains(&"RS256".to_string()));
+    }
+}

--- a/authkestra-op/src/handlers/jwks.rs
+++ b/authkestra-op/src/handlers/jwks.rs
@@ -1,0 +1,46 @@
+use authkestra_engine::token::jwk::Jwk;
+use serde::{Deserialize, Serialize};
+
+/// The JSON Web Key Set (JWKS) response format.
+/// Served at `/jwks.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JwksResponse {
+    /// The array of JWKs.
+    pub keys: Vec<Jwk>,
+}
+
+impl JwksResponse {
+    /// Creates a new JWKS response from an optional JWK.
+    /// If the token manager does not have a public key (e.g., symmetric only),
+    /// the keys array will be empty.
+    pub fn new(jwk: Option<Jwk>) -> Self {
+        Self {
+            keys: jwk.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_jwks_response_empty() {
+        let response = JwksResponse::new(None);
+        assert!(response.keys.is_empty());
+    }
+
+    #[test]
+    fn test_jwks_response_with_key() {
+        let jwk = Jwk {
+            kty: "RSA".to_string(),
+            alg: Some("RS256".to_string()),
+            kid: Some("123".to_string()),
+            n: Some("abc".to_string()),
+            e: Some("AQAB".to_string()),
+        };
+        let response = JwksResponse::new(Some(jwk.clone()));
+        assert_eq!(response.keys.len(), 1);
+        assert_eq!(response.keys[0].kid.as_deref(), Some("123"));
+    }
+}

--- a/authkestra-op/src/handlers/mod.rs
+++ b/authkestra-op/src/handlers/mod.rs
@@ -1,0 +1,7 @@
+/// Discovery endpoint handler (`/.well-known/openid-configuration`).
+pub mod discovery;
+pub use discovery::OidcDiscovery;
+
+/// JWKS endpoint handler (`/jwks.json`).
+pub mod jwks;
+pub use jwks::JwksResponse;

--- a/authkestra-op/src/lib.rs
+++ b/authkestra-op/src/lib.rs
@@ -27,6 +27,9 @@ pub use client::{ClientRegistration, ClientStore, GrantType};
 pub mod code;
 pub use code::{AuthorizationCode, AuthorizationCodeStore};
 
+/// HTTP handlers for OP endpoints (discovery, jwks, authorize, token).
+pub mod handlers;
+
 /// Provider-level configuration (issuer URL, supported scopes/response
 /// types).
 pub mod config;


### PR DESCRIPTION
Closes #46. Implements the `/.well-known/openid-configuration` and `/jwks.json` schemas and logic for OP.2.

Awaiting review before merging.