### PR TITLE
fix: Address data layer review follow-ups

### DIFF
--- a/crates/authkestra-engine/src/store/redis.rs
+++ b/crates/authkestra-engine/src/store/redis.rs
@@ -114,6 +114,11 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> AtomicConsume<T> f
     #[tracing::instrument(skip(self))]
     async fn consume(&self, key: &str) -> Result<Option<T>, StoreError> {
         tracing::debug!(key = %key, "atomically consuming from redis store");
+
+        // Note: We atomically consume the primary key using a Lua script.
+        // The associated index_key (if any) is not deleted here because it is not provided
+        // to `consume()`. This is benign: the stale index will expire simultaneously
+        // via its matching TTL, and `get_by_index` gracefully cleans up any orphaned pointers.
         let mut conn = self
             .client
             .get_multiplexed_async_connection()

--- a/crates/authkestra-engine/src/store/sql.rs
+++ b/crates/authkestra-engine/src/store/sql.rs
@@ -139,7 +139,7 @@ impl SqlKvStore<sqlx::Postgres> {
             table = self.table_name
         );
         let query2 = format!(
-            "CREATE INDEX IF NOT EXISTS {table}_idx ON {table}(index_key)",
+            "CREATE UNIQUE INDEX IF NOT EXISTS {table}_idx ON {table}(index_key)",
             table = self.table_name
         );
         sqlx::query(&query1)
@@ -278,7 +278,7 @@ impl SqlKvStore<sqlx::Sqlite> {
                 value TEXT NOT NULL,
                 expires_at DATETIME NOT NULL
             );
-            CREATE INDEX IF NOT EXISTS {table}_idx ON {table}(index_key);",
+            CREATE UNIQUE INDEX IF NOT EXISTS {table}_idx ON {table}(index_key);",
             table = self.table_name
         );
         sqlx::query(&query)
@@ -496,7 +496,7 @@ impl SqlKvStore<sqlx::MySql> {
                 index_key VARCHAR(255),
                 value TEXT NOT NULL,
                 expires_at DATETIME NOT NULL,
-                INDEX {table}_idx (index_key)
+                UNIQUE INDEX {table}_idx (index_key)
             )",
             table = self.table_name
         );


### PR DESCRIPTION
Follow-ups from the data layer PR (#84):
1. **SQL Uniqueness**: Added `UNIQUE` constraints to the `index_key` column creation across Postgres, SQLite, and MySQL to provide defense-in-depth against collisions.
2. **Redis Index Cleanup**: Added explicit inline documentation clarifying that the Lua-based `consume()` script inherently leaves the index entry to gracefully expire/self-heal, which avoids over-engineering a reverse-lookup solution.

Closes #84 (follow-up). All tests pass with the new constraint.