### PR TITLE
Fix: OP Followups (TTL and ID token nonce)

### DIFF
--- a/authkestra-actix/src/lib.rs
+++ b/authkestra-actix/src/lib.rs
@@ -221,7 +221,7 @@ impl FromRequest for AuthToken {
             }
 
             let token = &auth_header[7..];
-            let claims = token_manager.get_ref().validate_token(token).map_err(|e| {
+            let claims = token_manager.get_ref().validate_token(token, None).map_err(|e| {
                 tracing::error!(error = %e, "failed to validate token");
                 actix_web::error::ErrorUnauthorized(format!("Invalid token: {e}"))
             })?;

--- a/authkestra-actix/src/lib.rs
+++ b/authkestra-actix/src/lib.rs
@@ -221,10 +221,13 @@ impl FromRequest for AuthToken {
             }
 
             let token = &auth_header[7..];
-            let claims = token_manager.get_ref().validate_token(token, None).map_err(|e| {
-                tracing::error!(error = %e, "failed to validate token");
-                actix_web::error::ErrorUnauthorized(format!("Invalid token: {e}"))
-            })?;
+            let claims = token_manager
+                .get_ref()
+                .validate_token(token, None)
+                .map_err(|e| {
+                    tracing::error!(error = %e, "failed to validate token");
+                    actix_web::error::ErrorUnauthorized(format!("Invalid token: {e}"))
+                })?;
 
             tracing::info!("successfully extracted and validated actix AuthToken");
             Ok(AuthToken(claims))

--- a/authkestra-axum/src/helpers.rs
+++ b/authkestra-axum/src/helpers.rs
@@ -487,7 +487,7 @@ pub async fn get_token(
     }
 
     let token = &auth_header[7..];
-    let claims = token_manager.validate_token(token).map_err(|e| {
+    let claims = token_manager.validate_token(token, None).map_err(|e| {
         tracing::error!(error = %e, "failed to validate token");
         AuthEngineAxumError::Unauthorized(format!("Invalid token: {e}"))
     })?;

--- a/authkestra-engine/src/token/mod.rs
+++ b/authkestra-engine/src/token/mod.rs
@@ -219,9 +219,13 @@ impl TokenManager {
         encode(&header, &claims, &self.encoding_key).map_err(|e| AuthError::Token(e.to_string()))
     }
 
-    pub fn validate_token(&self, token: &str) -> Result<Claims, AuthError> {
+    pub fn validate_token(&self, token: &str, expected_aud: Option<&str>) -> Result<Claims, AuthError> {
         let mut validation = Validation::new(self.alg);
-        validation.validate_aud = false; // Don't strictly validate audience by default here
+        if let Some(aud) = expected_aud {
+            validation.set_audience(&[aud]);
+        } else {
+            validation.validate_aud = false;
+        }
         if let Some(ref iss) = self.issuer {
             validation.set_issuer(&[iss]);
         }
@@ -240,7 +244,7 @@ impl TokenService for TokenManager {
     }
 
     async fn verify(&self, token: &str) -> Result<Identity, AuthError> {
-        let claims = self.validate_token(token)?;
+        let claims = self.validate_token(token, None)?;
         claims
             .identity
             .ok_or_else(|| AuthError::Token("No identity in token".to_string()))
@@ -300,7 +304,7 @@ mod tests {
         };
 
         let token = manager.issue_user_token(identity, 3600, None).unwrap();
-        let claims = manager.validate_token(&token).unwrap();
+        let claims = manager.validate_token(&token, None).unwrap();
 
         assert_eq!(claims.iss, Some("issuer".to_string()));
         assert_eq!(claims.sub, "user123");
@@ -385,7 +389,7 @@ a0QMqKUcs8+YTy5R5K6qtw==
             .issue_id_token(identity, "client-1", Some("nonce123".to_string()), 3600)
             .unwrap();
 
-        let claims = manager.validate_token(&token).unwrap();
+        let claims = manager.validate_token(&token, None).unwrap();
 
         assert_eq!(claims.iss, Some("issuer".to_string()));
         assert_eq!(claims.sub, "user123");

--- a/authkestra-engine/src/token/mod.rs
+++ b/authkestra-engine/src/token/mod.rs
@@ -175,7 +175,9 @@ impl TokenManager {
         };
 
         if let Some(n) = nonce {
-            claims.extra.insert("nonce".to_string(), serde_json::Value::String(n));
+            claims
+                .extra
+                .insert("nonce".to_string(), serde_json::Value::String(n));
         }
 
         let mut header = Header::new(self.alg);
@@ -380,12 +382,7 @@ a0QMqKUcs8+YTy5R5K6qtw==
         };
 
         let token = manager
-            .issue_id_token(
-                identity,
-                "client-1",
-                Some("nonce123".to_string()),
-                3600,
-            )
+            .issue_id_token(identity, "client-1", Some("nonce123".to_string()), 3600)
             .unwrap();
 
         let claims = manager.validate_token(&token).unwrap();

--- a/authkestra-engine/src/token/mod.rs
+++ b/authkestra-engine/src/token/mod.rs
@@ -396,5 +396,29 @@ a0QMqKUcs8+YTy5R5K6qtw==
         assert_eq!(claims.aud, Some("client-1".to_string()));
         assert_eq!(claims.extra.get("nonce").unwrap(), "nonce123");
     }
+    #[test]
+    fn test_token_manager_audience_validation() {
+        let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
+        let identity = Identity {
+            provider_id: "mock".to_string(),
+            external_id: "user123".to_string(),
+            email: None,
+            username: None,
+            attributes: HashMap::new(),
+        };
+
+        // Issue token for "client-1"
+        let token = manager
+            .issue_id_token(identity, "client-1", None, 3600)
+            .unwrap();
+
+        // Validate with correct audience
+        let claims = manager.validate_token(&token, Some("client-1")).unwrap();
+        assert_eq!(claims.aud, Some("client-1".to_string()));
+
+        // Validate with incorrect audience (should fail)
+        let err = manager.validate_token(&token, Some("client-2")).unwrap_err();
+        assert!(err.to_string().contains("InvalidAudience"));
+    }
 }
 pub mod jwk;

--- a/authkestra-engine/src/token/mod.rs
+++ b/authkestra-engine/src/token/mod.rs
@@ -150,6 +150,42 @@ impl TokenManager {
         encode(&header, &claims, &self.encoding_key).map_err(|e| AuthError::Token(e.to_string()))
     }
 
+    /// Issues an OIDC-conformant ID token.
+    pub fn issue_id_token(
+        &self,
+        identity: Identity,
+        client_id: &str,
+        nonce: Option<String>,
+        expires_in_secs: u64,
+    ) -> Result<String, AuthError> {
+        let now = chrono::Utc::now().timestamp() as usize;
+        let expiration = now + expires_in_secs as usize;
+
+        let mut claims = Claims {
+            iss: self.issuer.clone(),
+            sub: identity.external_id.clone(),
+            aud: Some(client_id.to_string()),
+            exp: expiration,
+            iat: now,
+            nbf: Some(now),
+            jti: Some(uuid::Uuid::new_v4().to_string()),
+            scope: None,
+            identity: Some(identity),
+            extra: HashMap::new(),
+        };
+
+        if let Some(n) = nonce {
+            claims.extra.insert("nonce".to_string(), serde_json::Value::String(n));
+        }
+
+        let mut header = Header::new(self.alg);
+        if let Some(ref kid) = self.kid {
+            header.kid = Some(kid.clone());
+        }
+
+        encode(&header, &claims, &self.encoding_key).map_err(|e| AuthError::Token(e.to_string()))
+    }
+
     /// Issues a machine-to-machine (M2M) token for a client.
     pub fn issue_client_token(
         &self,
@@ -183,6 +219,7 @@ impl TokenManager {
 
     pub fn validate_token(&self, token: &str) -> Result<Claims, AuthError> {
         let mut validation = Validation::new(self.alg);
+        validation.validate_aud = false; // Don't strictly validate audience by default here
         if let Some(ref iss) = self.issuer {
             validation.set_issuer(&[iss]);
         }
@@ -329,6 +366,34 @@ a0QMqKUcs8+YTy5R5K6qtw==
             jsonwebtoken::decode::<Claims>(&token, &decoding_key, &validation).unwrap();
         assert_eq!(token_data.claims.sub, "user123");
         assert_eq!(token_data.header.kid.as_deref(), Some("my-kid-123"));
+    }
+
+    #[test]
+    fn test_issue_id_token() {
+        let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
+        let identity = Identity {
+            provider_id: "mock".to_string(),
+            external_id: "user123".to_string(),
+            email: None,
+            username: None,
+            attributes: HashMap::new(),
+        };
+
+        let token = manager
+            .issue_id_token(
+                identity,
+                "client-1",
+                Some("nonce123".to_string()),
+                3600,
+            )
+            .unwrap();
+
+        let claims = manager.validate_token(&token).unwrap();
+
+        assert_eq!(claims.iss, Some("issuer".to_string()));
+        assert_eq!(claims.sub, "user123");
+        assert_eq!(claims.aud, Some("client-1".to_string()));
+        assert_eq!(claims.extra.get("nonce").unwrap(), "nonce123");
     }
 }
 pub mod jwk;

--- a/authkestra-engine/src/token/mod.rs
+++ b/authkestra-engine/src/token/mod.rs
@@ -219,7 +219,11 @@ impl TokenManager {
         encode(&header, &claims, &self.encoding_key).map_err(|e| AuthError::Token(e.to_string()))
     }
 
-    pub fn validate_token(&self, token: &str, expected_aud: Option<&str>) -> Result<Claims, AuthError> {
+    pub fn validate_token(
+        &self,
+        token: &str,
+        expected_aud: Option<&str>,
+    ) -> Result<Claims, AuthError> {
         let mut validation = Validation::new(self.alg);
         if let Some(aud) = expected_aud {
             validation.set_audience(&[aud]);
@@ -417,7 +421,9 @@ a0QMqKUcs8+YTy5R5K6qtw==
         assert_eq!(claims.aud, Some("client-1".to_string()));
 
         // Validate with incorrect audience (should fail)
-        let err = manager.validate_token(&token, Some("client-2")).unwrap_err();
+        let err = manager
+            .validate_token(&token, Some("client-2"))
+            .unwrap_err();
         assert!(err.to_string().contains("InvalidAudience"));
     }
 }

--- a/authkestra-op/src/code.rs
+++ b/authkestra-op/src/code.rs
@@ -28,6 +28,8 @@ pub struct AuthorizationCode {
     pub code_challenge: Option<String>,
     /// PKCE code_challenge_method (`plain` or `S256`).
     pub code_challenge_method: Option<String>,
+    /// OIDC nonce, if provided in the authorization request.
+    pub nonce: Option<String>,
     /// The authenticated identity this code represents.
     pub identity: Identity,
     /// When this code expires. Recommend issuing with a short lifetime

--- a/authkestra-op/src/config.rs
+++ b/authkestra-op/src/config.rs
@@ -27,6 +27,8 @@ pub struct OpConfig {
     /// Lifetime, in seconds, of issued authorization codes. Keep short
     /// (RFC-003 §7 recommends ≤60).
     pub authorization_code_ttl_secs: i64,
+    /// Lifetime, in seconds, of issued access tokens.
+    pub access_token_ttl_secs: u64,
 }
 
 impl OpConfig {

--- a/authkestra-op/src/handlers/authorize.rs
+++ b/authkestra-op/src/handlers/authorize.rs
@@ -21,8 +21,10 @@ pub struct AuthorizeRequest {
     pub state: Option<String>,
     /// PKCE code challenge.
     pub code_challenge: Option<String>,
-    /// PKCE code challenge method ("S256").
+    /// PKCE code_challenge_method ("S256").
     pub code_challenge_method: Option<String>,
+    /// OIDC nonce.
+    pub nonce: Option<String>,
 }
 
 /// The result of an authorization request handler.
@@ -149,6 +151,7 @@ pub async fn handle_authorize(
         scope: req.scope.clone(),
         code_challenge: req.code_challenge.clone(),
         code_challenge_method: req.code_challenge_method.clone(),
+        nonce: req.nonce.clone(),
         identity,
         expires_at,
         used: false,
@@ -188,6 +191,7 @@ mod tests {
             grant_types_supported: vec![],
             id_token_signing_alg: "RS256".to_string(),
             authorization_code_ttl_secs: 60,
+            access_token_ttl_secs: 3600,
         }
     }
 
@@ -215,6 +219,7 @@ mod tests {
             state: None,
             code_challenge: None,
             code_challenge_method: None,
+            nonce: None,
         };
 
         let outcome = handle_authorize(req, test_identity(), &config, &clients, &codes).await;
@@ -248,6 +253,7 @@ mod tests {
             state: None,
             code_challenge: None,
             code_challenge_method: None,
+            nonce: None,
         };
 
         let outcome = handle_authorize(req, test_identity(), &config, &clients, &codes).await;
@@ -280,6 +286,7 @@ mod tests {
             state: Some("xyz".to_string()),
             code_challenge: None,
             code_challenge_method: None,
+            nonce: None,
         };
 
         let outcome = handle_authorize(req, test_identity(), &config, &clients, &codes).await;
@@ -315,6 +322,7 @@ mod tests {
             state: None,
             code_challenge: None, // Missing PKCE
             code_challenge_method: None,
+            nonce: None,
         };
 
         let outcome = handle_authorize(req, test_identity(), &config, &clients, &codes).await;
@@ -348,6 +356,7 @@ mod tests {
             state: None,
             code_challenge: Some("challenge".to_string()),
             code_challenge_method: Some("plain".to_string()), // plain is rejected
+            nonce: None,
         };
 
         let outcome = handle_authorize(req, test_identity(), &config, &clients, &codes).await;
@@ -381,6 +390,7 @@ mod tests {
             state: Some("abc".to_string()),
             code_challenge: Some("s256challenge".to_string()),
             code_challenge_method: Some("S256".to_string()),
+            nonce: None,
         };
 
         let outcome = handle_authorize(req, test_identity(), &config, &clients, &codes).await;
@@ -434,6 +444,7 @@ mod tests {
             state: Some(dangerous_state.to_string()),
             code_challenge: None,
             code_challenge_method: None,
+            nonce: None,
         };
 
         let outcome = handle_authorize(req, test_identity(), &config, &clients, &codes).await;
@@ -485,6 +496,7 @@ mod tests {
             state: None,
             code_challenge: None,
             code_challenge_method: Some("S256".to_string()), // Method provided without challenge
+            nonce: None,
         };
 
         let outcome = handle_authorize(req, test_identity(), &config, &clients, &codes).await;

--- a/authkestra-op/src/handlers/discovery.rs
+++ b/authkestra-op/src/handlers/discovery.rs
@@ -80,6 +80,7 @@ mod tests {
             grant_types_supported: vec!["authorization_code".to_string()],
             id_token_signing_alg: "RS256".to_string(),
             authorization_code_ttl_secs: 60,
+            access_token_ttl_secs: 3600,
         };
 
         let doc = OidcDiscovery::from_config(&config);

--- a/authkestra-op/src/handlers/mod.rs
+++ b/authkestra-op/src/handlers/mod.rs
@@ -14,6 +14,3 @@ pub use authorize::{handle_authorize, AuthorizeOutcome, AuthorizeRequest};
 pub mod token;
 pub use token::{handle_token, TokenErrorResponse, TokenRequest, TokenResponse};
 
-/// UserInfo endpoint handler (`/userinfo`).
-pub mod userinfo;
-pub use userinfo::{handle_userinfo, UserInfoErrorResponse, UserInfoRequest, UserInfoResponse};

--- a/authkestra-op/src/handlers/mod.rs
+++ b/authkestra-op/src/handlers/mod.rs
@@ -13,3 +13,7 @@ pub use authorize::{handle_authorize, AuthorizeOutcome, AuthorizeRequest};
 /// Token endpoint handler (`/token`).
 pub mod token;
 pub use token::{handle_token, TokenErrorResponse, TokenRequest, TokenResponse};
+
+/// UserInfo endpoint handler (`/userinfo`).
+pub mod userinfo;
+pub use userinfo::{handle_userinfo, UserInfoErrorResponse, UserInfoRequest, UserInfoResponse};

--- a/authkestra-op/src/handlers/mod.rs
+++ b/authkestra-op/src/handlers/mod.rs
@@ -13,4 +13,3 @@ pub use authorize::{handle_authorize, AuthorizeOutcome, AuthorizeRequest};
 /// Token endpoint handler (`/token`).
 pub mod token;
 pub use token::{handle_token, TokenErrorResponse, TokenRequest, TokenResponse};
-

--- a/authkestra-op/src/handlers/token.rs
+++ b/authkestra-op/src/handlers/token.rs
@@ -51,7 +51,7 @@ pub struct TokenErrorResponse {
 /// Handles token exchange requests (e.g. `grant_type=authorization_code`).
 pub async fn handle_token(
     req: TokenRequest,
-    _config: &OpConfig,
+    config: &OpConfig,
     clients: &dyn ClientStore,
     codes: &dyn AuthorizationCodeStore,
     tokens: &TokenManager,
@@ -185,7 +185,7 @@ pub async fn handle_token(
     }
 
     // 7. Issue tokens
-    let expires_in = 3600; // Typically would come from config or client settings
+    let expires_in = config.access_token_ttl_secs;
     let scope_opt = if auth_code.scope.is_empty() {
         None
     } else {
@@ -205,8 +205,12 @@ pub async fn handle_token(
         };
 
     let id_token = if auth_code.scope.contains("openid") {
-        // Here we just reissue a JWT for the ID token. In reality we might want a different audience, etc.
-        match tokens.issue_user_token(auth_code.identity, expires_in, scope_opt.clone()) {
+        match tokens.issue_id_token(
+            auth_code.identity,
+            &req.client_id,
+            auth_code.nonce,
+            expires_in,
+        ) {
             Ok(t) => Some(t),
             Err(e) => {
                 tracing::error!(error = ?e, "Failed to issue id token");
@@ -251,6 +255,7 @@ mod tests {
             grant_types_supported: vec![],
             id_token_signing_alg: "RS256".to_string(),
             authorization_code_ttl_secs: 60,
+            access_token_ttl_secs: 3600,
         }
     }
 
@@ -314,6 +319,7 @@ mod tests {
                 scope: "openid".to_string(),
                 code_challenge: Some(challenge),
                 code_challenge_method: Some("S256".to_string()),
+                nonce: None,
                 identity: test_identity(),
                 expires_at: Utc::now() + Duration::seconds(60),
                 used: false,
@@ -363,6 +369,7 @@ mod tests {
                 scope: "openid".to_string(),
                 code_challenge: Some("some-challenge".to_string()),
                 code_challenge_method: Some("S256".to_string()),
+                nonce: None,
                 identity: test_identity(),
                 expires_at: Utc::now() + Duration::seconds(60),
                 used: false,
@@ -407,6 +414,7 @@ mod tests {
                 scope: "".to_string(),
                 code_challenge: None,
                 code_challenge_method: None,
+                nonce: None,
                 identity: test_identity(),
                 expires_at: Utc::now() + Duration::seconds(60),
                 used: false,
@@ -449,8 +457,8 @@ mod tests {
                 redirect_uri: "https://app.example.com/cb".to_string(),
                 scope: "openid".to_string(),
                 code_challenge: Some("some-challenge".to_string()),
-                // Deliberately malformed stored code using "plain" method
                 code_challenge_method: Some("plain".to_string()),
+                nonce: None,
                 identity: test_identity(),
                 expires_at: Utc::now() + Duration::seconds(60),
                 used: false,

--- a/plans/ticket-op-3-4-plan.md
+++ b/plans/ticket-op-3-4-plan.md
@@ -1,0 +1,30 @@
+# OP.3 and OP.4: Authorization and Token Endpoints
+
+## Goal
+Implement the core OAuth 2.0 / OIDC Authorization Code grant. This covers the `/authorize` endpoint (which issues short-lived authorization codes) and the `/token` endpoint (which exchanges those codes for ID and Access Tokens).
+
+## Scope
+- **`authkestra-op/src/handlers/authorize.rs`**:
+  - Accept `client_id`, `redirect_uri`, `response_type=code`, `scope`, `state`, `code_challenge`, and `code_challenge_method`.
+  - Validate `client_id` exists via `ClientStore`.
+  - Validate `redirect_uri` matches one of the client's registered URIs (exact string equality).
+  - Enforce PKCE for public clients.
+  - Require the user to be authenticated (Identity context).
+  - Issue an `AuthorizationCode` using `AuthorizationCodeStore`.
+  - Redirect back to the client's `redirect_uri` with `code` and `state`.
+- **`authkestra-op/src/handlers/token.rs`**:
+  - Accept `grant_type=authorization_code`, `code`, `redirect_uri`, `client_id`, and `code_verifier`.
+  - Atomically consume the authorization code via `AuthorizationCodeStore::consume_code`.
+  - Validate that the code was issued to the requesting `client_id`.
+  - Validate that the `redirect_uri` matches the one provided at `/authorize`.
+  - Validate PKCE `code_verifier` against the stored `code_challenge`.
+  - Issue tokens (ID Token and Access Token) using `authkestra_engine::token::TokenManager`.
+- **Tests**:
+  - Unit tests for authorization request validation.
+  - Unit tests for token exchange validation and PKCE enforcement.
+  - Tests ensuring exact string matching for `redirect_uri`.
+
+## Design Notes
+- **Structural Links**: Like OP.2, ensure handler initialization takes `&OpConfig` to read capabilities, and takes an `Arc<TokenManager>` and `Arc<dyn ClientStore>`, etc.
+- **Stateless OAuth**: Avoid storing ephemeral OAuth state in database schemas. `AuthorizationCodeStore` handles the code exchange mechanism safely and atomically.
+- **Framework Agnostic**: Keep these handlers generic (request/response structs and logic) so `OP.6` can easily wrap them in Axum/Actix adapters later.

--- a/plans/ticket-op-5-plan.md
+++ b/plans/ticket-op-5-plan.md
@@ -1,0 +1,36 @@
+# OP.5: UserInfo Endpoint (`/userinfo`)
+
+## 1. Goal
+Implement the OIDC UserInfo Endpoint to return claims about the authenticated end-user.
+
+## 2. Specification Context (RFC-003 & OIDC Core 1.0)
+- **Endpoint**: `/userinfo`
+- **Method**: GET or POST
+- **Authentication**: Bearer Token in the `Authorization` header.
+- **Response**: JSON object containing user claims (e.g., `sub`, `email`, `username`), based on the scopes granted during the original authorization request.
+- **Constraints**: 
+  - Must validate the access token.
+  - Must return standard OIDC claims if the corresponding scopes were granted (e.g., `email` for the `email` scope).
+
+## 3. Implementation Plan
+### Step 1: Request & Response Types
+- Define `UserInfoRequest` (though mostly just the extracted bearer token).
+- Define `UserInfoResponse` as a generic JSON map (or typed struct for standard OIDC claims like `sub`, `name`, `email`).
+
+### Step 2: The Handler Logic (`authkestra-op/src/handlers/userinfo.rs`)
+1. **Extract Token**: Get the Bearer token from the `Authorization` header.
+2. **Verify Token**: Use `TokenManager` (or `TokenService`) to validate the access token.
+   - If invalid or expired, return `401 Unauthorized` with `WWW-Authenticate: error="invalid_token"`.
+3. **Check Scopes**: Ensure the token possesses the `openid` scope (UserInfo is an OIDC feature).
+4. **Build Claims**: Construct the JSON response using the `Identity` associated with the validated token. Include standard claims based on granted scopes (e.g., `email`, `profile`).
+
+### Step 3: Tests
+- **test_missing_token**: Request without Bearer token -> 401.
+- **test_invalid_token**: Request with tampered/expired token -> 401.
+- **test_missing_openid_scope**: Valid token but lacks `openid` scope -> 403 (or 401).
+- **test_successful_userinfo**: Valid token with `openid profile email` scopes -> 200 OK with expected JSON (`sub`, `email`, etc.).
+
+## 4. Acceptance Criteria
+- `/userinfo` correctly decodes Bearer access tokens.
+- OIDC standard claims are correctly returned based on the `Identity` object in the token.
+- Missing or invalid tokens are correctly rejected with 401.


### PR DESCRIPTION
This PR completes OP follow-ups:
- Added  to  and refactored  to use it (Fixes #69)
- Implemented OIDC conformant ID token generation with  and  (Fixes #70)
- Ensure tests run cleanly and pass
