### PR TITLE
feat(op): unify store interfaces into OpStore

### DIFF
--- a/crates/authkestra-actix/src/op.rs
+++ b/crates/authkestra-actix/src/op.rs
@@ -1,10 +1,7 @@
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
 use authkestra_engine::TokenManager;
 use authkestra_op::{
-    client::ClientStore,
-    code::AuthorizationCodeStore,
     config::OpConfig,
-    device::DeviceCodeStore,
     handlers::{
         authorize::{handle_authorize, AuthorizeOutcome, AuthorizeRequest},
         device_authorization::{handle_device_authorization, DeviceAuthorizationRequest},
@@ -13,7 +10,6 @@ use authkestra_op::{
         token::{handle_token, TokenRequest},
         userinfo::{handle_userinfo, UserInfoErrorResponse, UserInfoRequest},
     },
-    refresh::RefreshTokenStore,
 };
 use std::sync::Arc;
 

--- a/crates/authkestra-actix/src/op.rs
+++ b/crates/authkestra-actix/src/op.rs
@@ -30,8 +30,7 @@ pub async fn actix_discovery_handler(config: web::Data<OpConfig>) -> impl Respon
 }
 
 pub async fn actix_authorize_handler(
-    clients: web::Data<Arc<dyn ClientStore>>,
-    codes: web::Data<Arc<dyn AuthorizationCodeStore>>,
+    op_store: web::Data<Arc<dyn authkestra_op::OpStore>>,
     config: web::Data<OpConfig>,
     auth_session: Option<crate::AuthSession>,
     req: web::Query<AuthorizeRequest>,
@@ -54,8 +53,7 @@ pub async fn actix_authorize_handler(
         req.into_inner(),
         identity,
         config.get_ref(),
-        clients.get_ref().as_ref(),
-        codes.get_ref().as_ref(),
+        op_store.get_ref().as_ref(),
     )
     .await
     {
@@ -72,8 +70,7 @@ pub async fn actix_authorize_handler(
 pub async fn actix_device_authorization_handler(
     http_req: HttpRequest,
     req: web::Form<DeviceAuthorizationRequest>,
-    clients: web::Data<Arc<dyn ClientStore>>,
-    devices: web::Data<Arc<dyn DeviceCodeStore>>,
+    op_store: web::Data<Arc<dyn authkestra_op::OpStore>>,
     config: web::Data<OpConfig>,
 ) -> impl Responder {
     tracing::debug!("Handling OP device authorization request (actix)");
@@ -87,8 +84,7 @@ pub async fn actix_device_authorization_handler(
         req.into_inner(),
         auth_header,
         config.get_ref(),
-        clients.get_ref().as_ref(),
-        devices.get_ref().as_ref(),
+        op_store.get_ref().as_ref(),
     )
     .await
     {
@@ -109,10 +105,7 @@ pub async fn actix_device_authorization_handler(
 pub async fn actix_token_handler(
     http_req: HttpRequest,
     req: web::Form<TokenRequest>,
-    clients: web::Data<Arc<dyn ClientStore>>,
-    codes: web::Data<Arc<dyn AuthorizationCodeStore>>,
-    refresh_tokens: web::Data<Arc<dyn RefreshTokenStore>>,
-    devices: web::Data<Arc<dyn DeviceCodeStore>>,
+    op_store: web::Data<Arc<dyn authkestra_op::OpStore>>,
     tokens: web::Data<Arc<TokenManager>>,
     config: web::Data<OpConfig>,
 ) -> impl Responder {
@@ -127,10 +120,7 @@ pub async fn actix_token_handler(
         req.into_inner(),
         auth_header,
         config.get_ref(),
-        clients.get_ref().as_ref(),
-        codes.get_ref().as_ref(),
-        refresh_tokens.get_ref().as_ref(),
-        devices.get_ref().as_ref(),
+        op_store.get_ref().as_ref(),
         tokens.get_ref().as_ref(),
     )
     .await
@@ -187,7 +177,7 @@ pub async fn actix_userinfo_handler(
 
 pub async fn actix_device_verify_handler(
     req: web::Form<authkestra_op::handlers::device_verify::DeviceVerifyRequest>,
-    devices: web::Data<Arc<dyn DeviceCodeStore>>,
+    op_store: web::Data<Arc<dyn authkestra_op::OpStore>>,
     auth_session: Option<crate::AuthSession>,
 ) -> actix_web::HttpResponse {
     tracing::debug!("Handling OP device verify request (actix)");
@@ -205,7 +195,7 @@ pub async fn actix_device_verify_handler(
     match authkestra_op::handlers::device_verify::handle_device_verify(
         req.into_inner(),
         identity,
-        devices.get_ref().as_ref(),
+        op_store.get_ref().as_ref(),
     )
     .await
     {

--- a/crates/authkestra-axum/src/op.rs
+++ b/crates/authkestra-axum/src/op.rs
@@ -63,22 +63,16 @@ pub async fn axum_authorize_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn ClientStore>, AuthEngineAxumError>: FromRef<AppState>,
-    Result<Arc<dyn AuthorizationCodeStore>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
     Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
     authkestra_engine::SessionConfig: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!(client_id = %req.client_id, "Handling OP authorize request (axum)");
-    let clients = match <Result<Arc<dyn ClientStore>, AuthEngineAxumError>>::from_ref(&state) {
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
-    let codes =
-        match <Result<Arc<dyn AuthorizationCodeStore>, AuthEngineAxumError>>::from_ref(&state) {
-            Ok(c) => c,
-            Err(e) => return e.into_response(),
-        };
     let config = OpConfig::from_ref(&state);
 
     let session_store =
@@ -98,7 +92,7 @@ where
         }
     };
 
-    match handle_authorize(req, identity, &config, clients.as_ref(), codes.as_ref()).await {
+    match handle_authorize(req, identity, &config, op_store.as_ref()).await {
         authkestra_op::handlers::authorize::AuthorizeOutcome::Redirect(url) => {
             Redirect::to(&url).into_response()
         }
@@ -121,16 +115,11 @@ pub async fn axum_device_authorization_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn ClientStore>, AuthEngineAxumError>: FromRef<AppState>,
-    Result<Arc<dyn DeviceCodeStore>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP device authorization request (axum)");
-    let clients = match <Result<Arc<dyn ClientStore>, AuthEngineAxumError>>::from_ref(&state) {
-        Ok(c) => c,
-        Err(e) => return e.into_response(),
-    };
-    let devices = match <Result<Arc<dyn DeviceCodeStore>, AuthEngineAxumError>>::from_ref(&state) {
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
@@ -140,15 +129,7 @@ where
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|h| h.to_str().ok());
 
-    match handle_device_authorization(
-        req,
-        auth_header,
-        &config,
-        clients.as_ref(),
-        devices.as_ref(),
-    )
-    .await
-    {
+    match handle_device_authorization(req, auth_header, &config, op_store.as_ref()).await {
         Ok(resp) => (StatusCode::OK, Json(resp)).into_response(),
         Err(err) => {
             let status = match err.error.as_str() {
@@ -168,29 +149,12 @@ pub async fn axum_token_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn ClientStore>, AuthEngineAxumError>: FromRef<AppState>,
-    Result<Arc<dyn AuthorizationCodeStore>, AuthEngineAxumError>: FromRef<AppState>,
-    Result<Arc<dyn RefreshTokenStore>, AuthEngineAxumError>: FromRef<AppState>,
-    Result<Arc<dyn DeviceCodeStore>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
     Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!(grant_type = %req.grant_type, "Handling OP token request (axum)");
-    let clients = match <Result<Arc<dyn ClientStore>, AuthEngineAxumError>>::from_ref(&state) {
-        Ok(c) => c,
-        Err(e) => return e.into_response(),
-    };
-    let codes =
-        match <Result<Arc<dyn AuthorizationCodeStore>, AuthEngineAxumError>>::from_ref(&state) {
-            Ok(c) => c,
-            Err(e) => return e.into_response(),
-        };
-    let refresh_tokens =
-        match <Result<Arc<dyn RefreshTokenStore>, AuthEngineAxumError>>::from_ref(&state) {
-            Ok(c) => c,
-            Err(e) => return e.into_response(),
-        };
-    let devices = match <Result<Arc<dyn DeviceCodeStore>, AuthEngineAxumError>>::from_ref(&state) {
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
@@ -208,10 +172,7 @@ where
         req,
         auth_header,
         &config,
-        clients.as_ref(),
-        codes.as_ref(),
-        refresh_tokens.as_ref(),
-        devices.as_ref(),
+        op_store.as_ref(),
         tokens.as_ref(),
     )
     .await
@@ -288,12 +249,12 @@ pub async fn axum_device_verify_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn DeviceCodeStore>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
     Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
     authkestra_engine::SessionConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP device verify request (axum)");
-    let devices = match <Result<Arc<dyn DeviceCodeStore>, AuthEngineAxumError>>::from_ref(&state) {
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
@@ -318,7 +279,7 @@ where
     match authkestra_op::handlers::device_verify::handle_device_verify(
         req,
         identity,
-        devices.as_ref(),
+        op_store.as_ref(),
     )
     .await
     {
@@ -338,10 +299,7 @@ pub trait AuthEngineAxumOpExt {
     fn op_axum_router<AppState>(&self) -> axum::Router<AppState>
     where
         AppState: Clone + Send + Sync + 'static,
-        Result<Arc<dyn ClientStore>, AuthEngineAxumError>: FromRef<AppState>,
-        Result<Arc<dyn AuthorizationCodeStore>, AuthEngineAxumError>: FromRef<AppState>,
-        Result<Arc<dyn RefreshTokenStore>, AuthEngineAxumError>: FromRef<AppState>,
-        Result<Arc<dyn DeviceCodeStore>, AuthEngineAxumError>: FromRef<AppState>,
+        Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
         Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
         Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
         authkestra_engine::SessionConfig: FromRef<AppState>,
@@ -353,10 +311,7 @@ impl<T> AuthEngineAxumOpExt for T {
     fn op_axum_router<AppState>(&self) -> axum::Router<AppState>
     where
         AppState: Clone + Send + Sync + 'static,
-        Result<Arc<dyn ClientStore>, AuthEngineAxumError>: FromRef<AppState>,
-        Result<Arc<dyn AuthorizationCodeStore>, AuthEngineAxumError>: FromRef<AppState>,
-        Result<Arc<dyn RefreshTokenStore>, AuthEngineAxumError>: FromRef<AppState>,
-        Result<Arc<dyn DeviceCodeStore>, AuthEngineAxumError>: FromRef<AppState>,
+        Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
         Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
         Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
         authkestra_engine::SessionConfig: FromRef<AppState>,

--- a/crates/authkestra-axum/src/op.rs
+++ b/crates/authkestra-axum/src/op.rs
@@ -1,10 +1,7 @@
 use crate::AuthEngineAxumError;
 use authkestra_engine::TokenManager;
 use authkestra_op::{
-    client::ClientStore,
-    code::AuthorizationCodeStore,
     config::OpConfig,
-    device::DeviceCodeStore,
     handlers::{
         authorize::handle_authorize,
         device_authorization::{handle_device_authorization, DeviceAuthorizationRequest},
@@ -13,7 +10,6 @@ use authkestra_op::{
         token::{handle_token, TokenRequest},
         userinfo::{handle_userinfo, UserInfoErrorResponse, UserInfoRequest},
     },
-    refresh::RefreshTokenStore,
 };
 use axum::{
     extract::{Form, FromRef, Query, State},
@@ -69,10 +65,11 @@ where
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!(client_id = %req.client_id, "Handling OP authorize request (axum)");
-    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
-        Ok(c) => c,
-        Err(e) => return e.into_response(),
-    };
+    let op_store =
+        match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
+            Ok(c) => c,
+            Err(e) => return e.into_response(),
+        };
     let config = OpConfig::from_ref(&state);
 
     let session_store =
@@ -119,10 +116,11 @@ where
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP device authorization request (axum)");
-    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
-        Ok(c) => c,
-        Err(e) => return e.into_response(),
-    };
+    let op_store =
+        match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
+            Ok(c) => c,
+            Err(e) => return e.into_response(),
+        };
     let config = OpConfig::from_ref(&state);
 
     let auth_header = headers
@@ -154,10 +152,11 @@ where
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!(grant_type = %req.grant_type, "Handling OP token request (axum)");
-    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
-        Ok(c) => c,
-        Err(e) => return e.into_response(),
-    };
+    let op_store =
+        match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
+            Ok(c) => c,
+            Err(e) => return e.into_response(),
+        };
     let tokens = match <Result<Arc<TokenManager>, AuthEngineAxumError>>::from_ref(&state) {
         Ok(t) => t,
         Err(e) => return e.into_response(),
@@ -254,10 +253,11 @@ where
     authkestra_engine::SessionConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP device verify request (axum)");
-    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
-        Ok(c) => c,
-        Err(e) => return e.into_response(),
-    };
+    let op_store =
+        match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
+            Ok(c) => c,
+            Err(e) => return e.into_response(),
+        };
 
     let session_store =
         match <Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>>::from_ref(&state) {

--- a/crates/authkestra-op/src/handlers/authorize.rs
+++ b/crates/authkestra-op/src/handlers/authorize.rs
@@ -1,5 +1,6 @@
-use crate::client::{ClientStore, GrantType};
-use crate::code::{AuthorizationCode, AuthorizationCodeStore};
+use crate::client::GrantType;
+use crate::code::AuthorizationCode;
+use crate::store::OpStore;
 use crate::config::OpConfig;
 use crate::error::OpError;
 use authkestra_engine::auth::state::Identity;
@@ -42,12 +43,11 @@ pub async fn handle_authorize(
     req: AuthorizeRequest,
     identity: Identity,
     config: &OpConfig,
-    clients: &dyn ClientStore,
-    codes: &dyn AuthorizationCodeStore,
+    op_store: &dyn OpStore,
 ) -> AuthorizeOutcome {
     // 1. Look up client_id
     tracing::debug!(client_id = %req.client_id, "Looking up client for authorization request");
-    let client = match clients.find_client(&req.client_id).await {
+    let client = match op_store.find_client(&req.client_id).await {
         Ok(Some(client)) => client,
         Ok(None) => {
             tracing::warn!(client_id = %req.client_id, "Unknown client ID requested");
@@ -161,7 +161,7 @@ pub async fn handle_authorize(
     };
 
     // 8. Store the code
-    if let Err(e) = codes.store_code(auth_code).await {
+    if let Err(e) = op_store.store_code(auth_code).await {
         tracing::error!(error = ?e, client_id = %req.client_id, "Failed to store authorization code");
         return error_redirect("server_error", "Failed to store authorization code");
     }
@@ -183,7 +183,8 @@ pub async fn handle_authorize(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::client::ClientRegistration;
+    use crate::client::{ClientRegistration, ClientStore, GrantType};
+    use crate::code::AuthorizationCodeStore;
     use authkestra_engine::store::KvStore;
 
     fn test_config() -> OpConfig {
@@ -230,7 +231,7 @@ mod tests {
             nonce: None,
         };
 
-        let outcome = handle_authorize(req, test_identity(), &config, &clients, &codes).await;
+        let outcome = handle_authorize(req, test_identity(), &config, &crate::store::CompositeOpStore::new(clients, codes, authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(), authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new())).await;
         assert!(matches!(
             outcome,
             AuthorizeOutcome::DirectError(OpError::UnknownClient(_))
@@ -275,7 +276,7 @@ mod tests {
             nonce: None,
         };
 
-        let outcome = handle_authorize(req, test_identity(), &config, &clients, &codes).await;
+        let outcome = handle_authorize(req, test_identity(), &config, &crate::store::CompositeOpStore::new(clients, codes, authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(), authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new())).await;
         assert!(matches!(
             outcome,
             AuthorizeOutcome::DirectError(OpError::RedirectUriMismatch)
@@ -319,7 +320,7 @@ mod tests {
             nonce: None,
         };
 
-        let outcome = handle_authorize(req, test_identity(), &config, &clients, &codes).await;
+        let outcome = handle_authorize(req, test_identity(), &config, &crate::store::CompositeOpStore::new(clients, codes, authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(), authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new())).await;
         if let AuthorizeOutcome::Redirect(url) = outcome {
             assert!(url.contains("error=unsupported_response_type"));
             assert!(url.contains("state=xyz"));
@@ -366,7 +367,7 @@ mod tests {
             nonce: None,
         };
 
-        let outcome = handle_authorize(req, test_identity(), &config, &clients, &codes).await;
+        let outcome = handle_authorize(req, test_identity(), &config, &crate::store::CompositeOpStore::new(clients, codes, authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(), authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new())).await;
         if let AuthorizeOutcome::Redirect(url) = outcome {
             assert!(url.contains("error=invalid_request"));
         } else {
@@ -411,7 +412,7 @@ mod tests {
             nonce: None,
         };
 
-        let outcome = handle_authorize(req, test_identity(), &config, &clients, &codes).await;
+        let outcome = handle_authorize(req, test_identity(), &config, &crate::store::CompositeOpStore::new(clients, codes, authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(), authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new())).await;
         if let AuthorizeOutcome::Redirect(url) = outcome {
             assert!(url.contains("error=invalid_request"));
         } else {
@@ -456,7 +457,7 @@ mod tests {
             nonce: None,
         };
 
-        let outcome = handle_authorize(req, test_identity(), &config, &clients, &codes).await;
+        let outcome = handle_authorize(req, test_identity(), &config, &crate::store::CompositeOpStore::new(clients, codes.clone(), authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(), authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new())).await;
         if let AuthorizeOutcome::Redirect(url) = outcome {
             assert!(url.starts_with("https://app.example.com/cb?code="));
             assert!(url.contains("&state=abc"));
@@ -521,7 +522,7 @@ mod tests {
             nonce: None,
         };
 
-        let outcome = handle_authorize(req, test_identity(), &config, &clients, &codes).await;
+        let outcome = handle_authorize(req, test_identity(), &config, &crate::store::CompositeOpStore::new(clients, codes, authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(), authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new())).await;
         if let AuthorizeOutcome::Redirect(url) = outcome {
             let parsed = url::Url::parse(&url).expect("Should be a valid URL");
 
@@ -584,7 +585,7 @@ mod tests {
             nonce: None,
         };
 
-        let outcome = handle_authorize(req, test_identity(), &config, &clients, &codes).await;
+        let outcome = handle_authorize(req, test_identity(), &config, &crate::store::CompositeOpStore::new(clients, codes, authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(), authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new())).await;
         if let AuthorizeOutcome::Redirect(url) = outcome {
             assert!(url.contains("error=invalid_request"));
             assert!(

--- a/crates/authkestra-op/src/handlers/authorize.rs
+++ b/crates/authkestra-op/src/handlers/authorize.rs
@@ -1,8 +1,8 @@
 use crate::client::GrantType;
 use crate::code::AuthorizationCode;
-use crate::store::OpStore;
 use crate::config::OpConfig;
 use crate::error::OpError;
+use crate::store::OpStore;
 use authkestra_engine::auth::state::Identity;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use chrono::{Duration, Utc};

--- a/crates/authkestra-op/src/handlers/authorize.rs
+++ b/crates/authkestra-op/src/handlers/authorize.rs
@@ -183,7 +183,7 @@ pub async fn handle_authorize(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::client::{ClientRegistration, ClientStore, GrantType};
+    use crate::client::{ClientRegistration, GrantType};
     use crate::code::AuthorizationCodeStore;
     use authkestra_engine::store::KvStore;
 

--- a/crates/authkestra-op/src/handlers/device_authorization.rs
+++ b/crates/authkestra-op/src/handlers/device_authorization.rs
@@ -1,6 +1,7 @@
 use crate::client::ClientStore;
 use crate::config::OpConfig;
 use crate::device::{DeviceCodeSession, DeviceCodeStatus, DeviceCodeStore};
+use crate::store::OpStore;
 use base64::Engine;
 use chrono::{Duration, Utc};
 use serde::{Deserialize, Serialize};
@@ -46,8 +47,7 @@ pub async fn handle_device_authorization(
     req: DeviceAuthorizationRequest,
     auth_header: Option<&str>,
     config: &OpConfig,
-    clients: &dyn ClientStore,
-    devices: &dyn DeviceCodeStore,
+    op_store: &dyn OpStore,
 ) -> Result<DeviceAuthorizationResponse, DeviceAuthorizationErrorResponse> {
     let mut client_id = req.client_id.clone();
 
@@ -74,7 +74,7 @@ pub async fn handle_device_authorization(
         }
     };
 
-    let client = match clients.find_client(&client_id).await {
+    let client = match op_store.find_client(&client_id).await {
         Ok(Some(c)) => c,
         _ => {
             return Err(DeviceAuthorizationErrorResponse {
@@ -111,7 +111,7 @@ pub async fn handle_device_authorization(
         last_polled_at: None,
     };
 
-    if devices.store_device_code(session).await.is_err() {
+    if op_store.store_device_code(session).await.is_err() {
         return Err(DeviceAuthorizationErrorResponse {
             error: "server_error".to_string(),
             error_description: "Internal server error".to_string(),
@@ -193,7 +193,12 @@ mod tests {
             scope: Some("openid".to_string()),
         };
 
-        let res = handle_device_authorization(req, None, &config, &clients, &devices)
+        let res = handle_device_authorization(req, None, &config, &crate::store::CompositeOpStore::new(
+            clients.clone(),
+            codes.clone(),
+            refresh_tokens.clone(),
+            devices.clone(),
+        ))
             .await
             .unwrap();
 
@@ -223,10 +228,12 @@ mod tests {
             token_req.clone(),
             None,
             &config,
-            &clients,
-            &codes,
-            &refresh_tokens,
-            &devices,
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                codes.clone(),
+                refresh_tokens.clone(),
+                devices.clone(),
+            ),
             &tokens,
         )
         .await;
@@ -256,10 +263,12 @@ mod tests {
             token_req,
             None,
             &config,
-            &clients,
-            &codes,
-            &refresh_tokens,
-            &devices,
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                codes.clone(),
+                refresh_tokens.clone(),
+                devices.clone(),
+            ),
             &tokens,
         )
         .await

--- a/crates/authkestra-op/src/handlers/device_authorization.rs
+++ b/crates/authkestra-op/src/handlers/device_authorization.rs
@@ -1,4 +1,3 @@
-
 use crate::config::OpConfig;
 use crate::device::{DeviceCodeSession, DeviceCodeStatus};
 use crate::store::OpStore;
@@ -134,7 +133,7 @@ mod tests {
     use crate::client::{ClientRegistration, GrantType};
     use authkestra_engine::store::KvStore;
 
-    use crate::device::DeviceCodeStatus;
+    use crate::device::{DeviceCodeStatus, DeviceCodeStore};
     use crate::handlers::token::{handle_token, TokenRequest};
 
     use authkestra_engine::auth::state::Identity;

--- a/crates/authkestra-op/src/handlers/device_authorization.rs
+++ b/crates/authkestra-op/src/handlers/device_authorization.rs
@@ -1,6 +1,6 @@
-use crate::client::ClientStore;
+
 use crate::config::OpConfig;
-use crate::device::{DeviceCodeSession, DeviceCodeStatus, DeviceCodeStore};
+use crate::device::{DeviceCodeSession, DeviceCodeStatus};
 use crate::store::OpStore;
 use base64::Engine;
 use chrono::{Duration, Utc};
@@ -193,14 +193,19 @@ mod tests {
             scope: Some("openid".to_string()),
         };
 
-        let res = handle_device_authorization(req, None, &config, &crate::store::CompositeOpStore::new(
-            clients.clone(),
-            codes.clone(),
-            refresh_tokens.clone(),
-            devices.clone(),
-        ))
-            .await
-            .unwrap();
+        let res = handle_device_authorization(
+            req,
+            None,
+            &config,
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                codes.clone(),
+                refresh_tokens.clone(),
+                devices.clone(),
+            ),
+        )
+        .await
+        .unwrap();
 
         let device_code = res.device_code.clone();
         let user_code = res.user_code.clone();

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -1,7 +1,6 @@
-use crate::client::ClientStore;
-use crate::code::AuthorizationCodeStore;
+use crate::client::{ClientRegistration, GrantType};
 use crate::config::OpConfig;
-use crate::device::DeviceCodeStore;
+use crate::store::OpStore;
 use crate::refresh::{RefreshToken, RefreshTokenStore};
 use authkestra_engine::token::TokenManager;
 use base64::Engine;
@@ -85,10 +84,7 @@ pub async fn handle_token(
     req: TokenRequest,
     auth_header: Option<&str>,
     config: &OpConfig,
-    clients: &dyn ClientStore,
-    codes: &dyn AuthorizationCodeStore,
-    refresh_tokens: &dyn RefreshTokenStore,
-    devices: &dyn DeviceCodeStore,
+    op_store: &dyn OpStore,
     tokens: &TokenManager,
 ) -> Result<TokenResponse, TokenErrorResponse> {
     tracing::debug!(grant_type = %req.grant_type, "Processing token exchange request");
@@ -122,7 +118,7 @@ pub async fn handle_token(
     };
 
     // 1. Client validation
-    let client = match clients.find_client(&client_id).await {
+    let client = match op_store.find_client(&client_id).await {
         Ok(Some(c)) => c,
         Ok(None) => {
             tracing::warn!(client_id = %client_id, "Unknown client ID during token exchange");
@@ -159,8 +155,7 @@ pub async fn handle_token(
                 client_id,
                 client,
                 config,
-                codes,
-                refresh_tokens,
+                op_store,
                 tokens,
             )
             .await
@@ -169,7 +164,7 @@ pub async fn handle_token(
             handle_client_credentials(req, client_id, client, config, tokens).await
         }
         "refresh_token" => {
-            handle_refresh_token(req, client_id, client, config, refresh_tokens, tokens).await
+            handle_refresh_token(req, client_id, client, config, op_store, tokens).await
         }
         "urn:ietf:params:oauth:grant-type:device_code" => {
             handle_device_code(
@@ -177,8 +172,7 @@ pub async fn handle_token(
                 client_id,
                 client,
                 config,
-                devices,
-                refresh_tokens,
+                op_store,
                 tokens,
             )
             .await
@@ -200,13 +194,11 @@ pub async fn handle_token(
 async fn handle_device_code(
     req: TokenRequest,
     client_id: String,
-    client: crate::client::ClientRegistration,
+    client: ClientRegistration,
     config: &OpConfig,
-    devices: &dyn DeviceCodeStore,
-    refresh_tokens: &dyn RefreshTokenStore,
+    op_store: &dyn OpStore,
     tokens: &TokenManager,
 ) -> Result<TokenResponse, TokenErrorResponse> {
-    use crate::client::GrantType;
     use crate::device::DeviceCodeStatus;
 
     if !client.allows_grant_type(GrantType::DeviceCode) {
@@ -217,7 +209,7 @@ async fn handle_device_code(
         });
     }
 
-    let req_device_code = match req.device_code.as_deref() {
+    let device_code_str = match req.device_code.as_deref() {
         Some(c) => c,
         None => {
             tracing::warn!("Missing device_code in request");
@@ -228,7 +220,7 @@ async fn handle_device_code(
         }
     };
 
-    let session = match devices.get_device_code(req_device_code).await {
+    let session = match op_store.get_device_code(device_code_str).await {
         Ok(Some(s)) => s,
         Ok(None) => {
             return Err(TokenErrorResponse {
@@ -263,7 +255,7 @@ async fn handle_device_code(
             let now = Utc::now();
             let mut updated = session.clone();
             updated.last_polled_at = Some(now);
-            let _ = devices.update_device_code(updated).await;
+            let _ = op_store.store_device_code(updated).await;
 
             if let Some(last_poll) = session.last_polled_at {
                 if now < last_poll + chrono::Duration::seconds(5) {
@@ -281,7 +273,7 @@ async fn handle_device_code(
         }
         DeviceCodeStatus::Denied | DeviceCodeStatus::Approved(_) => {
             // Atomically consume to prevent race conditions
-            let consumed = match devices.consume_device_code(req_device_code).await {
+            let consumed = match op_store.consume_device_code(device_code_str).await {
                 Ok(Some(s)) => s,
                 _ => {
                     return Err(TokenErrorResponse {
@@ -331,14 +323,14 @@ async fn handle_device_code(
                 let mut issued_refresh_token = None;
                 if session.scope.contains("offline_access") {
                     let refresh_val = uuid::Uuid::new_v4().to_string();
-                    let rt = crate::refresh::RefreshToken {
+                    let rt = RefreshToken {
                         token: refresh_val.clone(),
                         client_id: client_id.clone(),
                         identity,
                         scope: session.scope,
                         expires_at: Utc::now() + chrono::Duration::days(30),
                     };
-                    if refresh_tokens.store_token(rt).await.is_ok() {
+                    if op_store.store_token(rt).await.is_ok() {
                         issued_refresh_token = Some(refresh_val);
                     }
                 }
@@ -365,17 +357,16 @@ async fn handle_device_code(
 async fn handle_authorization_code(
     req: TokenRequest,
     client_id: String,
-    client: crate::client::ClientRegistration,
+    client: ClientRegistration,
     config: &OpConfig,
-    codes: &dyn AuthorizationCodeStore,
-    refresh_tokens: &dyn RefreshTokenStore,
+    op_store: &dyn OpStore,
     tokens: &TokenManager,
 ) -> Result<TokenResponse, TokenErrorResponse> {
-    let req_code = req.code.as_deref().unwrap_or("");
+    let code_str = req.code.as_ref().unwrap();
     let req_redirect_uri = req.redirect_uri.as_deref().unwrap_or("");
 
     // 3. Consume the code atomically
-    let auth_code = match codes.consume_code(req_code).await {
+    let auth_code = match op_store.consume_code(code_str).await {
         Ok(Some(c)) => c,
         Ok(None) => {
             tracing::warn!("Invalid or expired authorization code");
@@ -520,14 +511,14 @@ async fn handle_authorization_code(
     let mut issued_refresh_token = None;
     if auth_code.scope.contains("offline_access") {
         let refresh_val = uuid::Uuid::new_v4().to_string();
-        let rt = RefreshToken {
+        let rt_model = RefreshToken {
             token: refresh_val.clone(),
             client_id: client_id.clone(),
             identity: auth_code.identity.clone(),
             scope: auth_code.scope.clone(),
             expires_at: Utc::now() + chrono::Duration::days(30),
         };
-        if let Err(e) = refresh_tokens.store_token(rt).await {
+        if let Err(e) = op_store.store_token(rt_model.clone()).await {
             tracing::error!(error = ?e, "Failed to store refresh token");
             // Non-fatal, just don't return a refresh token
         } else {
@@ -553,12 +544,10 @@ async fn handle_authorization_code(
 async fn handle_client_credentials(
     req: TokenRequest,
     client_id: String,
-    client: crate::client::ClientRegistration,
+    client: ClientRegistration,
     config: &OpConfig,
     tokens: &TokenManager,
 ) -> Result<TokenResponse, TokenErrorResponse> {
-    use crate::client::GrantType;
-
     if !client.allows_grant_type(GrantType::ClientCredentials) {
         tracing::warn!(client_id = %client_id, "Client not authorized for client_credentials grant");
         return Err(TokenErrorResponse {
@@ -619,13 +608,11 @@ async fn handle_client_credentials(
 async fn handle_refresh_token(
     req: TokenRequest,
     client_id: String,
-    client: crate::client::ClientRegistration,
+    client: ClientRegistration,
     config: &OpConfig,
-    refresh_tokens: &dyn RefreshTokenStore,
+    op_store: &dyn OpStore,
     tokens: &TokenManager,
 ) -> Result<TokenResponse, TokenErrorResponse> {
-    use crate::client::GrantType;
-
     if !client.allows_grant_type(GrantType::RefreshToken) {
         tracing::warn!(client_id = %client_id, "Client not authorized for refresh_token grant");
         return Err(TokenErrorResponse {
@@ -635,7 +622,7 @@ async fn handle_refresh_token(
         });
     }
 
-    let req_refresh_token = match req.refresh_token.as_deref() {
+    let refresh_token_str = match req.refresh_token.as_deref() {
         Some(t) => t,
         None => {
             tracing::warn!("Missing refresh_token in request");
@@ -646,7 +633,7 @@ async fn handle_refresh_token(
         }
     };
 
-    let rt = match refresh_tokens.consume_token(req_refresh_token).await {
+    let old_rt = match op_store.consume_token(refresh_token_str).await {
         Ok(Some(rt)) => rt,
         Ok(None) => {
             tracing::warn!("Invalid refresh token (possibly replayed)");
@@ -664,7 +651,7 @@ async fn handle_refresh_token(
         }
     };
 
-    if rt.client_id != client_id {
+    if old_rt.client_id != client_id {
         tracing::warn!("Refresh token issued to a different client");
         return Err(TokenErrorResponse {
             error: "invalid_grant".to_string(),
@@ -672,7 +659,7 @@ async fn handle_refresh_token(
         });
     }
 
-    if chrono::Utc::now() > rt.expires_at {
+    if chrono::Utc::now() > old_rt.expires_at {
         tracing::warn!("Refresh token expired");
         return Err(TokenErrorResponse {
             error: "invalid_grant".to_string(),
@@ -684,24 +671,24 @@ async fn handle_refresh_token(
     let new_rt = RefreshToken {
         token: new_refresh_val.clone(),
         client_id: client_id.clone(),
-        identity: rt.identity.clone(),
-        scope: rt.scope.clone(),
+        identity: old_rt.identity.clone(),
+        scope: old_rt.scope.clone(),
         expires_at: chrono::Utc::now() + chrono::Duration::days(30),
     };
 
-    if let Err(e) = refresh_tokens.store_token(new_rt).await {
+    if let Err(e) = op_store.store_token(new_rt).await {
         tracing::error!(error = ?e, "Failed to store new refresh token");
     }
 
     let expires_in = config.access_token_ttl_secs;
-    let scope_opt = if rt.scope.is_empty() {
+    let scope_opt = if old_rt.scope.is_empty() {
         None
     } else {
-        Some(rt.scope.clone())
+        Some(old_rt.scope.clone())
     };
 
     let access_token = match tokens.issue_user_token(
-        rt.identity.clone(),
+        old_rt.identity.clone(),
         expires_in,
         scope_opt.clone(),
         Some(client_id.clone()),
@@ -920,8 +907,9 @@ async fn handle_token_exchange(
 mod tests {
     use super::*;
     use crate::client::{ClientRegistration, GrantType};
-    use crate::code::AuthorizationCode;
-    use crate::refresh::RefreshToken;
+    use crate::code::{AuthorizationCode, AuthorizationCodeStore};
+    use crate::refresh::{RefreshToken, RefreshTokenStore};
+    use crate::device::DeviceCodeStore;
     use authkestra_engine::auth::state::Identity;
     use authkestra_engine::store::KvStore;
     use authkestra_engine::token::TokenManager;
@@ -1019,12 +1007,14 @@ mod tests {
             req,
             None,
             &test_config(false),
-            &clients,
-            &codes,
-            &refresh,
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                codes.clone(),
+                refresh.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &test_tokens(),
+            ),
+            &test_tokens()
         )
         .await;
         assert_eq!(res.unwrap_err().error, "unsupported_grant_type");
@@ -1096,12 +1086,14 @@ mod tests {
             req,
             None,
             &test_config(false),
-            &clients,
-            &codes,
-            &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                codes.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &test_tokens(),
+            ),
+            &test_tokens()
         )
         .await;
         assert!(res.is_ok());
@@ -1167,12 +1159,14 @@ mod tests {
             req,
             None,
             &test_config(false),
-            &clients,
-            &codes,
-            &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                codes.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &test_tokens(),
+            ),
+            &test_tokens()
         )
         .await;
         assert_eq!(res.unwrap_err().error, "invalid_grant");
@@ -1238,12 +1232,14 @@ mod tests {
             req,
             None,
             &test_config(false),
-            &clients,
-            &codes,
-            &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                codes.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &test_tokens(),
+            ),
+            &test_tokens()
         )
         .await;
         assert_eq!(res.unwrap_err().error, "invalid_grant");
@@ -1309,12 +1305,14 @@ mod tests {
             req,
             None,
             &test_config(false),
-            &clients,
-            &codes,
-            &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                codes.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &test_tokens(),
+            ),
+            &test_tokens()
         )
         .await;
         assert_eq!(res.unwrap_err().error, "server_error");
@@ -1362,12 +1360,14 @@ mod tests {
             req,
             None,
             &test_config(false),
-            &clients,
-            &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &test_tokens(),
+            ),
+            &test_tokens()
         )
         .await;
         assert!(res.is_ok());
@@ -1428,12 +1428,14 @@ mod tests {
             req,
             None,
             &test_config(false),
-            &clients,
-            &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-            &refresh,
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                refresh.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &test_tokens(),
+            ),
+            &test_tokens()
         )
         .await;
         assert!(res.is_ok());
@@ -1493,12 +1495,14 @@ mod tests {
             req,
             None,
             &test_config(true),
-            &clients,
-            &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &tokens,
+            ),
+            &tokens
         )
         .await;
         assert_eq!(res.unwrap_err().error, "invalid_grant");
@@ -1536,12 +1540,14 @@ mod tests {
             req,
             None,
             &test_config(true),
-            &clients,
-            &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &tokens,
+            ),
+            &tokens
         )
         .await;
         let res = res.unwrap();
@@ -1580,12 +1586,14 @@ mod tests {
             req,
             None,
             &test_config(true),
-            &clients,
-            &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &tokens,
+            ),
+            &tokens
         )
         .await;
         assert_eq!(res.unwrap_err().error, "invalid_scope");
@@ -1621,12 +1629,14 @@ mod tests {
             req,
             None,
             &test_config(false),
-            &clients,
-            &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &tokens,
+            ),
+            &tokens
         )
         .await;
         assert_eq!(res.unwrap_err().error, "unsupported_grant_type");
@@ -1663,12 +1673,14 @@ mod tests {
             req,
             None,
             &test_config(true),
-            &clients,
-            &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &tokens,
+            ),
+            &tokens
         )
         .await;
         assert_eq!(res.unwrap_err().error, "invalid_request");
@@ -1705,12 +1717,14 @@ mod tests {
             req,
             None,
             &test_config(true),
-            &clients,
-            &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &tokens,
+            ),
+            &tokens
         )
         .await;
         assert_eq!(res.unwrap_err().error, "invalid_request");
@@ -1747,12 +1761,14 @@ mod tests {
             req,
             None,
             &test_config(true),
-            &clients,
-            &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &tokens,
+            ),
+            &tokens
         )
         .await;
         assert_eq!(res.unwrap_err().error, "invalid_request");
@@ -1789,12 +1805,14 @@ mod tests {
             req,
             None,
             &test_config(true),
-            &clients,
-            &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &tokens,
+            ),
+            &tokens
         )
         .await;
         assert!(res.is_ok());
@@ -1835,12 +1853,14 @@ mod tests {
             req,
             None,
             &test_config(true),
-            &clients,
-            &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &tokens,
+            ),
+            &tokens
         )
         .await;
         assert_eq!(res.unwrap_err().error, "invalid_target");
@@ -1877,12 +1897,14 @@ mod tests {
             req,
             None,
             &test_config(true),
-            &clients,
-            &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &tokens,
+            ),
+            &tokens
         )
         .await;
         assert!(res.is_ok());
@@ -1928,12 +1950,14 @@ mod tests {
             req,
             None,
             &test_config(true),
-            &clients,
-            &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-            &authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
             ),
-            &tokens,
+            ),
+            &tokens
         )
         .await;
         assert_eq!(res.unwrap_err().error, "invalid_grant");

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -892,7 +892,7 @@ mod tests {
     use super::*;
     use crate::client::{ClientRegistration, GrantType};
     use crate::code::{AuthorizationCode, AuthorizationCodeStore};
-    use crate::device::DeviceCodeStore;
+
     use crate::refresh::{RefreshToken, RefreshTokenStore};
     use authkestra_engine::auth::state::Identity;
     use authkestra_engine::store::KvStore;

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -1,7 +1,7 @@
 use crate::client::{ClientRegistration, GrantType};
 use crate::config::OpConfig;
+use crate::refresh::RefreshToken;
 use crate::store::OpStore;
-use crate::refresh::{RefreshToken, RefreshTokenStore};
 use authkestra_engine::token::TokenManager;
 use base64::Engine;
 use chrono::Utc;
@@ -150,15 +150,7 @@ pub async fn handle_token(
 
     match req.grant_type.as_str() {
         "authorization_code" => {
-            handle_authorization_code(
-                req,
-                client_id,
-                client,
-                config,
-                op_store,
-                tokens,
-            )
-            .await
+            handle_authorization_code(req, client_id, client, config, op_store, tokens).await
         }
         "client_credentials" => {
             handle_client_credentials(req, client_id, client, config, tokens).await
@@ -167,15 +159,7 @@ pub async fn handle_token(
             handle_refresh_token(req, client_id, client, config, op_store, tokens).await
         }
         "urn:ietf:params:oauth:grant-type:device_code" => {
-            handle_device_code(
-                req,
-                client_id,
-                client,
-                config,
-                op_store,
-                tokens,
-            )
-            .await
+            handle_device_code(req, client_id, client, config, op_store, tokens).await
         }
         "urn:ietf:params:oauth:grant-type:token-exchange" => {
             handle_token_exchange(req, client_id, client, config, tokens).await
@@ -908,8 +892,8 @@ mod tests {
     use super::*;
     use crate::client::{ClientRegistration, GrantType};
     use crate::code::{AuthorizationCode, AuthorizationCodeStore};
-    use crate::refresh::{RefreshToken, RefreshTokenStore};
     use crate::device::DeviceCodeStore;
+    use crate::refresh::{RefreshToken, RefreshTokenStore};
     use authkestra_engine::auth::state::Identity;
     use authkestra_engine::store::KvStore;
     use authkestra_engine::token::TokenManager;

--- a/crates/authkestra-op/src/handlers/token/device_tests.rs
+++ b/crates/authkestra-op/src/handlers/token/device_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::client::{ClientRegistration, GrantType};
 use authkestra_engine::store::KvStore;
 
-use crate::device::{DeviceCodeSession, DeviceCodeStatus};
+use crate::device::{DeviceCodeSession, DeviceCodeStatus, DeviceCodeStore};
 use crate::handlers::token::tests::{test_config, test_tokens};
 
 use authkestra_engine::auth::state::Identity;
@@ -91,10 +91,12 @@ async fn test_device_denied() {
         req,
         None,
         &test_config(false),
-        &clients,
-        &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-        &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-        &devices,
+        &crate::store::CompositeOpStore::new(
+            clients.clone(),
+            authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+            authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+            devices.clone(),
+        ),
         &test_tokens(),
     )
     .await;
@@ -117,10 +119,12 @@ async fn test_device_wrong_client() {
         req,
         None,
         &test_config(false),
-        &clients,
-        &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-        &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-        &devices,
+        &crate::store::CompositeOpStore::new(
+            clients.clone(),
+            authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+            authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+            devices.clone(),
+        ),
         &test_tokens(),
     )
     .await;
@@ -169,10 +173,12 @@ async fn test_device_expired() {
         req,
         None,
         &test_config(false),
-        &clients,
-        &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-        &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-        &devices,
+        &crate::store::CompositeOpStore::new(
+            clients.clone(),
+            authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+            authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+            devices.clone(),
+        ),
         &test_tokens(),
     )
     .await;
@@ -195,10 +201,12 @@ async fn test_device_offline_access() {
         req,
         None,
         &test_config(false),
-        &clients,
-        &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-        &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-        &devices,
+        &crate::store::CompositeOpStore::new(
+            clients.clone(),
+            authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+            authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+            devices.clone(),
+        ),
         &test_tokens(),
     )
     .await;
@@ -261,10 +269,12 @@ async fn test_device_concurrency() {
                 req,
                 None,
                 &config,
-                &*clients,
-                &authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
-                &authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
-                &*devices,
+                &crate::store::CompositeOpStore::new(
+                    (*clients).clone(),
+                    authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                    authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                    (*devices).clone(),
+                ),
                 &tokens,
             )
             .await

--- a/crates/authkestra-op/src/lib.rs
+++ b/crates/authkestra-op/src/lib.rs
@@ -36,6 +36,10 @@ pub mod handlers;
 /// Refresh tokens and rotation logic.
 pub mod refresh;
 
+/// Unified OpStore trait.
+pub mod store;
+pub use store::OpStore;
+
 /// Provider-level configuration (issuer URL, supported scopes/response
 /// types).
 pub mod config;

--- a/crates/authkestra-op/src/store.rs
+++ b/crates/authkestra-op/src/store.rs
@@ -1,0 +1,144 @@
+use crate::client::ClientStore;
+use crate::code::AuthorizationCodeStore;
+use crate::device::DeviceCodeStore;
+use crate::refresh::RefreshTokenStore;
+
+/// A unified store for all OpenID Provider state.
+/// This supertrait aggregates `ClientStore`, `AuthorizationCodeStore`,
+/// `RefreshTokenStore`, and `DeviceCodeStore`.
+pub trait OpStore:
+    ClientStore + AuthorizationCodeStore + RefreshTokenStore + DeviceCodeStore + Send + Sync
+{
+}
+
+// Automatically implement `OpStore` for any type that implements the granular traits.
+impl<T> OpStore for T where
+    T: ClientStore + AuthorizationCodeStore + RefreshTokenStore + DeviceCodeStore + Send + Sync
+{
+}
+
+/// A helper struct that implements `OpStore` by delegating to 4 individual stores.
+/// Useful if you want to use different backends for different types of data (e.g., config for clients, Redis for codes).
+pub struct CompositeOpStore<C, A, R, D> {
+    clients: C,
+    codes: A,
+    refresh: R,
+    devices: D,
+}
+
+impl<C, A, R, D> CompositeOpStore<C, A, R, D> {
+    /// Create a new `CompositeOpStore` from individual stores.
+    pub fn new(clients: C, codes: A, refresh: R, devices: D) -> Self {
+        Self {
+            clients,
+            codes,
+            refresh,
+            devices,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<C: ClientStore, A: Send + Sync, R: Send + Sync, D: Send + Sync> ClientStore
+    for CompositeOpStore<C, A, R, D>
+{
+    async fn find_client(
+        &self,
+        client_id: &str,
+    ) -> Result<Option<crate::client::ClientRegistration>, crate::error::OpError> {
+        self.clients.find_client(client_id).await
+    }
+}
+
+#[async_trait::async_trait]
+impl<C: Send + Sync, A: AuthorizationCodeStore, R: Send + Sync, D: Send + Sync>
+    AuthorizationCodeStore for CompositeOpStore<C, A, R, D>
+{
+    async fn store_code(
+        &self,
+        code: crate::code::AuthorizationCode,
+    ) -> Result<(), crate::error::OpError> {
+        self.codes.store_code(code).await
+    }
+
+    async fn consume_code(
+        &self,
+        code: &str,
+    ) -> Result<Option<crate::code::AuthorizationCode>, crate::error::OpError> {
+        self.codes.consume_code(code).await
+    }
+}
+
+#[async_trait::async_trait]
+impl<C: Send + Sync, A: Send + Sync, R: RefreshTokenStore, D: Send + Sync> RefreshTokenStore
+    for CompositeOpStore<C, A, R, D>
+{
+    async fn store_token(
+        &self,
+        token: crate::refresh::RefreshToken,
+    ) -> Result<(), crate::error::OpError> {
+        self.refresh.store_token(token).await
+    }
+
+    async fn consume_token(
+        &self,
+        token: &str,
+    ) -> Result<Option<crate::refresh::RefreshToken>, crate::error::OpError> {
+        self.refresh.consume_token(token).await
+    }
+
+    async fn get_token(
+        &self,
+        token: &str,
+    ) -> Result<Option<crate::refresh::RefreshToken>, crate::error::OpError> {
+        self.refresh.get_token(token).await
+    }
+
+    async fn revoke_token(&self, token: &str) -> Result<(), crate::error::OpError> {
+        self.refresh.revoke_token(token).await
+    }
+}
+
+#[async_trait::async_trait]
+impl<C: Send + Sync, A: Send + Sync, R: Send + Sync, D: DeviceCodeStore> DeviceCodeStore
+    for CompositeOpStore<C, A, R, D>
+{
+    async fn store_device_code(
+        &self,
+        session: crate::device::DeviceCodeSession,
+    ) -> Result<(), crate::error::OpError> {
+        self.devices.store_device_code(session).await
+    }
+
+    async fn get_device_code(
+        &self,
+        device_code: &str,
+    ) -> Result<Option<crate::device::DeviceCodeSession>, crate::error::OpError> {
+        self.devices.get_device_code(device_code).await
+    }
+
+    async fn get_by_user_code(
+        &self,
+        user_code: &str,
+    ) -> Result<Option<crate::device::DeviceCodeSession>, crate::error::OpError> {
+        self.devices.get_by_user_code(user_code).await
+    }
+
+    async fn update_device_code(
+        &self,
+        session: crate::device::DeviceCodeSession,
+    ) -> Result<(), crate::error::OpError> {
+        self.devices.update_device_code(session).await
+    }
+
+    async fn delete_device_code(&self, device_code: &str) -> Result<(), crate::error::OpError> {
+        self.devices.delete_device_code(device_code).await
+    }
+
+    async fn consume_device_code(
+        &self,
+        device_code: &str,
+    ) -> Result<Option<crate::device::DeviceCodeSession>, crate::error::OpError> {
+        self.devices.consume_device_code(device_code).await
+    }
+}

--- a/crates/authkestra/examples/actix_op_server.rs
+++ b/crates/authkestra/examples/actix_op_server.rs
@@ -6,10 +6,7 @@ use authkestra_engine::store::KvStore;
 use actix_web::{App, HttpServer};
 use authkestra_actix::AuthEngineActixOpExt;
 use authkestra_engine::TokenManager;
-use authkestra_op::{
-    client::ClientRegistration,
-    config::OpConfig,
-};
+use authkestra_op::{client::ClientRegistration, config::OpConfig};
 use std::sync::Arc;
 
 struct AppState;
@@ -67,8 +64,6 @@ async fn main() -> std::io::Result<()> {
         cookie_name: "authkestra_sid".to_string(),
         ..Default::default()
     };
-
-
 
     println!("🚀 Actix OP Server running on http://localhost:8080");
     HttpServer::new(move || {

--- a/crates/authkestra/examples/actix_op_server.rs
+++ b/crates/authkestra/examples/actix_op_server.rs
@@ -7,10 +7,8 @@ use actix_web::{App, HttpServer};
 use authkestra_actix::AuthEngineActixOpExt;
 use authkestra_engine::TokenManager;
 use authkestra_op::{
-    client::{ClientRegistration, ClientStore},
-    code::AuthorizationCodeStore,
+    client::ClientRegistration,
     config::OpConfig,
-    refresh::RefreshTokenStore,
 };
 use std::sync::Arc;
 
@@ -40,16 +38,12 @@ async fn main() -> std::io::Result<()> {
         )
         .await
         .unwrap();
-    let clients: Arc<dyn ClientStore> = Arc::new(clients);
-
-    let codes: Arc<dyn AuthorizationCodeStore> =
-        Arc::new(authkestra_engine::store::memory::MemoryStore::<
-            authkestra_op::code::AuthorizationCode,
-        >::new());
-    let refresh_tokens: Arc<dyn RefreshTokenStore> =
-        Arc::new(authkestra_engine::store::memory::MemoryStore::<
-            authkestra_op::refresh::RefreshToken,
-        >::new());
+    let op_store: Arc<dyn authkestra_op::OpStore> = Arc::new(authkestra_op::store::CompositeOpStore::new(
+        clients,
+        authkestra_engine::store::memory::MemoryStore::<authkestra_op::code::AuthorizationCode>::new(),
+        authkestra_engine::store::memory::MemoryStore::<authkestra_op::refresh::RefreshToken>::new(),
+        authkestra_engine::store::memory::MemoryStore::<authkestra_op::device::DeviceCodeSession>::new(),
+    ));
 
     let config = OpConfig {
         issuer: "http://localhost:8080".to_string(),
@@ -74,22 +68,16 @@ async fn main() -> std::io::Result<()> {
         ..Default::default()
     };
 
-    let device_code_store: Arc<dyn authkestra_op::device::DeviceCodeStore> =
-        Arc::new(authkestra_engine::store::memory::MemoryStore::<
-            authkestra_op::device::DeviceCodeSession,
-        >::new());
+
 
     println!("🚀 Actix OP Server running on http://localhost:8080");
     HttpServer::new(move || {
         App::new()
             .app_data(actix_web::web::Data::new(token_manager.clone()))
-            .app_data(actix_web::web::Data::new(clients.clone()))
-            .app_data(actix_web::web::Data::new(codes.clone()))
-            .app_data(actix_web::web::Data::new(refresh_tokens.clone()))
+            .app_data(actix_web::web::Data::new(op_store.clone()))
             .app_data(actix_web::web::Data::new(config.clone()))
             .app_data(actix_web::web::Data::new(session_store.clone()))
             .app_data(actix_web::web::Data::new(session_config.clone()))
-            .app_data(actix_web::web::Data::new(device_code_store.clone()))
             .service(AppState.op_actix_scope())
     })
     .bind("0.0.0.0:8080")?

--- a/crates/authkestra/examples/axum_op_server.rs
+++ b/crates/authkestra/examples/axum_op_server.rs
@@ -5,10 +5,7 @@ use authkestra_engine::store::KvStore;
 
 use authkestra_axum::AuthEngineAxumOpExt;
 use authkestra_engine::{AuthEngine, Configured, TokenManager};
-use authkestra_op::{
-    client::ClientRegistration,
-    config::OpConfig,
-};
+use authkestra_op::{client::ClientRegistration, config::OpConfig};
 use axum::Router;
 use std::sync::Arc;
 

--- a/crates/authkestra/examples/axum_op_server.rs
+++ b/crates/authkestra/examples/axum_op_server.rs
@@ -6,10 +6,8 @@ use authkestra_engine::store::KvStore;
 use authkestra_axum::AuthEngineAxumOpExt;
 use authkestra_engine::{AuthEngine, Configured, TokenManager};
 use authkestra_op::{
-    client::{ClientRegistration, ClientStore},
-    code::AuthorizationCodeStore,
+    client::ClientRegistration,
     config::OpConfig,
-    refresh::RefreshTokenStore,
 };
 use axum::Router;
 use std::sync::Arc;
@@ -25,19 +23,10 @@ struct AppState {
     >,
 
     #[authkestra(store)]
-    clients: Arc<dyn ClientStore>,
-
-    #[authkestra(store)]
-    codes: Arc<dyn AuthorizationCodeStore>,
+    op_store: Arc<dyn authkestra_op::OpStore>,
 
     #[authkestra(store)]
     config: OpConfig,
-
-    #[authkestra(store)]
-    refresh_tokens: Arc<dyn RefreshTokenStore>,
-
-    #[authkestra(store)]
-    pub device_code_store: Arc<dyn authkestra_op::device::DeviceCodeStore>,
 }
 
 #[tokio::main]
@@ -64,20 +53,12 @@ async fn main() {
         )
         .await
         .unwrap();
-    let clients: Arc<dyn ClientStore> = Arc::new(clients);
-
-    let codes: Arc<dyn AuthorizationCodeStore> =
-        Arc::new(authkestra_engine::store::memory::MemoryStore::<
-            authkestra_op::code::AuthorizationCode,
-        >::new());
-    let refresh_tokens: Arc<dyn RefreshTokenStore> =
-        Arc::new(authkestra_engine::store::memory::MemoryStore::<
-            authkestra_op::refresh::RefreshToken,
-        >::new());
-    let device_code_store: Arc<dyn authkestra_op::device::DeviceCodeStore> =
-        Arc::new(authkestra_engine::store::memory::MemoryStore::<
-            authkestra_op::device::DeviceCodeSession,
-        >::new());
+    let op_store: Arc<dyn authkestra_op::OpStore> = Arc::new(authkestra_op::store::CompositeOpStore::new(
+        clients,
+        authkestra_engine::store::memory::MemoryStore::<authkestra_op::code::AuthorizationCode>::new(),
+        authkestra_engine::store::memory::MemoryStore::<authkestra_op::refresh::RefreshToken>::new(),
+        authkestra_engine::store::memory::MemoryStore::<authkestra_op::device::DeviceCodeSession>::new(),
+    ));
 
     let session_store: Arc<dyn authkestra_engine::auth::SessionStore> =
         Arc::new(authkestra_engine::store::memory::MemoryStore::new());
@@ -94,10 +75,7 @@ async fn main() {
 
     let state = AppState {
         authkestra,
-        clients,
-        codes,
-        refresh_tokens,
-        device_code_store,
+        op_store,
         config: OpConfig {
             issuer: "http://localhost:3000".to_string(),
             scopes_supported: vec![


### PR DESCRIPTION
This PR completes the migration to a unified `OpStore` trait for the `authkestra-op` handlers. It replaces disparate store dependencies (`ClientStore`, `AuthorizationCodeStore`, `RefreshTokenStore`, `DeviceCodeStore`) with a single `OpStore` argument in handlers like `handle_token`, `handle_authorize`, and `handle_device_authorization`. All tests and example server integrations have been updated to use `CompositeOpStore`.