### PR TITLE
refactor: apply Ak naming convention globally and cleanup legacy macros

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Authkestra Agent Rules
 
 - **Typestate Builder Pattern**: Use `Authkestra::builder()` which enforces compile-time availability of methods (e.g., `create_session` only exists if `session_store` is provided).
-- **RFC-001 Migration**: The project is migrating to a unified `authkestra-engine`. Do not add logic to `authkestra-core` or `authkestra-flow`; target `AuthEngine` and plugin interfaces (`AuthMethod`, `Flow`).
+- **RFC-001 Migration**: The project is migrating to a unified `authkestra-engine`. Do not add logic to `authkestra-core` or `authkestra-flow`; target `Engine` and plugin interfaces (`AuthMethod`, `Flow`).
 - **Trait Objects vs Generics**: Prefer `Box<dyn Trait>` (e.g., `Box<dyn AuthMethod>`) over generics for I/O bound paths to optimize compilation time and DX.
 - **Framework Agnostic**: The core must remain framework-independent. Axum/Actix integrations live in separate adapter crates (`authkestra-axum`, `authkestra-actix`) and use extractors (`AuthSession(session)`).
 - **Stateless OAuth**: Store OAuth `state` and `nonce` in encrypted cookies, never in the database.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authkestra"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "actix-files",
  "actix-web",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-actix"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "actix-utils",
  "actix-web",
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-axum"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "authkestra-engine",
  "authkestra-macros",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-engine"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-oidc"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "authkestra-engine",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-op"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-providers"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "authkestra-engine",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-resource"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "authkestra-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,16 +21,16 @@ keywords = ["auth", "authentication", "oauth2", "oidc"]
 categories = ["authentication"]
 
 [workspace.dependencies]
-authkestra-engine = { version = "0.1.2", path = "crates/authkestra-engine" }
-authkestra-providers = { version = "0.1.1", path = "crates/authkestra-providers" }
-authkestra-axum = { version = "0.1.3", path = "crates/authkestra-axum" }
-authkestra-macros = { version = "0.1.0", path = "crates/authkestra-macros" }
-authkestra-oidc = { version = "0.1.2", path = "crates/authkestra-oidc" }
-authkestra-actix = { version = "0.1.3", path = "crates/authkestra-actix" }
-authkestra-resource = { version = "0.1.0", path = "crates/authkestra-resource" }
-authkestra = { version = "0.1.2", path = "crates/authkestra" }
+authkestra-engine = { version = "0.2.0", path = "crates/authkestra-engine" }
+authkestra-providers = { version = "0.2.0", path = "crates/authkestra-providers" }
+authkestra-axum = { version = "0.2.0", path = "crates/authkestra-axum" }
+authkestra-macros = { version = "0.2.0", path = "crates/authkestra-macros" }
+authkestra-oidc = { version = "0.2.0", path = "crates/authkestra-oidc" }
+authkestra-actix = { version = "0.2.0", path = "crates/authkestra-actix" }
+authkestra-resource = { version = "0.2.0", path = "crates/authkestra-resource" }
+authkestra = { version = "0.2.0", path = "crates/authkestra" }
 
-authkestra-op = { version = "0.1.0", path = "crates/authkestra-op" }
+authkestra-op = { version = "0.2.0", path = "crates/authkestra-op" }
 rand = "0.9.2"
 url = "2.5"
 sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For advanced users, individual crates are still available and can be used indepe
 | Crate                                                                    | Responsibility                                                            |
 | :----------------------------------------------------------------------- | :------------------------------------------------------------------------ |
 | [`authkestra`](crates/authkestra/README.md)                                     | **Primary Facade**: Re-exports all other crates behind features.          |
-| [`authkestra-engine`](crates/authkestra-engine/README.md)                       | Foundational types, traits and the **AuthEngine** orchestrator.           |
+| [`authkestra-engine`](crates/authkestra-engine/README.md)                       | Foundational types, traits and the **Engine** orchestrator.           |
 | [`authkestra-resource`](crates/authkestra-resource/README.md)                   | Resource server enforcement and validation (JWT, etc).                    |
 | [`authkestra-session`](crates/authkestra-session/README.md)                     | Session persistence layer abstraction.                                    |
 | [`authkestra-providers`](crates/authkestra-providers/README.md)                 | Concrete implementation for OAuth providers (GitHub, Google, Discord).    |
@@ -43,18 +43,18 @@ For advanced users, individual crates are still available and can be used indepe
 
 ## 🛠️ Usage
 
-Authkestra utilizes a powerful **Typestate Builder Pattern** (`AuthEngine::builder()`). This enforces at compile-time that certain methods are only available if their prerequisites are met (e.g., you can only call session methods if a `SessionStore` was provided).
+Authkestra utilizes a powerful **Typestate Builder Pattern** (`Engine::builder()`). This enforces at compile-time that certain methods are only available if their prerequisites are met (e.g., you can only call session methods if a `SessionStore` was provided).
 
 ### Quick Start Example
 
 ```rust
-use authkestra::flow::{AuthEngine, OAuth2Flow};
+use authkestra::flow::{Engine, OAuth2Flow};
 use authkestra_providers::github::GithubProvider;
 
 // The builder ensures compile-time safety for your authentication stack
 let github_provider = GithubProvider::new(client_id, client_secret, redirect_uri);
 
-let auth_engine = AuthEngine::builder()
+let auth_engine = Engine::builder()
     .provider(OAuth2Flow::new(github_provider))
     .session_store(session_store)
     .build();
@@ -75,7 +75,7 @@ To see complete, runnable examples for various frameworks and flows, check out t
 
 Our architecture enforces strict design principles to guarantee compile-time safety and optimal Developer Experience (DX):
 
-- **Typestate Builder Pattern**: The `AuthEngine::builder()` uses Rust's typestate pattern. This makes misconfigurations a compile-time error rather than a runtime surprise.
+- **Typestate Builder Pattern**: The `Engine::builder()` uses Rust's typestate pattern. This makes misconfigurations a compile-time error rather than a runtime surprise.
 - **Trait Objects over Generics**: For I/O bound paths, we prefer `Box<dyn Trait>` (e.g., `Box<dyn AuthMethod>`) over heavy monomorphized generics. This drastically optimizes compilation times without sacrificing meaningful runtime performance.
 - **Framework Agnostic Core**: The `authkestra-engine` is pure Rust logic. Axum and Actix integrations are entirely isolated in separate adapter crates, utilizing explicit Extractors like `AuthSession(session)`.
 - **Plugin Interfaces**: We extend functionality via strict plugin interfaces (`AuthMethod`, `Flow`) rather than opaque, ordering-dependent middleware.

--- a/crates/authkestra-actix/Cargo.toml
+++ b/crates/authkestra-actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-actix"
-version = "0.1.3"
+version = "0.2.0"
 edition.workspace = true
 description = "Actix-web integration for the authkestra authentication framework"
 repository.workspace = true

--- a/crates/authkestra-actix/src/helpers.rs
+++ b/crates/authkestra-actix/src/helpers.rs
@@ -7,7 +7,7 @@ use authkestra_engine::pkce::Pkce;
 #[cfg(all(feature = "flow", not(feature = "session")))]
 use authkestra_engine::SessionConfig;
 #[cfg(feature = "flow")]
-use authkestra_engine::{state::OAuth2State, AuthEngine, ErasedOAuthFlow, OAuth2Flow};
+use authkestra_engine::{state::OAuth2State, AkBase, ErasedOAuthFlow, OAuth2Flow};
 #[allow(unused_imports)]
 use std::sync::Arc;
 
@@ -190,7 +190,7 @@ pub async fn handle_oauth_callback_erased(
 #[cfg(feature = "flow")]
 pub async fn actix_login_handler<S, T>(
     path: web::Path<String>,
-    authkestra: web::Data<AuthEngine<S, T>>,
+    authkestra: web::Data<AkBase<S, T>>,
     params: web::Query<OAuthLoginParams>,
 ) -> impl actix_web::Responder {
     let provider = path.into_inner();
@@ -219,7 +219,7 @@ pub async fn actix_login_handler<S, T>(
 pub async fn actix_callback_handler<S, T>(
     req: HttpRequest,
     path: web::Path<String>,
-    authkestra: web::Data<AuthEngine<S, T>>,
+    authkestra: web::Data<AkBase<S, T>>,
     params: web::Query<OAuthCallbackParams>,
 ) -> actix_web::Result<impl actix_web::Responder>
 where
@@ -251,7 +251,7 @@ where
 #[cfg(all(feature = "flow", feature = "session"))]
 pub async fn actix_logout_handler<S, T>(
     req: HttpRequest,
-    authkestra: web::Data<AuthEngine<S, T>>,
+    authkestra: web::Data<AkBase<S, T>>,
 ) -> actix_web::Result<impl actix_web::Responder>
 where
     S: authkestra_engine::SessionStoreState,

--- a/crates/authkestra-actix/src/helpers.rs
+++ b/crates/authkestra-actix/src/helpers.rs
@@ -7,7 +7,7 @@ use authkestra_engine::pkce::Pkce;
 #[cfg(all(feature = "flow", not(feature = "session")))]
 use authkestra_engine::SessionConfig;
 #[cfg(feature = "flow")]
-use authkestra_engine::{state::OAuth2State, AuthEngine, ErasedOAuthFlow, OAuth2Flow};
+use authkestra_engine::{state::OAuth2State, Engine, ErasedOAuthFlow, OAuth2Flow};
 #[allow(unused_imports)]
 use std::sync::Arc;
 
@@ -190,7 +190,7 @@ pub async fn handle_oauth_callback_erased(
 #[cfg(feature = "flow")]
 pub async fn actix_login_handler<S, T>(
     path: web::Path<String>,
-    authkestra: web::Data<AuthEngine<S, T>>,
+    authkestra: web::Data<Engine<S, T>>,
     params: web::Query<OAuthLoginParams>,
 ) -> impl actix_web::Responder {
     let provider = path.into_inner();
@@ -219,7 +219,7 @@ pub async fn actix_login_handler<S, T>(
 pub async fn actix_callback_handler<S, T>(
     req: HttpRequest,
     path: web::Path<String>,
-    authkestra: web::Data<AuthEngine<S, T>>,
+    authkestra: web::Data<Engine<S, T>>,
     params: web::Query<OAuthCallbackParams>,
 ) -> actix_web::Result<impl actix_web::Responder>
 where
@@ -251,7 +251,7 @@ where
 #[cfg(all(feature = "flow", feature = "session"))]
 pub async fn actix_logout_handler<S, T>(
     req: HttpRequest,
-    authkestra: web::Data<AuthEngine<S, T>>,
+    authkestra: web::Data<Engine<S, T>>,
 ) -> actix_web::Result<impl actix_web::Responder>
 where
     S: authkestra_engine::SessionStoreState,

--- a/crates/authkestra-actix/src/helpers.rs
+++ b/crates/authkestra-actix/src/helpers.rs
@@ -7,7 +7,7 @@ use authkestra_engine::pkce::Pkce;
 #[cfg(all(feature = "flow", not(feature = "session")))]
 use authkestra_engine::SessionConfig;
 #[cfg(feature = "flow")]
-use authkestra_engine::{state::OAuth2State, AkBase, ErasedOAuthFlow, OAuth2Flow};
+use authkestra_engine::{state::OAuth2State, AuthEngine, ErasedOAuthFlow, OAuth2Flow};
 #[allow(unused_imports)]
 use std::sync::Arc;
 
@@ -190,7 +190,7 @@ pub async fn handle_oauth_callback_erased(
 #[cfg(feature = "flow")]
 pub async fn actix_login_handler<S, T>(
     path: web::Path<String>,
-    authkestra: web::Data<AkBase<S, T>>,
+    authkestra: web::Data<AuthEngine<S, T>>,
     params: web::Query<OAuthLoginParams>,
 ) -> impl actix_web::Responder {
     let provider = path.into_inner();
@@ -219,7 +219,7 @@ pub async fn actix_login_handler<S, T>(
 pub async fn actix_callback_handler<S, T>(
     req: HttpRequest,
     path: web::Path<String>,
-    authkestra: web::Data<AkBase<S, T>>,
+    authkestra: web::Data<AuthEngine<S, T>>,
     params: web::Query<OAuthCallbackParams>,
 ) -> actix_web::Result<impl actix_web::Responder>
 where
@@ -251,7 +251,7 @@ where
 #[cfg(all(feature = "flow", feature = "session"))]
 pub async fn actix_logout_handler<S, T>(
     req: HttpRequest,
-    authkestra: web::Data<AkBase<S, T>>,
+    authkestra: web::Data<AuthEngine<S, T>>,
 ) -> actix_web::Result<impl actix_web::Responder>
 where
     S: authkestra_engine::SessionStoreState,

--- a/crates/authkestra-actix/src/lib.rs
+++ b/crates/authkestra-actix/src/lib.rs
@@ -9,7 +9,7 @@ pub use authkestra_engine::TokenManager;
 #[cfg(all(feature = "flow", feature = "token"))]
 pub use authkestra_engine::TokenManagerState;
 #[cfg(feature = "flow")]
-pub use authkestra_engine::{AkBase, SessionConfig};
+pub use authkestra_engine::{AuthEngine, SessionConfig};
 #[cfg(all(feature = "flow", any(feature = "session", feature = "token")))]
 pub use authkestra_engine::{Configured, Missing};
 #[cfg(any(feature = "session", feature = "token", feature = "resource"))]
@@ -28,16 +28,20 @@ pub use helpers::actix_login_handler;
 pub use helpers::{actix_callback_handler, actix_logout_handler};
 
 #[cfg(feature = "op")]
-pub use op::AkActixOpExt;
+pub use op::AuthEngineActixOpExt;
 
 #[cfg(feature = "flow")]
-pub trait AkActixExt<S, T> {
+pub trait AuthEngineActixExt<S, T> {
     fn actix_scope(&self) -> actix_web::Scope;
 }
 
+// Keep for backwards compatibility if needed
+#[cfg(feature = "flow")]
+pub use AuthEngineActixExt as AuthkestraActixExt;
+
 #[cfg(feature = "flow")]
 #[cfg(all(feature = "flow", feature = "session"))]
-impl<S, T> AkActixExt<S, T> for AkBase<S, T>
+impl<S, T> AuthEngineActixExt<S, T> for AuthEngine<S, T>
 where
     S: Clone + SessionStoreState + 'static,
     T: Clone + 'static,
@@ -73,14 +77,14 @@ impl FromRequest for AuthSession {
             .app_data::<web::Data<Arc<dyn SessionStore>>>()
             .cloned()
             .or_else(|| {
-                req.app_data::<web::Data<AkBase<Configured<Arc<dyn SessionStore>>, Missing>>>()
+                req.app_data::<web::Data<AuthEngine<Configured<Arc<dyn SessionStore>>, Missing>>>()
                     .map(|a| web::Data::new(a.session_store.get_store()))
             })
             .or_else(|| {
                 #[cfg(feature = "token")]
                 {
                     req.app_data::<web::Data<
-                        AkBase<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>,
+                        AuthEngine<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>,
                     >>()
                     .map(|a| web::Data::new(a.session_store.get_store()))
                 }
@@ -95,7 +99,7 @@ impl FromRequest for AuthSession {
             .cloned()
             .or_else(|| {
                 req.app_data::<web::Data<
-                    AkBase<authkestra_engine::Configured<Arc<dyn SessionStore>>, Missing>,
+                    AuthEngine<authkestra_engine::Configured<Arc<dyn SessionStore>>, Missing>,
                 >>()
                 .map(|a| web::Data::new(a.session_config.clone()))
             })
@@ -103,7 +107,7 @@ impl FromRequest for AuthSession {
                 #[cfg(feature = "token")]
                 {
                     req.app_data::<web::Data<
-                        AkBase<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>,
+                        AuthEngine<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>,
                     >>()
                     .map(|a| web::Data::new(a.session_config.clone()))
                 }
@@ -173,14 +177,14 @@ impl FromRequest for AuthToken {
             .app_data::<web::Data<Arc<TokenManager>>>()
             .cloned()
             .or_else(|| {
-                req.app_data::<web::Data<AkBase<Missing, Configured<Arc<TokenManager>>>>>()
+                req.app_data::<web::Data<AuthEngine<Missing, Configured<Arc<TokenManager>>>>>()
                     .map(|a| web::Data::new(a.token_manager.get_manager()))
             })
             .or_else(|| {
                 #[cfg(feature = "session")]
                 {
                     req.app_data::<web::Data<
-                        AkBase<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>,
+                        AuthEngine<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>,
                     >>()
                     .map(|a| web::Data::new(a.token_manager.get_manager()))
                 }

--- a/crates/authkestra-actix/src/lib.rs
+++ b/crates/authkestra-actix/src/lib.rs
@@ -9,7 +9,7 @@ pub use authkestra_engine::TokenManager;
 #[cfg(all(feature = "flow", feature = "token"))]
 pub use authkestra_engine::TokenManagerState;
 #[cfg(feature = "flow")]
-pub use authkestra_engine::{AuthEngine, SessionConfig};
+pub use authkestra_engine::{Engine, SessionConfig};
 #[cfg(all(feature = "flow", any(feature = "session", feature = "token")))]
 pub use authkestra_engine::{Configured, Missing};
 #[cfg(any(feature = "session", feature = "token", feature = "resource"))]
@@ -28,20 +28,18 @@ pub use helpers::actix_login_handler;
 pub use helpers::{actix_callback_handler, actix_logout_handler};
 
 #[cfg(feature = "op")]
-pub use op::AuthEngineActixOpExt;
+pub use op::OpExt;
 
 #[cfg(feature = "flow")]
-pub trait AuthEngineActixExt<S, T> {
+pub trait ActixExt<S, T> {
     fn actix_scope(&self) -> actix_web::Scope;
 }
 
-// Keep for backwards compatibility if needed
-#[cfg(feature = "flow")]
-pub use AuthEngineActixExt as AuthkestraActixExt;
+
 
 #[cfg(feature = "flow")]
 #[cfg(all(feature = "flow", feature = "session"))]
-impl<S, T> AuthEngineActixExt<S, T> for AuthEngine<S, T>
+impl<S, T> ActixExt<S, T> for Engine<S, T>
 where
     S: Clone + SessionStoreState + 'static,
     T: Clone + 'static,
@@ -77,14 +75,14 @@ impl FromRequest for AuthSession {
             .app_data::<web::Data<Arc<dyn SessionStore>>>()
             .cloned()
             .or_else(|| {
-                req.app_data::<web::Data<AuthEngine<Configured<Arc<dyn SessionStore>>, Missing>>>()
+                req.app_data::<web::Data<Engine<Configured<Arc<dyn SessionStore>>, Missing>>>()
                     .map(|a| web::Data::new(a.session_store.get_store()))
             })
             .or_else(|| {
                 #[cfg(feature = "token")]
                 {
                     req.app_data::<web::Data<
-                        AuthEngine<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>,
+                        Engine<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>,
                     >>()
                     .map(|a| web::Data::new(a.session_store.get_store()))
                 }
@@ -99,7 +97,7 @@ impl FromRequest for AuthSession {
             .cloned()
             .or_else(|| {
                 req.app_data::<web::Data<
-                    AuthEngine<authkestra_engine::Configured<Arc<dyn SessionStore>>, Missing>,
+                    Engine<authkestra_engine::Configured<Arc<dyn SessionStore>>, Missing>,
                 >>()
                 .map(|a| web::Data::new(a.session_config.clone()))
             })
@@ -107,7 +105,7 @@ impl FromRequest for AuthSession {
                 #[cfg(feature = "token")]
                 {
                     req.app_data::<web::Data<
-                        AuthEngine<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>,
+                        Engine<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>,
                     >>()
                     .map(|a| web::Data::new(a.session_config.clone()))
                 }
@@ -177,14 +175,14 @@ impl FromRequest for AuthToken {
             .app_data::<web::Data<Arc<TokenManager>>>()
             .cloned()
             .or_else(|| {
-                req.app_data::<web::Data<AuthEngine<Missing, Configured<Arc<TokenManager>>>>>()
+                req.app_data::<web::Data<Engine<Missing, Configured<Arc<TokenManager>>>>>()
                     .map(|a| web::Data::new(a.token_manager.get_manager()))
             })
             .or_else(|| {
                 #[cfg(feature = "session")]
                 {
                     req.app_data::<web::Data<
-                        AuthEngine<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>,
+                        Engine<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>,
                     >>()
                     .map(|a| web::Data::new(a.token_manager.get_manager()))
                 }

--- a/crates/authkestra-actix/src/lib.rs
+++ b/crates/authkestra-actix/src/lib.rs
@@ -27,7 +27,6 @@ pub use helpers::actix_login_handler;
 #[cfg(all(feature = "flow", feature = "session"))]
 pub use helpers::{actix_callback_handler, actix_logout_handler};
 
-
 #[cfg(feature = "op")]
 pub use op::AkActixOpExt;
 
@@ -81,10 +80,7 @@ impl FromRequest for AuthSession {
                 #[cfg(feature = "token")]
                 {
                     req.app_data::<web::Data<
-                        AkBase<
-                            Configured<Arc<dyn SessionStore>>,
-                            Configured<Arc<TokenManager>>,
-                        >,
+                        AkBase<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>,
                     >>()
                     .map(|a| web::Data::new(a.session_store.get_store()))
                 }
@@ -107,10 +103,7 @@ impl FromRequest for AuthSession {
                 #[cfg(feature = "token")]
                 {
                     req.app_data::<web::Data<
-                        AkBase<
-                            Configured<Arc<dyn SessionStore>>,
-                            Configured<Arc<TokenManager>>,
-                        >,
+                        AkBase<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>,
                     >>()
                     .map(|a| web::Data::new(a.session_config.clone()))
                 }
@@ -187,10 +180,7 @@ impl FromRequest for AuthToken {
                 #[cfg(feature = "session")]
                 {
                     req.app_data::<web::Data<
-                        AkBase<
-                            Configured<Arc<dyn SessionStore>>,
-                            Configured<Arc<TokenManager>>,
-                        >,
+                        AkBase<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>,
                     >>()
                     .map(|a| web::Data::new(a.token_manager.get_manager()))
                 }

--- a/crates/authkestra-actix/src/lib.rs
+++ b/crates/authkestra-actix/src/lib.rs
@@ -8,10 +8,10 @@ pub use authkestra_engine::SessionStoreState;
 pub use authkestra_engine::TokenManager;
 #[cfg(all(feature = "flow", feature = "token"))]
 pub use authkestra_engine::TokenManagerState;
-#[cfg(feature = "flow")]
-pub use authkestra_engine::{Engine, SessionConfig};
 #[cfg(all(feature = "flow", any(feature = "session", feature = "token")))]
 pub use authkestra_engine::{Configured, Missing};
+#[cfg(feature = "flow")]
+pub use authkestra_engine::{Engine, SessionConfig};
 #[cfg(any(feature = "session", feature = "token", feature = "resource"))]
 use futures::future::LocalBoxFuture;
 #[cfg(any(feature = "session", feature = "token", feature = "resource"))]
@@ -34,8 +34,6 @@ pub use op::OpExt;
 pub trait ActixExt<S, T> {
     fn actix_scope(&self) -> actix_web::Scope;
 }
-
-
 
 #[cfg(feature = "flow")]
 #[cfg(all(feature = "flow", feature = "session"))]

--- a/crates/authkestra-actix/src/lib.rs
+++ b/crates/authkestra-actix/src/lib.rs
@@ -9,7 +9,7 @@ pub use authkestra_engine::TokenManager;
 #[cfg(all(feature = "flow", feature = "token"))]
 pub use authkestra_engine::TokenManagerState;
 #[cfg(feature = "flow")]
-pub use authkestra_engine::{AuthEngine, SessionConfig};
+pub use authkestra_engine::{AkBase, SessionConfig};
 #[cfg(all(feature = "flow", any(feature = "session", feature = "token")))]
 pub use authkestra_engine::{Configured, Missing};
 #[cfg(any(feature = "session", feature = "token", feature = "resource"))]
@@ -27,20 +27,18 @@ pub use helpers::actix_login_handler;
 #[cfg(all(feature = "flow", feature = "session"))]
 pub use helpers::{actix_callback_handler, actix_logout_handler};
 
-#[cfg(all(feature = "flow", feature = "session"))]
-pub use AuthEngineActixExt as AuthkestraActixExt;
 
 #[cfg(feature = "op")]
-pub use op::AuthEngineActixOpExt;
+pub use op::AkActixOpExt;
 
 #[cfg(feature = "flow")]
-pub trait AuthEngineActixExt<S, T> {
+pub trait AkActixExt<S, T> {
     fn actix_scope(&self) -> actix_web::Scope;
 }
 
 #[cfg(feature = "flow")]
 #[cfg(all(feature = "flow", feature = "session"))]
-impl<S, T> AuthEngineActixExt<S, T> for AuthEngine<S, T>
+impl<S, T> AkActixExt<S, T> for AkBase<S, T>
 where
     S: Clone + SessionStoreState + 'static,
     T: Clone + 'static,
@@ -76,14 +74,14 @@ impl FromRequest for AuthSession {
             .app_data::<web::Data<Arc<dyn SessionStore>>>()
             .cloned()
             .or_else(|| {
-                req.app_data::<web::Data<AuthEngine<Configured<Arc<dyn SessionStore>>, Missing>>>()
+                req.app_data::<web::Data<AkBase<Configured<Arc<dyn SessionStore>>, Missing>>>()
                     .map(|a| web::Data::new(a.session_store.get_store()))
             })
             .or_else(|| {
                 #[cfg(feature = "token")]
                 {
                     req.app_data::<web::Data<
-                        AuthEngine<
+                        AkBase<
                             Configured<Arc<dyn SessionStore>>,
                             Configured<Arc<TokenManager>>,
                         >,
@@ -101,7 +99,7 @@ impl FromRequest for AuthSession {
             .cloned()
             .or_else(|| {
                 req.app_data::<web::Data<
-                    AuthEngine<authkestra_engine::Configured<Arc<dyn SessionStore>>, Missing>,
+                    AkBase<authkestra_engine::Configured<Arc<dyn SessionStore>>, Missing>,
                 >>()
                 .map(|a| web::Data::new(a.session_config.clone()))
             })
@@ -109,7 +107,7 @@ impl FromRequest for AuthSession {
                 #[cfg(feature = "token")]
                 {
                     req.app_data::<web::Data<
-                        AuthEngine<
+                        AkBase<
                             Configured<Arc<dyn SessionStore>>,
                             Configured<Arc<TokenManager>>,
                         >,
@@ -182,14 +180,14 @@ impl FromRequest for AuthToken {
             .app_data::<web::Data<Arc<TokenManager>>>()
             .cloned()
             .or_else(|| {
-                req.app_data::<web::Data<AuthEngine<Missing, Configured<Arc<TokenManager>>>>>()
+                req.app_data::<web::Data<AkBase<Missing, Configured<Arc<TokenManager>>>>>()
                     .map(|a| web::Data::new(a.token_manager.get_manager()))
             })
             .or_else(|| {
                 #[cfg(feature = "session")]
                 {
                     req.app_data::<web::Data<
-                        AuthEngine<
+                        AkBase<
                             Configured<Arc<dyn SessionStore>>,
                             Configured<Arc<TokenManager>>,
                         >,

--- a/crates/authkestra-actix/src/op.rs
+++ b/crates/authkestra-actix/src/op.rs
@@ -203,11 +203,11 @@ pub async fn actix_device_verify_handler(
     }
 }
 
-pub trait AuthEngineActixOpExt {
+pub trait AkActixOpExt {
     fn op_actix_scope(&self) -> actix_web::Scope;
 }
 
-impl<T> AuthEngineActixOpExt for T {
+impl<T> AkActixOpExt for T {
     fn op_actix_scope(&self) -> actix_web::Scope {
         web::scope("")
             .route("/jwks.json", web::get().to(actix_jwks_handler))

--- a/crates/authkestra-actix/src/op.rs
+++ b/crates/authkestra-actix/src/op.rs
@@ -203,11 +203,11 @@ pub async fn actix_device_verify_handler(
     }
 }
 
-pub trait AuthEngineActixOpExt {
+pub trait OpExt {
     fn op_actix_scope(&self) -> actix_web::Scope;
 }
 
-impl<T> AuthEngineActixOpExt for T {
+impl<T> OpExt for T {
     fn op_actix_scope(&self) -> actix_web::Scope {
         web::scope("")
             .route("/jwks.json", web::get().to(actix_jwks_handler))

--- a/crates/authkestra-actix/src/op.rs
+++ b/crates/authkestra-actix/src/op.rs
@@ -203,11 +203,11 @@ pub async fn actix_device_verify_handler(
     }
 }
 
-pub trait AkActixOpExt {
+pub trait AuthEngineActixOpExt {
     fn op_actix_scope(&self) -> actix_web::Scope;
 }
 
-impl<T> AkActixOpExt for T {
+impl<T> AuthEngineActixOpExt for T {
     fn op_actix_scope(&self) -> actix_web::Scope {
         web::scope("")
             .route("/jwks.json", web::get().to(actix_jwks_handler))

--- a/crates/authkestra-axum/Cargo.toml
+++ b/crates/authkestra-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-axum"
-version = "0.1.3"
+version = "0.2.0"
 edition.workspace = true
 description = "Axum integration for the authkestra authentication framework"
 repository.workspace = true

--- a/crates/authkestra-axum/README.md
+++ b/crates/authkestra-axum/README.md
@@ -7,7 +7,7 @@ This crate provides Axum-specific extractors and helpers to easily integrate the
 ## Features
 
 - **Extractors**:
-  - `Auth<I>`: Unified extractor that uses a configured `AuthkestraGuard` to validate the request.
+  - `Auth<I>`: Unified extractor that uses a configured `AkResourceGuard` to validate the request.
   - `AuthSession`: Extracts a validated session from cookies.
   - `AuthToken`: Extracts and validates a JWT from the `Authorization: Bearer` header.
 - **OAuth Helpers**:
@@ -70,7 +70,7 @@ If you prefer not to use the macro or need more control, you can manually implem
 
 ```rust
 use axum::{routing::get, Router, extract::FromRef};
-use authkestra_axum::{AuthSession, SessionConfig, AuthkestraAxumError};
+use authkestra_axum::{AuthSession, SessionConfig, AkAxumError};
 use authkestra_session::SessionStore;
 use tower_cookies::CookieManagerLayer;
 use std::sync::Arc;
@@ -96,12 +96,12 @@ impl FromRef<AppState> for SessionConfig {
 
 ### Example: Unified Authentication (Chained Strategies)
 
-The `Auth<I>` extractor allows you to use a central `AuthkestraGuard` that can try multiple authentication methods in order.
+The `Auth<I>` extractor allows you to use a central `AkResourceGuard` that can try multiple authentication methods in order.
 
 ```rust
 use axum::{routing::get, Router, extract::FromRef};
 use authkestra_axum::Auth;
-use authkestra_resource::{AuthEngineGuard, AuthPolicy};
+use authkestra_resource::{AkResourceGuard, AuthPolicy};
 use authkestra_resource::jwt::JwtStrategy;
 use authkestra_session::SessionStrategy;
 use std::sync::Arc;
@@ -111,17 +111,17 @@ struct User { id: String }
 
 #[derive(Clone)]
 struct AppState {
-    guard: Arc<AuthkestraGuard<User>>,
+    guard: Arc<AkResourceGuard<User>>,
 }
 
-impl FromRef<AppState> for Arc<AuthkestraGuard<User>> {
+impl FromRef<AppState> for Arc<AkResourceGuard<User>> {
     fn from_ref(state: &AppState) -> Self {
         state.guard.clone()
     }
 }
 
 fn app() -> Router {
-    let guard = AuthkestraGuard::builder()
+    let guard = AkResourceGuard::builder()
         .strategy(JwtStrategy::new(jwt_config))
         .strategy(SessionStrategy::new(session_store, "session_cookie"))
         .policy(AuthPolicy::FirstSuccess)

--- a/crates/authkestra-axum/README.md
+++ b/crates/authkestra-axum/README.md
@@ -7,7 +7,7 @@ This crate provides Axum-specific extractors and helpers to easily integrate the
 ## Features
 
 - **Extractors**:
-  - `Auth<I>`: Unified extractor that uses a configured `AkResourceGuard` to validate the request.
+  - `Auth<I>`: Unified extractor that uses a configured `AuthEngineGuard` to validate the request.
   - `AuthSession`: Extracts a validated session from cookies.
   - `AuthToken`: Extracts and validates a JWT from the `Authorization: Bearer` header.
 - **OAuth Helpers**:
@@ -70,7 +70,7 @@ If you prefer not to use the macro or need more control, you can manually implem
 
 ```rust
 use axum::{routing::get, Router, extract::FromRef};
-use authkestra_axum::{AuthSession, SessionConfig, AkAxumError};
+use authkestra_axum::{AuthSession, SessionConfig, AuthEngineAxumError};
 use authkestra_session::SessionStore;
 use tower_cookies::CookieManagerLayer;
 use std::sync::Arc;
@@ -96,12 +96,12 @@ impl FromRef<AppState> for SessionConfig {
 
 ### Example: Unified Authentication (Chained Strategies)
 
-The `Auth<I>` extractor allows you to use a central `AkResourceGuard` that can try multiple authentication methods in order.
+The `Auth<I>` extractor allows you to use a central `AuthEngineGuard` that can try multiple authentication methods in order.
 
 ```rust
 use axum::{routing::get, Router, extract::FromRef};
 use authkestra_axum::Auth;
-use authkestra_resource::{AkResourceGuard, AuthPolicy};
+use authkestra_resource::{AuthEngineGuard, AuthPolicy};
 use authkestra_resource::jwt::JwtStrategy;
 use authkestra_session::SessionStrategy;
 use std::sync::Arc;
@@ -111,17 +111,17 @@ struct User { id: String }
 
 #[derive(Clone)]
 struct AppState {
-    guard: Arc<AkResourceGuard<User>>,
+    guard: Arc<AuthEngineGuard<User>>,
 }
 
-impl FromRef<AppState> for Arc<AkResourceGuard<User>> {
+impl FromRef<AppState> for Arc<AuthEngineGuard<User>> {
     fn from_ref(state: &AppState) -> Self {
         state.guard.clone()
     }
 }
 
 fn app() -> Router {
-    let guard = AkResourceGuard::builder()
+    let guard = AuthEngineGuard::builder()
         .strategy(JwtStrategy::new(jwt_config))
         .strategy(SessionStrategy::new(session_store, "session_cookie"))
         .policy(AuthPolicy::FirstSuccess)

--- a/crates/authkestra-axum/README.md
+++ b/crates/authkestra-axum/README.md
@@ -7,7 +7,7 @@ This crate provides Axum-specific extractors and helpers to easily integrate the
 ## Features
 
 - **Extractors**:
-  - `Auth<I>`: Unified extractor that uses a configured `AuthEngineGuard` to validate the request.
+  - `Auth<I>`: Unified extractor that uses a configured `Guard` to validate the request.
   - `AuthSession`: Extracts a validated session from cookies.
   - `AuthToken`: Extracts and validates a JWT from the `Authorization: Bearer` header.
 - **OAuth Helpers**:
@@ -20,7 +20,7 @@ This crate provides Axum-specific extractors and helpers to easily integrate the
   - `logout`: Clears the session cookie and removes it from the store.
   - `SessionConfig`: Customizable session settings (cookie name, secure, http_only, etc.).
 - **Macros**:
-  - `AuthkestraFromRef`: Automatically generate `FromRef` implementations for your application state.
+  - `FromRef`: Automatically generate `FromRef` implementations for your application state.
 
 ## Usage
 
@@ -32,20 +32,20 @@ authkestra-axum = { version = "0.1.3", features = ["macros"] }
 tower-cookies = "0.10" # Required for session support
 ```
 
-### Quick Start with AuthkestraFromRef (Recommended)
+### Quick Start with FromRef (Recommended)
 
-The easiest way to integrate Authkestra with custom Axum state is using the `AuthkestraFromRef` macro:
+The easiest way to integrate Authkestra with custom Axum state is using the `FromRef` macro:
 
 ```rust
 use axum::{routing::get, Router};
-use authkestra_axum::{AuthSession, AuthkestraFromRef};
+use authkestra_axum::{AuthSession, FromRef};
 use authkestra::flow::Authkestra;
 use authkestra_flow::{Configured, Missing};
 use authkestra_session::SessionStore;
 use tower_cookies::CookieManagerLayer;
 use std::sync::Arc;
 
-#[derive(Clone, AuthkestraFromRef)]
+#[derive(Clone, FromRef)]
 struct AppState {
     #[authkestra]
     auth: Authkestra<Configured<Arc<dyn SessionStore>>, Missing>,
@@ -70,7 +70,7 @@ If you prefer not to use the macro or need more control, you can manually implem
 
 ```rust
 use axum::{routing::get, Router, extract::FromRef};
-use authkestra_axum::{AuthSession, SessionConfig, AuthEngineAxumError};
+use authkestra_axum::{AuthSession, SessionConfig, Error};
 use authkestra_session::SessionStore;
 use tower_cookies::CookieManagerLayer;
 use std::sync::Arc;
@@ -96,12 +96,12 @@ impl FromRef<AppState> for SessionConfig {
 
 ### Example: Unified Authentication (Chained Strategies)
 
-The `Auth<I>` extractor allows you to use a central `AuthEngineGuard` that can try multiple authentication methods in order.
+The `Auth<I>` extractor allows you to use a central `Guard` that can try multiple authentication methods in order.
 
 ```rust
 use axum::{routing::get, Router, extract::FromRef};
 use authkestra_axum::Auth;
-use authkestra_resource::{AuthEngineGuard, AuthPolicy};
+use authkestra_resource::{Guard, AuthPolicy};
 use authkestra_resource::jwt::JwtStrategy;
 use authkestra_session::SessionStrategy;
 use std::sync::Arc;
@@ -111,17 +111,17 @@ struct User { id: String }
 
 #[derive(Clone)]
 struct AppState {
-    guard: Arc<AuthEngineGuard<User>>,
+    guard: Arc<Guard<User>>,
 }
 
-impl FromRef<AppState> for Arc<AuthEngineGuard<User>> {
+impl FromRef<AppState> for Arc<Guard<User>> {
     fn from_ref(state: &AppState) -> Self {
         state.guard.clone()
     }
 }
 
 fn app() -> Router {
-    let guard = AuthEngineGuard::builder()
+    let guard = Guard::builder()
         .strategy(JwtStrategy::new(jwt_config))
         .strategy(SessionStrategy::new(session_store, "session_cookie"))
         .policy(AuthPolicy::FirstSuccess)

--- a/crates/authkestra-axum/src/helpers.rs
+++ b/crates/authkestra-axum/src/helpers.rs
@@ -8,7 +8,7 @@ use authkestra_engine::{
     state::{Identity, OAuth2State, OAuthToken},
 };
 #[cfg(feature = "flow")]
-use authkestra_engine::{AuthEngine, ErasedOAuthFlow, OAuth2Flow};
+use authkestra_engine::{Engine, ErasedOAuthFlow, OAuth2Flow};
 #[cfg(feature = "token")]
 use axum::Json;
 #[allow(unused_imports)]
@@ -298,20 +298,20 @@ pub async fn axum_login_handler<AppState, S, T>(
     axum::extract::State(state): axum::extract::State<AppState>,
     Query(params): Query<OAuthLoginParams>,
     cookies: Cookies,
-) -> Result<impl IntoResponse, AuthEngineAxumError>
+) -> Result<impl IntoResponse, Error>
 where
     AppState: Clone + Send + Sync + 'static,
-    AuthEngine<S, T>: axum::extract::FromRef<AppState>,
+    Engine<S, T>: axum::extract::FromRef<AppState>,
     SessionConfig: axum::extract::FromRef<AppState>,
 {
     use axum::extract::FromRef;
-    let authkestra = AuthEngine::<S, T>::from_ref(&state);
+    let authkestra = Engine::<S, T>::from_ref(&state);
     let session_config = SessionConfig::from_ref(&state);
 
     let flow: &Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Err(AuthEngineAxumError::Internal("Provider not found".to_string()));
+            return Err(Error::Internal("Provider not found".to_string()));
         }
     };
 
@@ -338,22 +338,22 @@ pub async fn axum_callback_handler<AppState, S, T>(
     axum::extract::State(state): axum::extract::State<AppState>,
     Query(params): Query<OAuthCallbackParams>,
     cookies: Cookies,
-) -> Result<impl IntoResponse, AuthEngineAxumError>
+) -> Result<impl IntoResponse, Error>
 where
     AppState: Clone + Send + Sync + 'static,
-    AuthEngine<S, T>: axum::extract::FromRef<AppState>,
+    Engine<S, T>: axum::extract::FromRef<AppState>,
     SessionConfig: axum::extract::FromRef<AppState>,
-    Result<Arc<dyn SessionStore>, AuthEngineAxumError>: axum::extract::FromRef<AppState>,
+    Result<Arc<dyn SessionStore>, Error>: axum::extract::FromRef<AppState>,
 {
     use axum::extract::FromRef;
-    let authkestra = AuthEngine::<S, T>::from_ref(&state);
+    let authkestra = Engine::<S, T>::from_ref(&state);
     let session_config = SessionConfig::from_ref(&state);
-    let session_store = <Result<Arc<dyn SessionStore>, AuthEngineAxumError>>::from_ref(&state)?;
+    let session_store = <Result<Arc<dyn SessionStore>, Error>>::from_ref(&state)?;
 
     let flow: &Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Err(AuthEngineAxumError::Internal("Provider not found".to_string()));
+            return Err(Error::Internal("Provider not found".to_string()));
         }
     };
 
@@ -368,9 +368,9 @@ where
     .await
     .map_err(|(status, msg)| {
         if status == StatusCode::UNAUTHORIZED {
-            AuthEngineAxumError::Unauthorized(msg)
+            Error::Unauthorized(msg)
         } else {
-            AuthEngineAxumError::Internal(msg)
+            Error::Internal(msg)
         }
     })
 }
@@ -379,51 +379,51 @@ where
 pub async fn axum_logout_handler<AppState, S, T>(
     axum::extract::State(state): axum::extract::State<AppState>,
     cookies: Cookies,
-) -> Result<impl IntoResponse, AuthEngineAxumError>
+) -> Result<impl IntoResponse, Error>
 where
     AppState: Clone + Send + Sync + 'static,
     SessionConfig: axum::extract::FromRef<AppState>,
-    Result<Arc<dyn SessionStore>, AuthEngineAxumError>: axum::extract::FromRef<AppState>,
+    Result<Arc<dyn SessionStore>, Error>: axum::extract::FromRef<AppState>,
 {
     use axum::extract::FromRef;
     let session_config = SessionConfig::from_ref(&state);
-    let session_store = <Result<Arc<dyn SessionStore>, AuthEngineAxumError>>::from_ref(&state)?;
+    let session_store = <Result<Arc<dyn SessionStore>, Error>>::from_ref(&state)?;
 
     logout(cookies, session_store, session_config, "/")
         .await
         .map_err(|(status, msg)| {
             if status == StatusCode::UNAUTHORIZED {
-                AuthEngineAxumError::Unauthorized(msg)
+                Error::Unauthorized(msg)
             } else {
-                AuthEngineAxumError::Internal(msg)
+                Error::Internal(msg)
             }
         })
 }
 
 #[derive(Debug, Clone)]
-pub enum AuthEngineAxumError {
+pub enum Error {
     Unauthorized(String),
     Internal(String),
     /// A required component (e.g., SessionManager, TokenManager) is missing
     ComponentMissing(String),
 }
 
-impl std::fmt::Display for AuthEngineAxumError {
+impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AuthEngineAxumError::Unauthorized(msg) => write!(f, "Unauthorized: {}", msg),
-            AuthEngineAxumError::Internal(msg) => write!(f, "Internal Error: {}", msg),
-            AuthEngineAxumError::ComponentMissing(msg) => write!(f, "Component Missing: {}", msg),
+            Error::Unauthorized(msg) => write!(f, "Unauthorized: {}", msg),
+            Error::Internal(msg) => write!(f, "Internal Error: {}", msg),
+            Error::ComponentMissing(msg) => write!(f, "Component Missing: {}", msg),
         }
     }
 }
 
-impl IntoResponse for AuthEngineAxumError {
+impl IntoResponse for Error {
     fn into_response(self) -> axum::response::Response {
         let (status, message) = match self {
-            AuthEngineAxumError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg),
-            AuthEngineAxumError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
-            AuthEngineAxumError::ComponentMissing(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+            Error::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg),
+            Error::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+            Error::ComponentMissing(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
         };
         (status, message).into_response()
     }
@@ -435,14 +435,14 @@ pub async fn get_session(
     store: &Arc<dyn SessionStore>,
     config: &SessionConfig,
     cookies: &Cookies,
-) -> Result<Session, AuthEngineAxumError> {
+) -> Result<Session, Error> {
     tracing::debug!("getting session from cookies");
     let session_id = cookies
         .get(&config.cookie_name)
         .map(|c| c.value().to_string())
         .ok_or_else(|| {
             tracing::warn!("missing session cookie in request");
-            AuthEngineAxumError::Unauthorized("Missing session cookie".to_string())
+            Error::Unauthorized("Missing session cookie".to_string())
         })?;
 
     let session = store
@@ -450,11 +450,11 @@ pub async fn get_session(
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "failed to load session from store");
-            AuthEngineAxumError::Internal(e.to_string())
+            Error::Internal(e.to_string())
         })?
         .ok_or_else(|| {
             tracing::warn!("session not found or invalid");
-            AuthEngineAxumError::Unauthorized("Invalid session".to_string())
+            Error::Unauthorized("Invalid session".to_string())
         })?;
 
     tracing::info!(session_id = %session.id, user_id = %session.identity.external_id, "successfully retrieved session");
@@ -466,7 +466,7 @@ pub async fn get_session(
 pub async fn get_token(
     parts: &axum::http::request::Parts,
     token_manager: &TokenManager,
-) -> Result<authkestra_engine::Claims, AuthEngineAxumError> {
+) -> Result<authkestra_engine::Claims, Error> {
     tracing::debug!("getting token from request parts");
     let auth_header = parts
         .headers
@@ -474,12 +474,12 @@ pub async fn get_token(
         .and_then(|h| h.to_str().ok())
         .ok_or_else(|| {
             tracing::warn!("missing Authorization header in request");
-            AuthEngineAxumError::Unauthorized("Missing Authorization header".to_string())
+            Error::Unauthorized("Missing Authorization header".to_string())
         })?;
 
     if !auth_header.starts_with("Bearer ") {
         tracing::warn!("invalid Authorization header format in request");
-        return Err(AuthEngineAxumError::Unauthorized(
+        return Err(Error::Unauthorized(
             "Invalid Authorization header".to_string(),
         ));
     }
@@ -487,7 +487,7 @@ pub async fn get_token(
     let token = &auth_header[7..];
     let claims = token_manager.validate_token(token, None).map_err(|e| {
         tracing::error!(error = %e, "failed to validate token");
-        AuthEngineAxumError::Unauthorized(format!("Invalid token: {e}"))
+        Error::Unauthorized(format!("Invalid token: {e}"))
     })?;
 
     tracing::info!("successfully retrieved and validated token");

--- a/crates/authkestra-axum/src/helpers.rs
+++ b/crates/authkestra-axum/src/helpers.rs
@@ -298,7 +298,7 @@ pub async fn axum_login_handler<AppState, S, T>(
     axum::extract::State(state): axum::extract::State<AppState>,
     Query(params): Query<OAuthLoginParams>,
     cookies: Cookies,
-) -> Result<impl IntoResponse, Error>
+) -> Result<impl IntoResponse, AxumError>
 where
     AppState: Clone + Send + Sync + 'static,
     Engine<S, T>: axum::extract::FromRef<AppState>,
@@ -311,7 +311,7 @@ where
     let flow: &Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Err(Error::Internal("Provider not found".to_string()));
+            return Err(AxumError::Internal("Provider not found".to_string()));
         }
     };
 
@@ -338,22 +338,22 @@ pub async fn axum_callback_handler<AppState, S, T>(
     axum::extract::State(state): axum::extract::State<AppState>,
     Query(params): Query<OAuthCallbackParams>,
     cookies: Cookies,
-) -> Result<impl IntoResponse, Error>
+) -> Result<impl IntoResponse, AxumError>
 where
     AppState: Clone + Send + Sync + 'static,
     Engine<S, T>: axum::extract::FromRef<AppState>,
     SessionConfig: axum::extract::FromRef<AppState>,
-    Result<Arc<dyn SessionStore>, Error>: axum::extract::FromRef<AppState>,
+    Result<Arc<dyn SessionStore>, AxumError>: axum::extract::FromRef<AppState>,
 {
     use axum::extract::FromRef;
     let authkestra = Engine::<S, T>::from_ref(&state);
     let session_config = SessionConfig::from_ref(&state);
-    let session_store = <Result<Arc<dyn SessionStore>, Error>>::from_ref(&state)?;
+    let session_store = <Result<Arc<dyn SessionStore>, AxumError>>::from_ref(&state)?;
 
     let flow: &Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Err(Error::Internal("Provider not found".to_string()));
+            return Err(AxumError::Internal("Provider not found".to_string()));
         }
     };
 
@@ -368,9 +368,9 @@ where
     .await
     .map_err(|(status, msg)| {
         if status == StatusCode::UNAUTHORIZED {
-            Error::Unauthorized(msg)
+            AxumError::Unauthorized(msg)
         } else {
-            Error::Internal(msg)
+            AxumError::Internal(msg)
         }
     })
 }
@@ -379,51 +379,51 @@ where
 pub async fn axum_logout_handler<AppState, S, T>(
     axum::extract::State(state): axum::extract::State<AppState>,
     cookies: Cookies,
-) -> Result<impl IntoResponse, Error>
+) -> Result<impl IntoResponse, AxumError>
 where
     AppState: Clone + Send + Sync + 'static,
     SessionConfig: axum::extract::FromRef<AppState>,
-    Result<Arc<dyn SessionStore>, Error>: axum::extract::FromRef<AppState>,
+    Result<Arc<dyn SessionStore>, AxumError>: axum::extract::FromRef<AppState>,
 {
     use axum::extract::FromRef;
     let session_config = SessionConfig::from_ref(&state);
-    let session_store = <Result<Arc<dyn SessionStore>, Error>>::from_ref(&state)?;
+    let session_store = <Result<Arc<dyn SessionStore>, AxumError>>::from_ref(&state)?;
 
     logout(cookies, session_store, session_config, "/")
         .await
         .map_err(|(status, msg)| {
             if status == StatusCode::UNAUTHORIZED {
-                Error::Unauthorized(msg)
+                AxumError::Unauthorized(msg)
             } else {
-                Error::Internal(msg)
+                AxumError::Internal(msg)
             }
         })
 }
 
 #[derive(Debug, Clone)]
-pub enum Error {
+pub enum AxumError {
     Unauthorized(String),
     Internal(String),
     /// A required component (e.g., SessionManager, TokenManager) is missing
     ComponentMissing(String),
 }
 
-impl std::fmt::Display for Error {
+impl std::fmt::Display for AxumError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::Unauthorized(msg) => write!(f, "Unauthorized: {}", msg),
-            Error::Internal(msg) => write!(f, "Internal Error: {}", msg),
-            Error::ComponentMissing(msg) => write!(f, "Component Missing: {}", msg),
+            AxumError::Unauthorized(msg) => write!(f, "Unauthorized: {}", msg),
+            AxumError::Internal(msg) => write!(f, "Internal Error: {}", msg),
+            AxumError::ComponentMissing(msg) => write!(f, "Component Missing: {}", msg),
         }
     }
 }
 
-impl IntoResponse for Error {
+impl IntoResponse for AxumError {
     fn into_response(self) -> axum::response::Response {
         let (status, message) = match self {
-            Error::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg),
-            Error::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
-            Error::ComponentMissing(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+            AxumError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg),
+            AxumError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+            AxumError::ComponentMissing(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
         };
         (status, message).into_response()
     }
@@ -435,14 +435,14 @@ pub async fn get_session(
     store: &Arc<dyn SessionStore>,
     config: &SessionConfig,
     cookies: &Cookies,
-) -> Result<Session, Error> {
+) -> Result<Session, AxumError> {
     tracing::debug!("getting session from cookies");
     let session_id = cookies
         .get(&config.cookie_name)
         .map(|c| c.value().to_string())
         .ok_or_else(|| {
             tracing::warn!("missing session cookie in request");
-            Error::Unauthorized("Missing session cookie".to_string())
+            AxumError::Unauthorized("Missing session cookie".to_string())
         })?;
 
     let session = store
@@ -450,11 +450,11 @@ pub async fn get_session(
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "failed to load session from store");
-            Error::Internal(e.to_string())
+            AxumError::Internal(e.to_string())
         })?
         .ok_or_else(|| {
             tracing::warn!("session not found or invalid");
-            Error::Unauthorized("Invalid session".to_string())
+            AxumError::Unauthorized("Invalid session".to_string())
         })?;
 
     tracing::info!(session_id = %session.id, user_id = %session.identity.external_id, "successfully retrieved session");
@@ -466,7 +466,7 @@ pub async fn get_session(
 pub async fn get_token(
     parts: &axum::http::request::Parts,
     token_manager: &TokenManager,
-) -> Result<authkestra_engine::Claims, Error> {
+) -> Result<authkestra_engine::Claims, AxumError> {
     tracing::debug!("getting token from request parts");
     let auth_header = parts
         .headers
@@ -474,12 +474,12 @@ pub async fn get_token(
         .and_then(|h| h.to_str().ok())
         .ok_or_else(|| {
             tracing::warn!("missing Authorization header in request");
-            Error::Unauthorized("Missing Authorization header".to_string())
+            AxumError::Unauthorized("Missing Authorization header".to_string())
         })?;
 
     if !auth_header.starts_with("Bearer ") {
         tracing::warn!("invalid Authorization header format in request");
-        return Err(Error::Unauthorized(
+        return Err(AxumError::Unauthorized(
             "Invalid Authorization header".to_string(),
         ));
     }
@@ -487,7 +487,7 @@ pub async fn get_token(
     let token = &auth_header[7..];
     let claims = token_manager.validate_token(token, None).map_err(|e| {
         tracing::error!(error = %e, "failed to validate token");
-        Error::Unauthorized(format!("Invalid token: {e}"))
+        AxumError::Unauthorized(format!("Invalid token: {e}"))
     })?;
 
     tracing::info!("successfully retrieved and validated token");

--- a/crates/authkestra-axum/src/helpers.rs
+++ b/crates/authkestra-axum/src/helpers.rs
@@ -8,7 +8,7 @@ use authkestra_engine::{
     state::{Identity, OAuth2State, OAuthToken},
 };
 #[cfg(feature = "flow")]
-use authkestra_engine::{AkBase, ErasedOAuthFlow, OAuth2Flow};
+use authkestra_engine::{AuthEngine, ErasedOAuthFlow, OAuth2Flow};
 #[cfg(feature = "token")]
 use axum::Json;
 #[allow(unused_imports)]
@@ -298,20 +298,20 @@ pub async fn axum_login_handler<AppState, S, T>(
     axum::extract::State(state): axum::extract::State<AppState>,
     Query(params): Query<OAuthLoginParams>,
     cookies: Cookies,
-) -> Result<impl IntoResponse, AkAxumError>
+) -> Result<impl IntoResponse, AuthEngineAxumError>
 where
     AppState: Clone + Send + Sync + 'static,
-    AkBase<S, T>: axum::extract::FromRef<AppState>,
+    AuthEngine<S, T>: axum::extract::FromRef<AppState>,
     SessionConfig: axum::extract::FromRef<AppState>,
 {
     use axum::extract::FromRef;
-    let authkestra = AkBase::<S, T>::from_ref(&state);
+    let authkestra = AuthEngine::<S, T>::from_ref(&state);
     let session_config = SessionConfig::from_ref(&state);
 
     let flow: &Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Err(AkAxumError::Internal("Provider not found".to_string()));
+            return Err(AuthEngineAxumError::Internal("Provider not found".to_string()));
         }
     };
 
@@ -338,22 +338,22 @@ pub async fn axum_callback_handler<AppState, S, T>(
     axum::extract::State(state): axum::extract::State<AppState>,
     Query(params): Query<OAuthCallbackParams>,
     cookies: Cookies,
-) -> Result<impl IntoResponse, AkAxumError>
+) -> Result<impl IntoResponse, AuthEngineAxumError>
 where
     AppState: Clone + Send + Sync + 'static,
-    AkBase<S, T>: axum::extract::FromRef<AppState>,
+    AuthEngine<S, T>: axum::extract::FromRef<AppState>,
     SessionConfig: axum::extract::FromRef<AppState>,
-    Result<Arc<dyn SessionStore>, AkAxumError>: axum::extract::FromRef<AppState>,
+    Result<Arc<dyn SessionStore>, AuthEngineAxumError>: axum::extract::FromRef<AppState>,
 {
     use axum::extract::FromRef;
-    let authkestra = AkBase::<S, T>::from_ref(&state);
+    let authkestra = AuthEngine::<S, T>::from_ref(&state);
     let session_config = SessionConfig::from_ref(&state);
-    let session_store = <Result<Arc<dyn SessionStore>, AkAxumError>>::from_ref(&state)?;
+    let session_store = <Result<Arc<dyn SessionStore>, AuthEngineAxumError>>::from_ref(&state)?;
 
     let flow: &Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Err(AkAxumError::Internal("Provider not found".to_string()));
+            return Err(AuthEngineAxumError::Internal("Provider not found".to_string()));
         }
     };
 
@@ -368,9 +368,9 @@ where
     .await
     .map_err(|(status, msg)| {
         if status == StatusCode::UNAUTHORIZED {
-            AkAxumError::Unauthorized(msg)
+            AuthEngineAxumError::Unauthorized(msg)
         } else {
-            AkAxumError::Internal(msg)
+            AuthEngineAxumError::Internal(msg)
         }
     })
 }
@@ -379,51 +379,51 @@ where
 pub async fn axum_logout_handler<AppState, S, T>(
     axum::extract::State(state): axum::extract::State<AppState>,
     cookies: Cookies,
-) -> Result<impl IntoResponse, AkAxumError>
+) -> Result<impl IntoResponse, AuthEngineAxumError>
 where
     AppState: Clone + Send + Sync + 'static,
     SessionConfig: axum::extract::FromRef<AppState>,
-    Result<Arc<dyn SessionStore>, AkAxumError>: axum::extract::FromRef<AppState>,
+    Result<Arc<dyn SessionStore>, AuthEngineAxumError>: axum::extract::FromRef<AppState>,
 {
     use axum::extract::FromRef;
     let session_config = SessionConfig::from_ref(&state);
-    let session_store = <Result<Arc<dyn SessionStore>, AkAxumError>>::from_ref(&state)?;
+    let session_store = <Result<Arc<dyn SessionStore>, AuthEngineAxumError>>::from_ref(&state)?;
 
     logout(cookies, session_store, session_config, "/")
         .await
         .map_err(|(status, msg)| {
             if status == StatusCode::UNAUTHORIZED {
-                AkAxumError::Unauthorized(msg)
+                AuthEngineAxumError::Unauthorized(msg)
             } else {
-                AkAxumError::Internal(msg)
+                AuthEngineAxumError::Internal(msg)
             }
         })
 }
 
 #[derive(Debug, Clone)]
-pub enum AkAxumError {
+pub enum AuthEngineAxumError {
     Unauthorized(String),
     Internal(String),
     /// A required component (e.g., SessionManager, TokenManager) is missing
     ComponentMissing(String),
 }
 
-impl std::fmt::Display for AkAxumError {
+impl std::fmt::Display for AuthEngineAxumError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AkAxumError::Unauthorized(msg) => write!(f, "Unauthorized: {}", msg),
-            AkAxumError::Internal(msg) => write!(f, "Internal Error: {}", msg),
-            AkAxumError::ComponentMissing(msg) => write!(f, "Component Missing: {}", msg),
+            AuthEngineAxumError::Unauthorized(msg) => write!(f, "Unauthorized: {}", msg),
+            AuthEngineAxumError::Internal(msg) => write!(f, "Internal Error: {}", msg),
+            AuthEngineAxumError::ComponentMissing(msg) => write!(f, "Component Missing: {}", msg),
         }
     }
 }
 
-impl IntoResponse for AkAxumError {
+impl IntoResponse for AuthEngineAxumError {
     fn into_response(self) -> axum::response::Response {
         let (status, message) = match self {
-            AkAxumError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg),
-            AkAxumError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
-            AkAxumError::ComponentMissing(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+            AuthEngineAxumError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg),
+            AuthEngineAxumError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+            AuthEngineAxumError::ComponentMissing(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
         };
         (status, message).into_response()
     }
@@ -435,14 +435,14 @@ pub async fn get_session(
     store: &Arc<dyn SessionStore>,
     config: &SessionConfig,
     cookies: &Cookies,
-) -> Result<Session, AkAxumError> {
+) -> Result<Session, AuthEngineAxumError> {
     tracing::debug!("getting session from cookies");
     let session_id = cookies
         .get(&config.cookie_name)
         .map(|c| c.value().to_string())
         .ok_or_else(|| {
             tracing::warn!("missing session cookie in request");
-            AkAxumError::Unauthorized("Missing session cookie".to_string())
+            AuthEngineAxumError::Unauthorized("Missing session cookie".to_string())
         })?;
 
     let session = store
@@ -450,11 +450,11 @@ pub async fn get_session(
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "failed to load session from store");
-            AkAxumError::Internal(e.to_string())
+            AuthEngineAxumError::Internal(e.to_string())
         })?
         .ok_or_else(|| {
             tracing::warn!("session not found or invalid");
-            AkAxumError::Unauthorized("Invalid session".to_string())
+            AuthEngineAxumError::Unauthorized("Invalid session".to_string())
         })?;
 
     tracing::info!(session_id = %session.id, user_id = %session.identity.external_id, "successfully retrieved session");
@@ -466,7 +466,7 @@ pub async fn get_session(
 pub async fn get_token(
     parts: &axum::http::request::Parts,
     token_manager: &TokenManager,
-) -> Result<authkestra_engine::Claims, AkAxumError> {
+) -> Result<authkestra_engine::Claims, AuthEngineAxumError> {
     tracing::debug!("getting token from request parts");
     let auth_header = parts
         .headers
@@ -474,12 +474,12 @@ pub async fn get_token(
         .and_then(|h| h.to_str().ok())
         .ok_or_else(|| {
             tracing::warn!("missing Authorization header in request");
-            AkAxumError::Unauthorized("Missing Authorization header".to_string())
+            AuthEngineAxumError::Unauthorized("Missing Authorization header".to_string())
         })?;
 
     if !auth_header.starts_with("Bearer ") {
         tracing::warn!("invalid Authorization header format in request");
-        return Err(AkAxumError::Unauthorized(
+        return Err(AuthEngineAxumError::Unauthorized(
             "Invalid Authorization header".to_string(),
         ));
     }
@@ -487,7 +487,7 @@ pub async fn get_token(
     let token = &auth_header[7..];
     let claims = token_manager.validate_token(token, None).map_err(|e| {
         tracing::error!(error = %e, "failed to validate token");
-        AkAxumError::Unauthorized(format!("Invalid token: {e}"))
+        AuthEngineAxumError::Unauthorized(format!("Invalid token: {e}"))
     })?;
 
     tracing::info!("successfully retrieved and validated token");

--- a/crates/authkestra-axum/src/helpers.rs
+++ b/crates/authkestra-axum/src/helpers.rs
@@ -8,7 +8,7 @@ use authkestra_engine::{
     state::{Identity, OAuth2State, OAuthToken},
 };
 #[cfg(feature = "flow")]
-use authkestra_engine::{AuthEngine, ErasedOAuthFlow, OAuth2Flow};
+use authkestra_engine::{AkBase, ErasedOAuthFlow, OAuth2Flow};
 #[cfg(feature = "token")]
 use axum::Json;
 #[allow(unused_imports)]
@@ -298,20 +298,20 @@ pub async fn axum_login_handler<AppState, S, T>(
     axum::extract::State(state): axum::extract::State<AppState>,
     Query(params): Query<OAuthLoginParams>,
     cookies: Cookies,
-) -> Result<impl IntoResponse, AuthEngineAxumError>
+) -> Result<impl IntoResponse, AkAxumError>
 where
     AppState: Clone + Send + Sync + 'static,
-    AuthEngine<S, T>: axum::extract::FromRef<AppState>,
+    AkBase<S, T>: axum::extract::FromRef<AppState>,
     SessionConfig: axum::extract::FromRef<AppState>,
 {
     use axum::extract::FromRef;
-    let authkestra = AuthEngine::<S, T>::from_ref(&state);
+    let authkestra = AkBase::<S, T>::from_ref(&state);
     let session_config = SessionConfig::from_ref(&state);
 
     let flow: &Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Err(AuthEngineAxumError::Internal(
+            return Err(AkAxumError::Internal(
                 "Provider not found".to_string(),
             ));
         }
@@ -340,22 +340,22 @@ pub async fn axum_callback_handler<AppState, S, T>(
     axum::extract::State(state): axum::extract::State<AppState>,
     Query(params): Query<OAuthCallbackParams>,
     cookies: Cookies,
-) -> Result<impl IntoResponse, AuthEngineAxumError>
+) -> Result<impl IntoResponse, AkAxumError>
 where
     AppState: Clone + Send + Sync + 'static,
-    AuthEngine<S, T>: axum::extract::FromRef<AppState>,
+    AkBase<S, T>: axum::extract::FromRef<AppState>,
     SessionConfig: axum::extract::FromRef<AppState>,
-    Result<Arc<dyn SessionStore>, AuthEngineAxumError>: axum::extract::FromRef<AppState>,
+    Result<Arc<dyn SessionStore>, AkAxumError>: axum::extract::FromRef<AppState>,
 {
     use axum::extract::FromRef;
-    let authkestra = AuthEngine::<S, T>::from_ref(&state);
+    let authkestra = AkBase::<S, T>::from_ref(&state);
     let session_config = SessionConfig::from_ref(&state);
-    let session_store = <Result<Arc<dyn SessionStore>, AuthEngineAxumError>>::from_ref(&state)?;
+    let session_store = <Result<Arc<dyn SessionStore>, AkAxumError>>::from_ref(&state)?;
 
     let flow: &Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Err(AuthEngineAxumError::Internal(
+            return Err(AkAxumError::Internal(
                 "Provider not found".to_string(),
             ));
         }
@@ -372,9 +372,9 @@ where
     .await
     .map_err(|(status, msg)| {
         if status == StatusCode::UNAUTHORIZED {
-            AuthEngineAxumError::Unauthorized(msg)
+            AkAxumError::Unauthorized(msg)
         } else {
-            AuthEngineAxumError::Internal(msg)
+            AkAxumError::Internal(msg)
         }
     })
 }
@@ -383,51 +383,51 @@ where
 pub async fn axum_logout_handler<AppState, S, T>(
     axum::extract::State(state): axum::extract::State<AppState>,
     cookies: Cookies,
-) -> Result<impl IntoResponse, AuthEngineAxumError>
+) -> Result<impl IntoResponse, AkAxumError>
 where
     AppState: Clone + Send + Sync + 'static,
     SessionConfig: axum::extract::FromRef<AppState>,
-    Result<Arc<dyn SessionStore>, AuthEngineAxumError>: axum::extract::FromRef<AppState>,
+    Result<Arc<dyn SessionStore>, AkAxumError>: axum::extract::FromRef<AppState>,
 {
     use axum::extract::FromRef;
     let session_config = SessionConfig::from_ref(&state);
-    let session_store = <Result<Arc<dyn SessionStore>, AuthEngineAxumError>>::from_ref(&state)?;
+    let session_store = <Result<Arc<dyn SessionStore>, AkAxumError>>::from_ref(&state)?;
 
     logout(cookies, session_store, session_config, "/")
         .await
         .map_err(|(status, msg)| {
             if status == StatusCode::UNAUTHORIZED {
-                AuthEngineAxumError::Unauthorized(msg)
+                AkAxumError::Unauthorized(msg)
             } else {
-                AuthEngineAxumError::Internal(msg)
+                AkAxumError::Internal(msg)
             }
         })
 }
 
 #[derive(Debug, Clone)]
-pub enum AuthEngineAxumError {
+pub enum AkAxumError {
     Unauthorized(String),
     Internal(String),
     /// A required component (e.g., SessionManager, TokenManager) is missing
     ComponentMissing(String),
 }
 
-impl std::fmt::Display for AuthEngineAxumError {
+impl std::fmt::Display for AkAxumError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AuthEngineAxumError::Unauthorized(msg) => write!(f, "Unauthorized: {}", msg),
-            AuthEngineAxumError::Internal(msg) => write!(f, "Internal Error: {}", msg),
-            AuthEngineAxumError::ComponentMissing(msg) => write!(f, "Component Missing: {}", msg),
+            AkAxumError::Unauthorized(msg) => write!(f, "Unauthorized: {}", msg),
+            AkAxumError::Internal(msg) => write!(f, "Internal Error: {}", msg),
+            AkAxumError::ComponentMissing(msg) => write!(f, "Component Missing: {}", msg),
         }
     }
 }
 
-impl IntoResponse for AuthEngineAxumError {
+impl IntoResponse for AkAxumError {
     fn into_response(self) -> axum::response::Response {
         let (status, message) = match self {
-            AuthEngineAxumError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg),
-            AuthEngineAxumError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
-            AuthEngineAxumError::ComponentMissing(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+            AkAxumError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg),
+            AkAxumError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+            AkAxumError::ComponentMissing(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
         };
         (status, message).into_response()
     }
@@ -439,14 +439,14 @@ pub async fn get_session(
     store: &Arc<dyn SessionStore>,
     config: &SessionConfig,
     cookies: &Cookies,
-) -> Result<Session, AuthEngineAxumError> {
+) -> Result<Session, AkAxumError> {
     tracing::debug!("getting session from cookies");
     let session_id = cookies
         .get(&config.cookie_name)
         .map(|c| c.value().to_string())
         .ok_or_else(|| {
             tracing::warn!("missing session cookie in request");
-            AuthEngineAxumError::Unauthorized("Missing session cookie".to_string())
+            AkAxumError::Unauthorized("Missing session cookie".to_string())
         })?;
 
     let session = store
@@ -454,11 +454,11 @@ pub async fn get_session(
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "failed to load session from store");
-            AuthEngineAxumError::Internal(e.to_string())
+            AkAxumError::Internal(e.to_string())
         })?
         .ok_or_else(|| {
             tracing::warn!("session not found or invalid");
-            AuthEngineAxumError::Unauthorized("Invalid session".to_string())
+            AkAxumError::Unauthorized("Invalid session".to_string())
         })?;
 
     tracing::info!(session_id = %session.id, user_id = %session.identity.external_id, "successfully retrieved session");
@@ -470,7 +470,7 @@ pub async fn get_session(
 pub async fn get_token(
     parts: &axum::http::request::Parts,
     token_manager: &TokenManager,
-) -> Result<authkestra_engine::Claims, AuthEngineAxumError> {
+) -> Result<authkestra_engine::Claims, AkAxumError> {
     tracing::debug!("getting token from request parts");
     let auth_header = parts
         .headers
@@ -478,12 +478,12 @@ pub async fn get_token(
         .and_then(|h| h.to_str().ok())
         .ok_or_else(|| {
             tracing::warn!("missing Authorization header in request");
-            AuthEngineAxumError::Unauthorized("Missing Authorization header".to_string())
+            AkAxumError::Unauthorized("Missing Authorization header".to_string())
         })?;
 
     if !auth_header.starts_with("Bearer ") {
         tracing::warn!("invalid Authorization header format in request");
-        return Err(AuthEngineAxumError::Unauthorized(
+        return Err(AkAxumError::Unauthorized(
             "Invalid Authorization header".to_string(),
         ));
     }
@@ -491,7 +491,7 @@ pub async fn get_token(
     let token = &auth_header[7..];
     let claims = token_manager.validate_token(token, None).map_err(|e| {
         tracing::error!(error = %e, "failed to validate token");
-        AuthEngineAxumError::Unauthorized(format!("Invalid token: {e}"))
+        AkAxumError::Unauthorized(format!("Invalid token: {e}"))
     })?;
 
     tracing::info!("successfully retrieved and validated token");

--- a/crates/authkestra-axum/src/helpers.rs
+++ b/crates/authkestra-axum/src/helpers.rs
@@ -311,9 +311,7 @@ where
     let flow: &Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Err(AkAxumError::Internal(
-                "Provider not found".to_string(),
-            ));
+            return Err(AkAxumError::Internal("Provider not found".to_string()));
         }
     };
 
@@ -355,9 +353,7 @@ where
     let flow: &Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Err(AkAxumError::Internal(
-                "Provider not found".to_string(),
-            ));
+            return Err(AkAxumError::Internal("Provider not found".to_string()));
         }
     };
 

--- a/crates/authkestra-axum/src/lib.rs
+++ b/crates/authkestra-axum/src/lib.rs
@@ -23,26 +23,21 @@ pub use helpers::{Session, SessionStore};
 #[cfg(feature = "op")]
 pub use op::AkAxumOpExt;
 
-#[cfg(feature = "flow")]
-pub use AuthEngineState as AuthkestraState;
-
 #[cfg(feature = "macros")]
 extern crate self as authkestra_axum;
 
 #[cfg(feature = "macros")]
-pub use authkestra_macros::AuthkestraFromRef;
-#[cfg(feature = "macros")]
-pub use authkestra_macros::AuthkestraState; // Keep for backwards compatibility if needed
+pub use authkestra_macros::AuthkestraState;
 
 #[cfg(feature = "flow")]
 #[derive(Clone, AuthkestraState)]
-pub struct AuthEngineState<S = Missing, T = Missing> {
+pub struct AkState<S = Missing, T = Missing> {
     #[authkestra(engine)]
     pub authkestra: AkBase<S, T>,
 }
 
 #[cfg(feature = "flow")]
-impl<S, T> From<AkBase<S, T>> for AuthEngineState<S, T> {
+impl<S, T> From<AkBase<S, T>> for AkState<S, T> {
     fn from(authkestra: AkBase<S, T>) -> Self {
         Self { authkestra }
     }

--- a/crates/authkestra-axum/src/lib.rs
+++ b/crates/authkestra-axum/src/lib.rs
@@ -23,8 +23,6 @@ pub use helpers::{Session, SessionStore};
 #[cfg(feature = "op")]
 pub use op::OpExt;
 
-
-
 #[cfg(feature = "macros")]
 extern crate self as authkestra_axum;
 
@@ -192,9 +190,7 @@ where
             }
             Ok(None) => {
                 tracing::warn!("authentication failed: no identity returned");
-                Err(AxumError::Unauthorized(
-                    "Authentication failed".to_string(),
-                ))
+                Err(AxumError::Unauthorized("Authentication failed".to_string()))
             }
             Err(e) => {
                 tracing::error!(error = %e, "internal error during authentication");

--- a/crates/authkestra-axum/src/lib.rs
+++ b/crates/authkestra-axum/src/lib.rs
@@ -143,9 +143,7 @@ where
             .headers
             .get(axum::http::header::AUTHORIZATION)
             .and_then(|h| h.to_str().ok())
-            .ok_or_else(|| {
-                AkAxumError::Unauthorized("Missing Authorization header".to_string())
-            })?;
+            .ok_or_else(|| AkAxumError::Unauthorized("Missing Authorization header".to_string()))?;
 
         if !auth_header.starts_with("Bearer ") {
             return Err(AkAxumError::Unauthorized(

--- a/crates/authkestra-axum/src/lib.rs
+++ b/crates/authkestra-axum/src/lib.rs
@@ -16,7 +16,7 @@ pub mod helpers;
 #[cfg(feature = "op")]
 pub mod op;
 
-pub use helpers::Error;
+pub use helpers::AxumError;
 #[cfg(feature = "session")]
 pub use helpers::{Session, SessionStore};
 
@@ -29,17 +29,17 @@ pub use op::OpExt;
 extern crate self as authkestra_axum;
 
 #[cfg(feature = "macros")]
-pub use authkestra_macros::State;
+pub use authkestra_macros::AxumState;
 
 #[cfg(feature = "flow")]
-#[derive(Clone, State)]
-pub struct State<S = Missing, T = Missing> {
+#[derive(Clone, AxumState)]
+pub struct AxumState<S = Missing, T = Missing> {
     #[authkestra(engine)]
     pub authkestra: Engine<S, T>,
 }
 
 #[cfg(feature = "flow")]
-impl<S, T> From<Engine<S, T>> for State<S, T> {
+impl<S, T> From<Engine<S, T>> for AxumState<S, T> {
     fn from(authkestra: Engine<S, T>) -> Self {
         Self { authkestra }
     }
@@ -53,10 +53,10 @@ pub struct AuthSession(pub Session);
 impl<S> FromRequestParts<S> for AuthSession
 where
     S: Send + Sync,
-    Result<Arc<dyn SessionStore>, Error>: FromRef<S>,
+    Result<Arc<dyn SessionStore>, AxumError>: FromRef<S>,
     SessionConfig: FromRef<S>,
 {
-    type Rejection = Error;
+    type Rejection = AxumError;
 
     #[tracing::instrument(skip_all)]
     async fn from_request_parts(
@@ -65,13 +65,13 @@ where
     ) -> Result<Self, Self::Rejection> {
         use tower_cookies::Cookies;
         tracing::debug!("extracting AuthSession from request");
-        let session_store = <Result<Arc<dyn SessionStore>, Error>>::from_ref(state)?;
+        let session_store = <Result<Arc<dyn SessionStore>, AxumError>>::from_ref(state)?;
         let session_config = SessionConfig::from_ref(state);
         let cookies = Cookies::from_request_parts(parts, state)
             .await
             .map_err(|e| {
                 tracing::error!(error = %e.1, "failed to extract cookies");
-                Error::Internal(e.1.to_string())
+                AxumError::Internal(e.1.to_string())
             })?;
 
         let session = helpers::get_session(&session_store, &session_config, &cookies)
@@ -96,9 +96,9 @@ pub struct AuthToken(pub authkestra_engine::Claims);
 impl<S> FromRequestParts<S> for AuthToken
 where
     S: Send + Sync,
-    Result<Arc<TokenManager>, Error>: FromRef<S>,
+    Result<Arc<TokenManager>, AxumError>: FromRef<S>,
 {
-    type Rejection = Error;
+    type Rejection = AxumError;
 
     #[tracing::instrument(skip_all)]
     async fn from_request_parts(
@@ -106,7 +106,7 @@ where
         state: &S,
     ) -> Result<Self, Self::Rejection> {
         tracing::debug!("extracting AuthToken from request");
-        let token_manager = <Result<Arc<TokenManager>, Error>>::from_ref(state)?;
+        let token_manager = <Result<Arc<TokenManager>, AxumError>>::from_ref(state)?;
         let token = helpers::get_token(parts, &token_manager)
             .await
             .map_err(|e| {
@@ -132,7 +132,7 @@ where
     jsonwebtoken::Validation: FromRef<S>,
     T: for<'de> serde::Deserialize<'de> + 'static,
 {
-    type Rejection = Error;
+    type Rejection = AxumError;
 
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
@@ -145,10 +145,10 @@ where
             .headers
             .get(axum::http::header::AUTHORIZATION)
             .and_then(|h| h.to_str().ok())
-            .ok_or_else(|| Error::Unauthorized("Missing Authorization header".to_string()))?;
+            .ok_or_else(|| AxumError::Unauthorized("Missing Authorization header".to_string()))?;
 
         if !auth_header.starts_with("Bearer ") {
-            return Err(Error::Unauthorized(
+            return Err(AxumError::Unauthorized(
                 "Invalid Authorization header".to_string(),
             ));
         }
@@ -157,7 +157,7 @@ where
         let claims =
             authkestra_resource::jwt::validate_jwt_generic::<T>(token, &cache, &validation)
                 .await
-                .map_err(|e| Error::Unauthorized(format!("Invalid token: {e}")))?;
+                .map_err(|e| AxumError::Unauthorized(format!("Invalid token: {e}")))?;
 
         Ok(Jwt(claims))
     }
@@ -176,7 +176,7 @@ where
     Arc<authkestra_resource::Guard<I>>: FromRef<S>,
     I: Send + Sync + 'static,
 {
-    type Rejection = Error;
+    type Rejection = AxumError;
 
     #[tracing::instrument(skip_all)]
     async fn from_request_parts(
@@ -192,13 +192,13 @@ where
             }
             Ok(None) => {
                 tracing::warn!("authentication failed: no identity returned");
-                Err(Error::Unauthorized(
+                Err(AxumError::Unauthorized(
                     "Authentication failed".to_string(),
                 ))
             }
             Err(e) => {
                 tracing::error!(error = %e, "internal error during authentication");
-                Err(Error::Internal(e.to_string()))
+                Err(AxumError::Internal(e.to_string()))
             }
         }
     }
@@ -211,7 +211,7 @@ pub trait AxumExt<S, T> {
         AppState: Clone + Send + Sync + 'static,
         Engine<S, T>: FromRef<AppState>,
         SessionConfig: FromRef<AppState>,
-        Result<Arc<dyn SessionStore>, Error>: FromRef<AppState>;
+        Result<Arc<dyn SessionStore>, AxumError>: FromRef<AppState>;
 }
 
 #[cfg(all(feature = "flow", feature = "session"))]
@@ -223,7 +223,7 @@ impl<S: Clone + Send + Sync + 'static, T: Clone + Send + Sync + 'static> AxumExt
         AppState: Clone + Send + Sync + 'static,
         Engine<S, T>: FromRef<AppState>,
         SessionConfig: FromRef<AppState>,
-        Result<Arc<dyn SessionStore>, Error>: FromRef<AppState>,
+        Result<Arc<dyn SessionStore>, AxumError>: FromRef<AppState>,
     {
         use axum::routing::get;
         axum::Router::new()

--- a/crates/authkestra-axum/src/lib.rs
+++ b/crates/authkestra-axum/src/lib.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "token")]
 pub use authkestra_engine::TokenManager;
 #[cfg(feature = "flow")]
-pub use authkestra_engine::{AuthEngine, Missing, SessionConfig};
+pub use authkestra_engine::{AkBase, Missing, SessionConfig};
 #[cfg(feature = "resource")]
-pub use authkestra_resource::AuthEngineGuard;
+pub use authkestra_resource::AkResourceGuard;
 #[allow(unused_imports)]
 use axum::extract::FromRef;
 #[cfg(feature = "session")]
@@ -16,16 +16,12 @@ pub mod helpers;
 #[cfg(feature = "op")]
 pub mod op;
 
-pub use helpers::AuthEngineAxumError;
-pub use helpers::AuthEngineAxumError as AuthkestraAxumError;
+pub use helpers::AkAxumError;
 #[cfg(feature = "session")]
 pub use helpers::{Session, SessionStore};
 
-#[cfg(all(feature = "flow", feature = "session"))]
-pub use AuthEngineAxumExt as AuthkestraAxumExt;
-
 #[cfg(feature = "op")]
-pub use op::AuthEngineAxumOpExt;
+pub use op::AkAxumOpExt;
 
 #[cfg(feature = "flow")]
 pub use AuthEngineState as AuthkestraState;
@@ -42,12 +38,12 @@ pub use authkestra_macros::AuthkestraState; // Keep for backwards compatibility 
 #[derive(Clone, AuthkestraState)]
 pub struct AuthEngineState<S = Missing, T = Missing> {
     #[authkestra(engine)]
-    pub authkestra: AuthEngine<S, T>,
+    pub authkestra: AkBase<S, T>,
 }
 
 #[cfg(feature = "flow")]
-impl<S, T> From<AuthEngine<S, T>> for AuthEngineState<S, T> {
-    fn from(authkestra: AuthEngine<S, T>) -> Self {
+impl<S, T> From<AkBase<S, T>> for AuthEngineState<S, T> {
+    fn from(authkestra: AkBase<S, T>) -> Self {
         Self { authkestra }
     }
 }
@@ -60,10 +56,10 @@ pub struct AuthSession(pub Session);
 impl<S> FromRequestParts<S> for AuthSession
 where
     S: Send + Sync,
-    Result<Arc<dyn SessionStore>, AuthEngineAxumError>: FromRef<S>,
+    Result<Arc<dyn SessionStore>, AkAxumError>: FromRef<S>,
     SessionConfig: FromRef<S>,
 {
-    type Rejection = AuthEngineAxumError;
+    type Rejection = AkAxumError;
 
     #[tracing::instrument(skip_all)]
     async fn from_request_parts(
@@ -72,13 +68,13 @@ where
     ) -> Result<Self, Self::Rejection> {
         use tower_cookies::Cookies;
         tracing::debug!("extracting AuthSession from request");
-        let session_store = <Result<Arc<dyn SessionStore>, AuthEngineAxumError>>::from_ref(state)?;
+        let session_store = <Result<Arc<dyn SessionStore>, AkAxumError>>::from_ref(state)?;
         let session_config = SessionConfig::from_ref(state);
         let cookies = Cookies::from_request_parts(parts, state)
             .await
             .map_err(|e| {
                 tracing::error!(error = %e.1, "failed to extract cookies");
-                AuthEngineAxumError::Internal(e.1.to_string())
+                AkAxumError::Internal(e.1.to_string())
             })?;
 
         let session = helpers::get_session(&session_store, &session_config, &cookies)
@@ -103,9 +99,9 @@ pub struct AuthToken(pub authkestra_engine::Claims);
 impl<S> FromRequestParts<S> for AuthToken
 where
     S: Send + Sync,
-    Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<S>,
+    Result<Arc<TokenManager>, AkAxumError>: FromRef<S>,
 {
-    type Rejection = AuthEngineAxumError;
+    type Rejection = AkAxumError;
 
     #[tracing::instrument(skip_all)]
     async fn from_request_parts(
@@ -113,7 +109,7 @@ where
         state: &S,
     ) -> Result<Self, Self::Rejection> {
         tracing::debug!("extracting AuthToken from request");
-        let token_manager = <Result<Arc<TokenManager>, AuthEngineAxumError>>::from_ref(state)?;
+        let token_manager = <Result<Arc<TokenManager>, AkAxumError>>::from_ref(state)?;
         let token = helpers::get_token(parts, &token_manager)
             .await
             .map_err(|e| {
@@ -139,7 +135,7 @@ where
     jsonwebtoken::Validation: FromRef<S>,
     T: for<'de> serde::Deserialize<'de> + 'static,
 {
-    type Rejection = AuthEngineAxumError;
+    type Rejection = AkAxumError;
 
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
@@ -153,11 +149,11 @@ where
             .get(axum::http::header::AUTHORIZATION)
             .and_then(|h| h.to_str().ok())
             .ok_or_else(|| {
-                AuthEngineAxumError::Unauthorized("Missing Authorization header".to_string())
+                AkAxumError::Unauthorized("Missing Authorization header".to_string())
             })?;
 
         if !auth_header.starts_with("Bearer ") {
-            return Err(AuthEngineAxumError::Unauthorized(
+            return Err(AkAxumError::Unauthorized(
                 "Invalid Authorization header".to_string(),
             ));
         }
@@ -166,7 +162,7 @@ where
         let claims =
             authkestra_resource::jwt::validate_jwt_generic::<T>(token, &cache, &validation)
                 .await
-                .map_err(|e| AuthEngineAxumError::Unauthorized(format!("Invalid token: {e}")))?;
+                .map_err(|e| AkAxumError::Unauthorized(format!("Invalid token: {e}")))?;
 
         Ok(Jwt(claims))
     }
@@ -174,7 +170,7 @@ where
 
 /// A unified extractor for authentication.
 ///
-/// It uses the `AuthEngineGuard` from the application state to validate the request.
+/// It uses the `AkResourceGuard` from the application state to validate the request.
 #[cfg(feature = "resource")]
 pub struct Auth<I>(pub I);
 
@@ -182,57 +178,57 @@ pub struct Auth<I>(pub I);
 impl<S, I> FromRequestParts<S> for Auth<I>
 where
     S: Send + Sync,
-    Arc<authkestra_resource::AuthEngineGuard<I>>: FromRef<S>,
+    Arc<authkestra_resource::AkResourceGuard<I>>: FromRef<S>,
     I: Send + Sync + 'static,
 {
-    type Rejection = AuthEngineAxumError;
+    type Rejection = AkAxumError;
 
     #[tracing::instrument(skip_all)]
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
         state: &S,
     ) -> Result<Self, Self::Rejection> {
-        tracing::debug!("extracting generic Auth from request via AuthEngineGuard");
-        let guard = Arc::<authkestra_resource::AuthEngineGuard<I>>::from_ref(state);
+        tracing::debug!("extracting generic Auth from request via AkResourceGuard");
+        let guard = Arc::<authkestra_resource::AkResourceGuard<I>>::from_ref(state);
         match guard.authenticate(parts).await {
             Ok(Some(identity)) => {
-                tracing::info!("successfully authenticated request via AuthEngineGuard");
+                tracing::info!("successfully authenticated request via AkResourceGuard");
                 Ok(Auth(identity))
             }
             Ok(None) => {
                 tracing::warn!("authentication failed: no identity returned");
-                Err(AuthEngineAxumError::Unauthorized(
+                Err(AkAxumError::Unauthorized(
                     "Authentication failed".to_string(),
                 ))
             }
             Err(e) => {
                 tracing::error!(error = %e, "internal error during authentication");
-                Err(AuthEngineAxumError::Internal(e.to_string()))
+                Err(AkAxumError::Internal(e.to_string()))
             }
         }
     }
 }
 
 #[cfg(all(feature = "flow", feature = "session"))]
-pub trait AuthEngineAxumExt<S, T> {
+pub trait AkAxumExt<S, T> {
     fn axum_router<AppState>(&self) -> axum::Router<AppState>
     where
         AppState: Clone + Send + Sync + 'static,
-        AuthEngine<S, T>: FromRef<AppState>,
+        AkBase<S, T>: FromRef<AppState>,
         SessionConfig: FromRef<AppState>,
-        Result<Arc<dyn SessionStore>, AuthEngineAxumError>: FromRef<AppState>;
+        Result<Arc<dyn SessionStore>, AkAxumError>: FromRef<AppState>;
 }
 
 #[cfg(all(feature = "flow", feature = "session"))]
-impl<S: Clone + Send + Sync + 'static, T: Clone + Send + Sync + 'static> AuthEngineAxumExt<S, T>
-    for AuthEngine<S, T>
+impl<S: Clone + Send + Sync + 'static, T: Clone + Send + Sync + 'static> AkAxumExt<S, T>
+    for AkBase<S, T>
 {
     fn axum_router<AppState>(&self) -> axum::Router<AppState>
     where
         AppState: Clone + Send + Sync + 'static,
-        AuthEngine<S, T>: FromRef<AppState>,
+        AkBase<S, T>: FromRef<AppState>,
         SessionConfig: FromRef<AppState>,
-        Result<Arc<dyn SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
+        Result<Arc<dyn SessionStore>, AkAxumError>: FromRef<AppState>,
     {
         use axum::routing::get;
         axum::Router::new()

--- a/crates/authkestra-axum/src/lib.rs
+++ b/crates/authkestra-axum/src/lib.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "token")]
 pub use authkestra_engine::TokenManager;
 #[cfg(feature = "flow")]
-pub use authkestra_engine::{AuthEngine, Missing, SessionConfig};
+pub use authkestra_engine::{Engine, Missing, SessionConfig};
 #[cfg(feature = "resource")]
-pub use authkestra_resource::AuthEngineGuard;
+pub use authkestra_resource::Guard;
 #[allow(unused_imports)]
 use axum::extract::FromRef;
 #[cfg(feature = "session")]
@@ -16,34 +16,31 @@ pub mod helpers;
 #[cfg(feature = "op")]
 pub mod op;
 
-pub use helpers::AuthEngineAxumError;
+pub use helpers::Error;
 #[cfg(feature = "session")]
 pub use helpers::{Session, SessionStore};
 
 #[cfg(feature = "op")]
-pub use op::AuthEngineAxumOpExt;
+pub use op::OpExt;
 
-// Keep for backwards compatibility if needed
-pub type AuthkestraAxumError = AuthEngineAxumError;
-#[cfg(all(feature = "flow", feature = "session"))]
-pub use AuthEngineAxumExt as AuthkestraAxumExt;
+
 
 #[cfg(feature = "macros")]
 extern crate self as authkestra_axum;
 
 #[cfg(feature = "macros")]
-pub use authkestra_macros::AuthkestraState;
+pub use authkestra_macros::State;
 
 #[cfg(feature = "flow")]
-#[derive(Clone, AuthkestraState)]
-pub struct AuthEngineState<S = Missing, T = Missing> {
+#[derive(Clone, State)]
+pub struct State<S = Missing, T = Missing> {
     #[authkestra(engine)]
-    pub authkestra: AuthEngine<S, T>,
+    pub authkestra: Engine<S, T>,
 }
 
 #[cfg(feature = "flow")]
-impl<S, T> From<AuthEngine<S, T>> for AuthEngineState<S, T> {
-    fn from(authkestra: AuthEngine<S, T>) -> Self {
+impl<S, T> From<Engine<S, T>> for State<S, T> {
+    fn from(authkestra: Engine<S, T>) -> Self {
         Self { authkestra }
     }
 }
@@ -56,10 +53,10 @@ pub struct AuthSession(pub Session);
 impl<S> FromRequestParts<S> for AuthSession
 where
     S: Send + Sync,
-    Result<Arc<dyn SessionStore>, AuthEngineAxumError>: FromRef<S>,
+    Result<Arc<dyn SessionStore>, Error>: FromRef<S>,
     SessionConfig: FromRef<S>,
 {
-    type Rejection = AuthEngineAxumError;
+    type Rejection = Error;
 
     #[tracing::instrument(skip_all)]
     async fn from_request_parts(
@@ -68,13 +65,13 @@ where
     ) -> Result<Self, Self::Rejection> {
         use tower_cookies::Cookies;
         tracing::debug!("extracting AuthSession from request");
-        let session_store = <Result<Arc<dyn SessionStore>, AuthEngineAxumError>>::from_ref(state)?;
+        let session_store = <Result<Arc<dyn SessionStore>, Error>>::from_ref(state)?;
         let session_config = SessionConfig::from_ref(state);
         let cookies = Cookies::from_request_parts(parts, state)
             .await
             .map_err(|e| {
                 tracing::error!(error = %e.1, "failed to extract cookies");
-                AuthEngineAxumError::Internal(e.1.to_string())
+                Error::Internal(e.1.to_string())
             })?;
 
         let session = helpers::get_session(&session_store, &session_config, &cookies)
@@ -99,9 +96,9 @@ pub struct AuthToken(pub authkestra_engine::Claims);
 impl<S> FromRequestParts<S> for AuthToken
 where
     S: Send + Sync,
-    Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<S>,
+    Result<Arc<TokenManager>, Error>: FromRef<S>,
 {
-    type Rejection = AuthEngineAxumError;
+    type Rejection = Error;
 
     #[tracing::instrument(skip_all)]
     async fn from_request_parts(
@@ -109,7 +106,7 @@ where
         state: &S,
     ) -> Result<Self, Self::Rejection> {
         tracing::debug!("extracting AuthToken from request");
-        let token_manager = <Result<Arc<TokenManager>, AuthEngineAxumError>>::from_ref(state)?;
+        let token_manager = <Result<Arc<TokenManager>, Error>>::from_ref(state)?;
         let token = helpers::get_token(parts, &token_manager)
             .await
             .map_err(|e| {
@@ -135,7 +132,7 @@ where
     jsonwebtoken::Validation: FromRef<S>,
     T: for<'de> serde::Deserialize<'de> + 'static,
 {
-    type Rejection = AuthEngineAxumError;
+    type Rejection = Error;
 
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
@@ -148,10 +145,10 @@ where
             .headers
             .get(axum::http::header::AUTHORIZATION)
             .and_then(|h| h.to_str().ok())
-            .ok_or_else(|| AuthEngineAxumError::Unauthorized("Missing Authorization header".to_string()))?;
+            .ok_or_else(|| Error::Unauthorized("Missing Authorization header".to_string()))?;
 
         if !auth_header.starts_with("Bearer ") {
-            return Err(AuthEngineAxumError::Unauthorized(
+            return Err(Error::Unauthorized(
                 "Invalid Authorization header".to_string(),
             ));
         }
@@ -160,7 +157,7 @@ where
         let claims =
             authkestra_resource::jwt::validate_jwt_generic::<T>(token, &cache, &validation)
                 .await
-                .map_err(|e| AuthEngineAxumError::Unauthorized(format!("Invalid token: {e}")))?;
+                .map_err(|e| Error::Unauthorized(format!("Invalid token: {e}")))?;
 
         Ok(Jwt(claims))
     }
@@ -168,7 +165,7 @@ where
 
 /// A unified extractor for authentication.
 ///
-/// It uses the `AuthEngineGuard` from the application state to validate the request.
+/// It uses the `Guard` from the application state to validate the request.
 #[cfg(feature = "resource")]
 pub struct Auth<I>(pub I);
 
@@ -176,57 +173,57 @@ pub struct Auth<I>(pub I);
 impl<S, I> FromRequestParts<S> for Auth<I>
 where
     S: Send + Sync,
-    Arc<authkestra_resource::AuthEngineGuard<I>>: FromRef<S>,
+    Arc<authkestra_resource::Guard<I>>: FromRef<S>,
     I: Send + Sync + 'static,
 {
-    type Rejection = AuthEngineAxumError;
+    type Rejection = Error;
 
     #[tracing::instrument(skip_all)]
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
         state: &S,
     ) -> Result<Self, Self::Rejection> {
-        tracing::debug!("extracting generic Auth from request via AuthEngineGuard");
-        let guard = Arc::<authkestra_resource::AuthEngineGuard<I>>::from_ref(state);
+        tracing::debug!("extracting generic Auth from request via Guard");
+        let guard = Arc::<authkestra_resource::Guard<I>>::from_ref(state);
         match guard.authenticate(parts).await {
             Ok(Some(identity)) => {
-                tracing::info!("successfully authenticated request via AuthEngineGuard");
+                tracing::info!("successfully authenticated request via Guard");
                 Ok(Auth(identity))
             }
             Ok(None) => {
                 tracing::warn!("authentication failed: no identity returned");
-                Err(AuthEngineAxumError::Unauthorized(
+                Err(Error::Unauthorized(
                     "Authentication failed".to_string(),
                 ))
             }
             Err(e) => {
                 tracing::error!(error = %e, "internal error during authentication");
-                Err(AuthEngineAxumError::Internal(e.to_string()))
+                Err(Error::Internal(e.to_string()))
             }
         }
     }
 }
 
 #[cfg(all(feature = "flow", feature = "session"))]
-pub trait AuthEngineAxumExt<S, T> {
+pub trait AxumExt<S, T> {
     fn axum_router<AppState>(&self) -> axum::Router<AppState>
     where
         AppState: Clone + Send + Sync + 'static,
-        AuthEngine<S, T>: FromRef<AppState>,
+        Engine<S, T>: FromRef<AppState>,
         SessionConfig: FromRef<AppState>,
-        Result<Arc<dyn SessionStore>, AuthEngineAxumError>: FromRef<AppState>;
+        Result<Arc<dyn SessionStore>, Error>: FromRef<AppState>;
 }
 
 #[cfg(all(feature = "flow", feature = "session"))]
-impl<S: Clone + Send + Sync + 'static, T: Clone + Send + Sync + 'static> AuthEngineAxumExt<S, T>
-    for AuthEngine<S, T>
+impl<S: Clone + Send + Sync + 'static, T: Clone + Send + Sync + 'static> AxumExt<S, T>
+    for Engine<S, T>
 {
     fn axum_router<AppState>(&self) -> axum::Router<AppState>
     where
         AppState: Clone + Send + Sync + 'static,
-        AuthEngine<S, T>: FromRef<AppState>,
+        Engine<S, T>: FromRef<AppState>,
         SessionConfig: FromRef<AppState>,
-        Result<Arc<dyn SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
+        Result<Arc<dyn SessionStore>, Error>: FromRef<AppState>,
     {
         use axum::routing::get;
         axum::Router::new()

--- a/crates/authkestra-axum/src/lib.rs
+++ b/crates/authkestra-axum/src/lib.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "token")]
 pub use authkestra_engine::TokenManager;
 #[cfg(feature = "flow")]
-pub use authkestra_engine::{AkBase, Missing, SessionConfig};
+pub use authkestra_engine::{AuthEngine, Missing, SessionConfig};
 #[cfg(feature = "resource")]
-pub use authkestra_resource::AkResourceGuard;
+pub use authkestra_resource::AuthEngineGuard;
 #[allow(unused_imports)]
 use axum::extract::FromRef;
 #[cfg(feature = "session")]
@@ -16,12 +16,17 @@ pub mod helpers;
 #[cfg(feature = "op")]
 pub mod op;
 
-pub use helpers::AkAxumError;
+pub use helpers::AuthEngineAxumError;
 #[cfg(feature = "session")]
 pub use helpers::{Session, SessionStore};
 
 #[cfg(feature = "op")]
-pub use op::AkAxumOpExt;
+pub use op::AuthEngineAxumOpExt;
+
+// Keep for backwards compatibility if needed
+pub type AuthkestraAxumError = AuthEngineAxumError;
+#[cfg(all(feature = "flow", feature = "session"))]
+pub use AuthEngineAxumExt as AuthkestraAxumExt;
 
 #[cfg(feature = "macros")]
 extern crate self as authkestra_axum;
@@ -31,14 +36,14 @@ pub use authkestra_macros::AuthkestraState;
 
 #[cfg(feature = "flow")]
 #[derive(Clone, AuthkestraState)]
-pub struct AkState<S = Missing, T = Missing> {
+pub struct AuthEngineState<S = Missing, T = Missing> {
     #[authkestra(engine)]
-    pub authkestra: AkBase<S, T>,
+    pub authkestra: AuthEngine<S, T>,
 }
 
 #[cfg(feature = "flow")]
-impl<S, T> From<AkBase<S, T>> for AkState<S, T> {
-    fn from(authkestra: AkBase<S, T>) -> Self {
+impl<S, T> From<AuthEngine<S, T>> for AuthEngineState<S, T> {
+    fn from(authkestra: AuthEngine<S, T>) -> Self {
         Self { authkestra }
     }
 }
@@ -51,10 +56,10 @@ pub struct AuthSession(pub Session);
 impl<S> FromRequestParts<S> for AuthSession
 where
     S: Send + Sync,
-    Result<Arc<dyn SessionStore>, AkAxumError>: FromRef<S>,
+    Result<Arc<dyn SessionStore>, AuthEngineAxumError>: FromRef<S>,
     SessionConfig: FromRef<S>,
 {
-    type Rejection = AkAxumError;
+    type Rejection = AuthEngineAxumError;
 
     #[tracing::instrument(skip_all)]
     async fn from_request_parts(
@@ -63,13 +68,13 @@ where
     ) -> Result<Self, Self::Rejection> {
         use tower_cookies::Cookies;
         tracing::debug!("extracting AuthSession from request");
-        let session_store = <Result<Arc<dyn SessionStore>, AkAxumError>>::from_ref(state)?;
+        let session_store = <Result<Arc<dyn SessionStore>, AuthEngineAxumError>>::from_ref(state)?;
         let session_config = SessionConfig::from_ref(state);
         let cookies = Cookies::from_request_parts(parts, state)
             .await
             .map_err(|e| {
                 tracing::error!(error = %e.1, "failed to extract cookies");
-                AkAxumError::Internal(e.1.to_string())
+                AuthEngineAxumError::Internal(e.1.to_string())
             })?;
 
         let session = helpers::get_session(&session_store, &session_config, &cookies)
@@ -94,9 +99,9 @@ pub struct AuthToken(pub authkestra_engine::Claims);
 impl<S> FromRequestParts<S> for AuthToken
 where
     S: Send + Sync,
-    Result<Arc<TokenManager>, AkAxumError>: FromRef<S>,
+    Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<S>,
 {
-    type Rejection = AkAxumError;
+    type Rejection = AuthEngineAxumError;
 
     #[tracing::instrument(skip_all)]
     async fn from_request_parts(
@@ -104,7 +109,7 @@ where
         state: &S,
     ) -> Result<Self, Self::Rejection> {
         tracing::debug!("extracting AuthToken from request");
-        let token_manager = <Result<Arc<TokenManager>, AkAxumError>>::from_ref(state)?;
+        let token_manager = <Result<Arc<TokenManager>, AuthEngineAxumError>>::from_ref(state)?;
         let token = helpers::get_token(parts, &token_manager)
             .await
             .map_err(|e| {
@@ -130,7 +135,7 @@ where
     jsonwebtoken::Validation: FromRef<S>,
     T: for<'de> serde::Deserialize<'de> + 'static,
 {
-    type Rejection = AkAxumError;
+    type Rejection = AuthEngineAxumError;
 
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
@@ -143,10 +148,10 @@ where
             .headers
             .get(axum::http::header::AUTHORIZATION)
             .and_then(|h| h.to_str().ok())
-            .ok_or_else(|| AkAxumError::Unauthorized("Missing Authorization header".to_string()))?;
+            .ok_or_else(|| AuthEngineAxumError::Unauthorized("Missing Authorization header".to_string()))?;
 
         if !auth_header.starts_with("Bearer ") {
-            return Err(AkAxumError::Unauthorized(
+            return Err(AuthEngineAxumError::Unauthorized(
                 "Invalid Authorization header".to_string(),
             ));
         }
@@ -155,7 +160,7 @@ where
         let claims =
             authkestra_resource::jwt::validate_jwt_generic::<T>(token, &cache, &validation)
                 .await
-                .map_err(|e| AkAxumError::Unauthorized(format!("Invalid token: {e}")))?;
+                .map_err(|e| AuthEngineAxumError::Unauthorized(format!("Invalid token: {e}")))?;
 
         Ok(Jwt(claims))
     }
@@ -163,7 +168,7 @@ where
 
 /// A unified extractor for authentication.
 ///
-/// It uses the `AkResourceGuard` from the application state to validate the request.
+/// It uses the `AuthEngineGuard` from the application state to validate the request.
 #[cfg(feature = "resource")]
 pub struct Auth<I>(pub I);
 
@@ -171,57 +176,57 @@ pub struct Auth<I>(pub I);
 impl<S, I> FromRequestParts<S> for Auth<I>
 where
     S: Send + Sync,
-    Arc<authkestra_resource::AkResourceGuard<I>>: FromRef<S>,
+    Arc<authkestra_resource::AuthEngineGuard<I>>: FromRef<S>,
     I: Send + Sync + 'static,
 {
-    type Rejection = AkAxumError;
+    type Rejection = AuthEngineAxumError;
 
     #[tracing::instrument(skip_all)]
     async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
         state: &S,
     ) -> Result<Self, Self::Rejection> {
-        tracing::debug!("extracting generic Auth from request via AkResourceGuard");
-        let guard = Arc::<authkestra_resource::AkResourceGuard<I>>::from_ref(state);
+        tracing::debug!("extracting generic Auth from request via AuthEngineGuard");
+        let guard = Arc::<authkestra_resource::AuthEngineGuard<I>>::from_ref(state);
         match guard.authenticate(parts).await {
             Ok(Some(identity)) => {
-                tracing::info!("successfully authenticated request via AkResourceGuard");
+                tracing::info!("successfully authenticated request via AuthEngineGuard");
                 Ok(Auth(identity))
             }
             Ok(None) => {
                 tracing::warn!("authentication failed: no identity returned");
-                Err(AkAxumError::Unauthorized(
+                Err(AuthEngineAxumError::Unauthorized(
                     "Authentication failed".to_string(),
                 ))
             }
             Err(e) => {
                 tracing::error!(error = %e, "internal error during authentication");
-                Err(AkAxumError::Internal(e.to_string()))
+                Err(AuthEngineAxumError::Internal(e.to_string()))
             }
         }
     }
 }
 
 #[cfg(all(feature = "flow", feature = "session"))]
-pub trait AkAxumExt<S, T> {
+pub trait AuthEngineAxumExt<S, T> {
     fn axum_router<AppState>(&self) -> axum::Router<AppState>
     where
         AppState: Clone + Send + Sync + 'static,
-        AkBase<S, T>: FromRef<AppState>,
+        AuthEngine<S, T>: FromRef<AppState>,
         SessionConfig: FromRef<AppState>,
-        Result<Arc<dyn SessionStore>, AkAxumError>: FromRef<AppState>;
+        Result<Arc<dyn SessionStore>, AuthEngineAxumError>: FromRef<AppState>;
 }
 
 #[cfg(all(feature = "flow", feature = "session"))]
-impl<S: Clone + Send + Sync + 'static, T: Clone + Send + Sync + 'static> AkAxumExt<S, T>
-    for AkBase<S, T>
+impl<S: Clone + Send + Sync + 'static, T: Clone + Send + Sync + 'static> AuthEngineAxumExt<S, T>
+    for AuthEngine<S, T>
 {
     fn axum_router<AppState>(&self) -> axum::Router<AppState>
     where
         AppState: Clone + Send + Sync + 'static,
-        AkBase<S, T>: FromRef<AppState>,
+        AuthEngine<S, T>: FromRef<AppState>,
         SessionConfig: FromRef<AppState>,
-        Result<Arc<dyn SessionStore>, AkAxumError>: FromRef<AppState>,
+        Result<Arc<dyn SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
     {
         use axum::routing::get;
         axum::Router::new()

--- a/crates/authkestra-axum/src/op.rs
+++ b/crates/authkestra-axum/src/op.rs
@@ -71,8 +71,7 @@ where
     };
     let config = OpConfig::from_ref(&state);
 
-    let session_store = match <Result<Arc<dyn crate::SessionStore>, AxumError>>::from_ref(&state)
-    {
+    let session_store = match <Result<Arc<dyn crate::SessionStore>, AxumError>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
@@ -255,8 +254,7 @@ where
         Err(e) => return e.into_response(),
     };
 
-    let session_store = match <Result<Arc<dyn crate::SessionStore>, AxumError>>::from_ref(&state)
-    {
+    let session_store = match <Result<Arc<dyn crate::SessionStore>, AxumError>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };

--- a/crates/authkestra-axum/src/op.rs
+++ b/crates/authkestra-axum/src/op.rs
@@ -1,4 +1,4 @@
-use crate::AuthEngineAxumError;
+use crate::AkAxumError;
 use authkestra_engine::TokenManager;
 use authkestra_op::{
     config::OpConfig,
@@ -23,9 +23,9 @@ use std::sync::Arc;
 pub async fn axum_jwks_handler<AppState>(State(state): State<AppState>) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<TokenManager>, AkAxumError>: FromRef<AppState>,
 {
-    let token_manager = match <Result<Arc<TokenManager>, AuthEngineAxumError>>::from_ref(&state) {
+    let token_manager = match <Result<Arc<TokenManager>, AkAxumError>>::from_ref(&state) {
         Ok(t) => t,
         Err(e) => return e.into_response(),
     };
@@ -59,21 +59,21 @@ pub async fn axum_authorize_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
-    Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>: FromRef<AppState>,
+    Result<Arc<dyn crate::SessionStore>, AkAxumError>: FromRef<AppState>,
     authkestra_engine::SessionConfig: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!(client_id = %req.client_id, "Handling OP authorize request (axum)");
     let op_store =
-        match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
+        match <Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>>::from_ref(&state) {
             Ok(c) => c,
             Err(e) => return e.into_response(),
         };
     let config = OpConfig::from_ref(&state);
 
     let session_store =
-        match <Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>>::from_ref(&state) {
+        match <Result<Arc<dyn crate::SessionStore>, AkAxumError>>::from_ref(&state) {
             Ok(c) => c,
             Err(e) => return e.into_response(),
         };
@@ -112,12 +112,12 @@ pub async fn axum_device_authorization_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP device authorization request (axum)");
     let op_store =
-        match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
+        match <Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>>::from_ref(&state) {
             Ok(c) => c,
             Err(e) => return e.into_response(),
         };
@@ -147,17 +147,17 @@ pub async fn axum_token_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
-    Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>: FromRef<AppState>,
+    Result<Arc<TokenManager>, AkAxumError>: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!(grant_type = %req.grant_type, "Handling OP token request (axum)");
     let op_store =
-        match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
+        match <Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>>::from_ref(&state) {
             Ok(c) => c,
             Err(e) => return e.into_response(),
         };
-    let tokens = match <Result<Arc<TokenManager>, AuthEngineAxumError>>::from_ref(&state) {
+    let tokens = match <Result<Arc<TokenManager>, AkAxumError>>::from_ref(&state) {
         Ok(t) => t,
         Err(e) => return e.into_response(),
     };
@@ -194,11 +194,11 @@ pub async fn axum_userinfo_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<TokenManager>, AkAxumError>: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP userinfo request (axum)");
-    let tokens = match <Result<Arc<TokenManager>, AuthEngineAxumError>>::from_ref(&state) {
+    let tokens = match <Result<Arc<TokenManager>, AkAxumError>>::from_ref(&state) {
         Ok(t) => t,
         Err(e) => return e.into_response(),
     };
@@ -248,19 +248,19 @@ pub async fn axum_device_verify_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
-    Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>: FromRef<AppState>,
+    Result<Arc<dyn crate::SessionStore>, AkAxumError>: FromRef<AppState>,
     authkestra_engine::SessionConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP device verify request (axum)");
     let op_store =
-        match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
+        match <Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>>::from_ref(&state) {
             Ok(c) => c,
             Err(e) => return e.into_response(),
         };
 
     let session_store =
-        match <Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>>::from_ref(&state) {
+        match <Result<Arc<dyn crate::SessionStore>, AkAxumError>>::from_ref(&state) {
             Ok(c) => c,
             Err(e) => return e.into_response(),
         };
@@ -295,25 +295,25 @@ where
     }
 }
 
-pub trait AuthEngineAxumOpExt {
+pub trait AkAxumOpExt {
     fn op_axum_router<AppState>(&self) -> axum::Router<AppState>
     where
         AppState: Clone + Send + Sync + 'static,
-        Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
-        Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
-        Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
+        Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>: FromRef<AppState>,
+        Result<Arc<TokenManager>, AkAxumError>: FromRef<AppState>,
+        Result<Arc<dyn crate::SessionStore>, AkAxumError>: FromRef<AppState>,
         authkestra_engine::SessionConfig: FromRef<AppState>,
         OpConfig: FromRef<AppState>;
 }
 
-// Implement for any type to allow standalone usage or usage with AuthEngine.
-impl<T> AuthEngineAxumOpExt for T {
+// Implement for any type to allow standalone usage or usage with AkBase.
+impl<T> AkAxumOpExt for T {
     fn op_axum_router<AppState>(&self) -> axum::Router<AppState>
     where
         AppState: Clone + Send + Sync + 'static,
-        Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
-        Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
-        Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
+        Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>: FromRef<AppState>,
+        Result<Arc<TokenManager>, AkAxumError>: FromRef<AppState>,
+        Result<Arc<dyn crate::SessionStore>, AkAxumError>: FromRef<AppState>,
         authkestra_engine::SessionConfig: FromRef<AppState>,
         OpConfig: FromRef<AppState>,
     {

--- a/crates/authkestra-axum/src/op.rs
+++ b/crates/authkestra-axum/src/op.rs
@@ -1,4 +1,4 @@
-use crate::AkAxumError;
+use crate::AuthEngineAxumError;
 use authkestra_engine::TokenManager;
 use authkestra_op::{
     config::OpConfig,
@@ -23,9 +23,9 @@ use std::sync::Arc;
 pub async fn axum_jwks_handler<AppState>(State(state): State<AppState>) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<TokenManager>, AkAxumError>: FromRef<AppState>,
+    Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
 {
-    let token_manager = match <Result<Arc<TokenManager>, AkAxumError>>::from_ref(&state) {
+    let token_manager = match <Result<Arc<TokenManager>, AuthEngineAxumError>>::from_ref(&state) {
         Ok(t) => t,
         Err(e) => return e.into_response(),
     };
@@ -59,19 +59,19 @@ pub async fn axum_authorize_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>: FromRef<AppState>,
-    Result<Arc<dyn crate::SessionStore>, AkAxumError>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
     authkestra_engine::SessionConfig: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!(client_id = %req.client_id, "Handling OP authorize request (axum)");
-    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>>::from_ref(&state) {
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
     let config = OpConfig::from_ref(&state);
 
-    let session_store = match <Result<Arc<dyn crate::SessionStore>, AkAxumError>>::from_ref(&state)
+    let session_store = match <Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>>::from_ref(&state)
     {
         Ok(c) => c,
         Err(e) => return e.into_response(),
@@ -111,11 +111,11 @@ pub async fn axum_device_authorization_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP device authorization request (axum)");
-    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>>::from_ref(&state) {
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
@@ -145,16 +145,16 @@ pub async fn axum_token_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>: FromRef<AppState>,
-    Result<Arc<TokenManager>, AkAxumError>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!(grant_type = %req.grant_type, "Handling OP token request (axum)");
-    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>>::from_ref(&state) {
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
-    let tokens = match <Result<Arc<TokenManager>, AkAxumError>>::from_ref(&state) {
+    let tokens = match <Result<Arc<TokenManager>, AuthEngineAxumError>>::from_ref(&state) {
         Ok(t) => t,
         Err(e) => return e.into_response(),
     };
@@ -191,11 +191,11 @@ pub async fn axum_userinfo_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<TokenManager>, AkAxumError>: FromRef<AppState>,
+    Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP userinfo request (axum)");
-    let tokens = match <Result<Arc<TokenManager>, AkAxumError>>::from_ref(&state) {
+    let tokens = match <Result<Arc<TokenManager>, AuthEngineAxumError>>::from_ref(&state) {
         Ok(t) => t,
         Err(e) => return e.into_response(),
     };
@@ -245,17 +245,17 @@ pub async fn axum_device_verify_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>: FromRef<AppState>,
-    Result<Arc<dyn crate::SessionStore>, AkAxumError>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
     authkestra_engine::SessionConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP device verify request (axum)");
-    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>>::from_ref(&state) {
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
 
-    let session_store = match <Result<Arc<dyn crate::SessionStore>, AkAxumError>>::from_ref(&state)
+    let session_store = match <Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>>::from_ref(&state)
     {
         Ok(c) => c,
         Err(e) => return e.into_response(),
@@ -291,25 +291,25 @@ where
     }
 }
 
-pub trait AkAxumOpExt {
+pub trait AuthEngineAxumOpExt {
     fn op_axum_router<AppState>(&self) -> axum::Router<AppState>
     where
         AppState: Clone + Send + Sync + 'static,
-        Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>: FromRef<AppState>,
-        Result<Arc<TokenManager>, AkAxumError>: FromRef<AppState>,
-        Result<Arc<dyn crate::SessionStore>, AkAxumError>: FromRef<AppState>,
+        Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
+        Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
+        Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
         authkestra_engine::SessionConfig: FromRef<AppState>,
         OpConfig: FromRef<AppState>;
 }
 
-// Implement for any type to allow standalone usage or usage with AkBase.
-impl<T> AkAxumOpExt for T {
+// Implement for any type to allow standalone usage or usage with AuthEngine.
+impl<T> AuthEngineAxumOpExt for T {
     fn op_axum_router<AppState>(&self) -> axum::Router<AppState>
     where
         AppState: Clone + Send + Sync + 'static,
-        Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>: FromRef<AppState>,
-        Result<Arc<TokenManager>, AkAxumError>: FromRef<AppState>,
-        Result<Arc<dyn crate::SessionStore>, AkAxumError>: FromRef<AppState>,
+        Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
+        Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
+        Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
         authkestra_engine::SessionConfig: FromRef<AppState>,
         OpConfig: FromRef<AppState>,
     {

--- a/crates/authkestra-axum/src/op.rs
+++ b/crates/authkestra-axum/src/op.rs
@@ -1,4 +1,4 @@
-use crate::AuthEngineAxumError;
+use crate::Error;
 use authkestra_engine::TokenManager;
 use authkestra_op::{
     config::OpConfig,
@@ -23,9 +23,9 @@ use std::sync::Arc;
 pub async fn axum_jwks_handler<AppState>(State(state): State<AppState>) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<TokenManager>, Error>: FromRef<AppState>,
 {
-    let token_manager = match <Result<Arc<TokenManager>, AuthEngineAxumError>>::from_ref(&state) {
+    let token_manager = match <Result<Arc<TokenManager>, Error>>::from_ref(&state) {
         Ok(t) => t,
         Err(e) => return e.into_response(),
     };
@@ -59,19 +59,19 @@ pub async fn axum_authorize_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
-    Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, Error>: FromRef<AppState>,
+    Result<Arc<dyn crate::SessionStore>, Error>: FromRef<AppState>,
     authkestra_engine::SessionConfig: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!(client_id = %req.client_id, "Handling OP authorize request (axum)");
-    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, Error>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
     let config = OpConfig::from_ref(&state);
 
-    let session_store = match <Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>>::from_ref(&state)
+    let session_store = match <Result<Arc<dyn crate::SessionStore>, Error>>::from_ref(&state)
     {
         Ok(c) => c,
         Err(e) => return e.into_response(),
@@ -111,11 +111,11 @@ pub async fn axum_device_authorization_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, Error>: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP device authorization request (axum)");
-    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, Error>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
@@ -145,16 +145,16 @@ pub async fn axum_token_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
-    Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, Error>: FromRef<AppState>,
+    Result<Arc<TokenManager>, Error>: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!(grant_type = %req.grant_type, "Handling OP token request (axum)");
-    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, Error>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
-    let tokens = match <Result<Arc<TokenManager>, AuthEngineAxumError>>::from_ref(&state) {
+    let tokens = match <Result<Arc<TokenManager>, Error>>::from_ref(&state) {
         Ok(t) => t,
         Err(e) => return e.into_response(),
     };
@@ -191,11 +191,11 @@ pub async fn axum_userinfo_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<TokenManager>, Error>: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP userinfo request (axum)");
-    let tokens = match <Result<Arc<TokenManager>, AuthEngineAxumError>>::from_ref(&state) {
+    let tokens = match <Result<Arc<TokenManager>, Error>>::from_ref(&state) {
         Ok(t) => t,
         Err(e) => return e.into_response(),
     };
@@ -245,17 +245,17 @@ pub async fn axum_device_verify_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
-    Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, Error>: FromRef<AppState>,
+    Result<Arc<dyn crate::SessionStore>, Error>: FromRef<AppState>,
     authkestra_engine::SessionConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP device verify request (axum)");
-    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>>::from_ref(&state) {
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, Error>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
 
-    let session_store = match <Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>>::from_ref(&state)
+    let session_store = match <Result<Arc<dyn crate::SessionStore>, Error>>::from_ref(&state)
     {
         Ok(c) => c,
         Err(e) => return e.into_response(),
@@ -291,25 +291,25 @@ where
     }
 }
 
-pub trait AuthEngineAxumOpExt {
+pub trait OpExt {
     fn op_axum_router<AppState>(&self) -> axum::Router<AppState>
     where
         AppState: Clone + Send + Sync + 'static,
-        Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
-        Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
-        Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
+        Result<Arc<dyn authkestra_op::OpStore>, Error>: FromRef<AppState>,
+        Result<Arc<TokenManager>, Error>: FromRef<AppState>,
+        Result<Arc<dyn crate::SessionStore>, Error>: FromRef<AppState>,
         authkestra_engine::SessionConfig: FromRef<AppState>,
         OpConfig: FromRef<AppState>;
 }
 
-// Implement for any type to allow standalone usage or usage with AuthEngine.
-impl<T> AuthEngineAxumOpExt for T {
+// Implement for any type to allow standalone usage or usage with Engine.
+impl<T> OpExt for T {
     fn op_axum_router<AppState>(&self) -> axum::Router<AppState>
     where
         AppState: Clone + Send + Sync + 'static,
-        Result<Arc<dyn authkestra_op::OpStore>, AuthEngineAxumError>: FromRef<AppState>,
-        Result<Arc<TokenManager>, AuthEngineAxumError>: FromRef<AppState>,
-        Result<Arc<dyn crate::SessionStore>, AuthEngineAxumError>: FromRef<AppState>,
+        Result<Arc<dyn authkestra_op::OpStore>, Error>: FromRef<AppState>,
+        Result<Arc<TokenManager>, Error>: FromRef<AppState>,
+        Result<Arc<dyn crate::SessionStore>, Error>: FromRef<AppState>,
         authkestra_engine::SessionConfig: FromRef<AppState>,
         OpConfig: FromRef<AppState>,
     {

--- a/crates/authkestra-axum/src/op.rs
+++ b/crates/authkestra-axum/src/op.rs
@@ -1,4 +1,4 @@
-use crate::Error;
+use crate::AxumError;
 use authkestra_engine::TokenManager;
 use authkestra_op::{
     config::OpConfig,
@@ -23,9 +23,9 @@ use std::sync::Arc;
 pub async fn axum_jwks_handler<AppState>(State(state): State<AppState>) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<TokenManager>, Error>: FromRef<AppState>,
+    Result<Arc<TokenManager>, AxumError>: FromRef<AppState>,
 {
-    let token_manager = match <Result<Arc<TokenManager>, Error>>::from_ref(&state) {
+    let token_manager = match <Result<Arc<TokenManager>, AxumError>>::from_ref(&state) {
         Ok(t) => t,
         Err(e) => return e.into_response(),
     };
@@ -59,19 +59,19 @@ pub async fn axum_authorize_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn authkestra_op::OpStore>, Error>: FromRef<AppState>,
-    Result<Arc<dyn crate::SessionStore>, Error>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, AxumError>: FromRef<AppState>,
+    Result<Arc<dyn crate::SessionStore>, AxumError>: FromRef<AppState>,
     authkestra_engine::SessionConfig: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!(client_id = %req.client_id, "Handling OP authorize request (axum)");
-    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, Error>>::from_ref(&state) {
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AxumError>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
     let config = OpConfig::from_ref(&state);
 
-    let session_store = match <Result<Arc<dyn crate::SessionStore>, Error>>::from_ref(&state)
+    let session_store = match <Result<Arc<dyn crate::SessionStore>, AxumError>>::from_ref(&state)
     {
         Ok(c) => c,
         Err(e) => return e.into_response(),
@@ -111,11 +111,11 @@ pub async fn axum_device_authorization_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn authkestra_op::OpStore>, Error>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, AxumError>: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP device authorization request (axum)");
-    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, Error>>::from_ref(&state) {
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AxumError>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
@@ -145,16 +145,16 @@ pub async fn axum_token_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn authkestra_op::OpStore>, Error>: FromRef<AppState>,
-    Result<Arc<TokenManager>, Error>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, AxumError>: FromRef<AppState>,
+    Result<Arc<TokenManager>, AxumError>: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!(grant_type = %req.grant_type, "Handling OP token request (axum)");
-    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, Error>>::from_ref(&state) {
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AxumError>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
-    let tokens = match <Result<Arc<TokenManager>, Error>>::from_ref(&state) {
+    let tokens = match <Result<Arc<TokenManager>, AxumError>>::from_ref(&state) {
         Ok(t) => t,
         Err(e) => return e.into_response(),
     };
@@ -191,11 +191,11 @@ pub async fn axum_userinfo_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<TokenManager>, Error>: FromRef<AppState>,
+    Result<Arc<TokenManager>, AxumError>: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP userinfo request (axum)");
-    let tokens = match <Result<Arc<TokenManager>, Error>>::from_ref(&state) {
+    let tokens = match <Result<Arc<TokenManager>, AxumError>>::from_ref(&state) {
         Ok(t) => t,
         Err(e) => return e.into_response(),
     };
@@ -245,17 +245,17 @@ pub async fn axum_device_verify_handler<AppState>(
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
-    Result<Arc<dyn authkestra_op::OpStore>, Error>: FromRef<AppState>,
-    Result<Arc<dyn crate::SessionStore>, Error>: FromRef<AppState>,
+    Result<Arc<dyn authkestra_op::OpStore>, AxumError>: FromRef<AppState>,
+    Result<Arc<dyn crate::SessionStore>, AxumError>: FromRef<AppState>,
     authkestra_engine::SessionConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP device verify request (axum)");
-    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, Error>>::from_ref(&state) {
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AxumError>>::from_ref(&state) {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
 
-    let session_store = match <Result<Arc<dyn crate::SessionStore>, Error>>::from_ref(&state)
+    let session_store = match <Result<Arc<dyn crate::SessionStore>, AxumError>>::from_ref(&state)
     {
         Ok(c) => c,
         Err(e) => return e.into_response(),
@@ -295,9 +295,9 @@ pub trait OpExt {
     fn op_axum_router<AppState>(&self) -> axum::Router<AppState>
     where
         AppState: Clone + Send + Sync + 'static,
-        Result<Arc<dyn authkestra_op::OpStore>, Error>: FromRef<AppState>,
-        Result<Arc<TokenManager>, Error>: FromRef<AppState>,
-        Result<Arc<dyn crate::SessionStore>, Error>: FromRef<AppState>,
+        Result<Arc<dyn authkestra_op::OpStore>, AxumError>: FromRef<AppState>,
+        Result<Arc<TokenManager>, AxumError>: FromRef<AppState>,
+        Result<Arc<dyn crate::SessionStore>, AxumError>: FromRef<AppState>,
         authkestra_engine::SessionConfig: FromRef<AppState>,
         OpConfig: FromRef<AppState>;
 }
@@ -307,9 +307,9 @@ impl<T> OpExt for T {
     fn op_axum_router<AppState>(&self) -> axum::Router<AppState>
     where
         AppState: Clone + Send + Sync + 'static,
-        Result<Arc<dyn authkestra_op::OpStore>, Error>: FromRef<AppState>,
-        Result<Arc<TokenManager>, Error>: FromRef<AppState>,
-        Result<Arc<dyn crate::SessionStore>, Error>: FromRef<AppState>,
+        Result<Arc<dyn authkestra_op::OpStore>, AxumError>: FromRef<AppState>,
+        Result<Arc<TokenManager>, AxumError>: FromRef<AppState>,
+        Result<Arc<dyn crate::SessionStore>, AxumError>: FromRef<AppState>,
         authkestra_engine::SessionConfig: FromRef<AppState>,
         OpConfig: FromRef<AppState>,
     {

--- a/crates/authkestra-axum/src/op.rs
+++ b/crates/authkestra-axum/src/op.rs
@@ -65,18 +65,17 @@ where
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!(client_id = %req.client_id, "Handling OP authorize request (axum)");
-    let op_store =
-        match <Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>>::from_ref(&state) {
-            Ok(c) => c,
-            Err(e) => return e.into_response(),
-        };
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>>::from_ref(&state) {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
     let config = OpConfig::from_ref(&state);
 
-    let session_store =
-        match <Result<Arc<dyn crate::SessionStore>, AkAxumError>>::from_ref(&state) {
-            Ok(c) => c,
-            Err(e) => return e.into_response(),
-        };
+    let session_store = match <Result<Arc<dyn crate::SessionStore>, AkAxumError>>::from_ref(&state)
+    {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
     let session_config = authkestra_engine::SessionConfig::from_ref(&state);
 
     let session_res = crate::helpers::get_session(&session_store, &session_config, &cookies).await;
@@ -116,11 +115,10 @@ where
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP device authorization request (axum)");
-    let op_store =
-        match <Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>>::from_ref(&state) {
-            Ok(c) => c,
-            Err(e) => return e.into_response(),
-        };
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>>::from_ref(&state) {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
     let config = OpConfig::from_ref(&state);
 
     let auth_header = headers
@@ -152,11 +150,10 @@ where
     OpConfig: FromRef<AppState>,
 {
     tracing::debug!(grant_type = %req.grant_type, "Handling OP token request (axum)");
-    let op_store =
-        match <Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>>::from_ref(&state) {
-            Ok(c) => c,
-            Err(e) => return e.into_response(),
-        };
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>>::from_ref(&state) {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
     let tokens = match <Result<Arc<TokenManager>, AkAxumError>>::from_ref(&state) {
         Ok(t) => t,
         Err(e) => return e.into_response(),
@@ -253,17 +250,16 @@ where
     authkestra_engine::SessionConfig: FromRef<AppState>,
 {
     tracing::debug!("Handling OP device verify request (axum)");
-    let op_store =
-        match <Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>>::from_ref(&state) {
-            Ok(c) => c,
-            Err(e) => return e.into_response(),
-        };
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AkAxumError>>::from_ref(&state) {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
 
-    let session_store =
-        match <Result<Arc<dyn crate::SessionStore>, AkAxumError>>::from_ref(&state) {
-            Ok(c) => c,
-            Err(e) => return e.into_response(),
-        };
+    let session_store = match <Result<Arc<dyn crate::SessionStore>, AkAxumError>>::from_ref(&state)
+    {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
     let session_config = authkestra_engine::SessionConfig::from_ref(&state);
 
     let session_res = crate::helpers::get_session(&session_store, &session_config, &cookies).await;

--- a/crates/authkestra-engine/Cargo.toml
+++ b/crates/authkestra-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-engine"
-version = "0.1.2"
+version = "0.2.0"
 edition.workspace = true
 description = "Unified authentication engine for the authkestra framework"
 repository.workspace = true

--- a/crates/authkestra-engine/src/aliases.rs
+++ b/crates/authkestra-engine/src/aliases.rs
@@ -1,16 +1,16 @@
 use crate::auth::SessionStore;
-use crate::engine::{AkBase, Configured, Missing};
+use crate::engine::{AuthEngine, Configured, Missing};
 #[cfg(feature = "token")]
 use crate::token::TokenManager;
 use std::sync::Arc;
 
 /// Authkestra configured for stateful web app sessions.
-pub type AkWebAppEngine = AkBase<Configured<Arc<dyn SessionStore>>, Missing>;
+pub type AkWebAppEngine = AuthEngine<Configured<Arc<dyn SessionStore>>, Missing>;
 
 /// Authkestra configured for stateless API tokens.
 #[cfg(feature = "token")]
-pub type AkApiEngine = AkBase<Missing, Configured<Arc<TokenManager>>>;
+pub type AkApiEngine = AuthEngine<Missing, Configured<Arc<TokenManager>>>;
 
 /// Authkestra configured for both sessions and tokens (e.g. OpenID Connect Provider).
 #[cfg(feature = "token")]
-pub type AkEngine = AkBase<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>;
+pub type AkEngine = AuthEngine<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>;

--- a/crates/authkestra-engine/src/aliases.rs
+++ b/crates/authkestra-engine/src/aliases.rs
@@ -1,16 +1,16 @@
 use crate::auth::SessionStore;
-use crate::engine::{AuthEngine, Configured, Missing};
+use crate::engine::{Engine, Configured, Missing};
 #[cfg(feature = "token")]
 use crate::token::TokenManager;
 use std::sync::Arc;
 
 /// Authkestra configured for stateful web app sessions.
-pub type AkWebAppEngine = AuthEngine<Configured<Arc<dyn SessionStore>>, Missing>;
+pub type AkWebAppEngine = Engine<Configured<Arc<dyn SessionStore>>, Missing>;
 
 /// Authkestra configured for stateless API tokens.
 #[cfg(feature = "token")]
-pub type AkApiEngine = AuthEngine<Missing, Configured<Arc<TokenManager>>>;
+pub type AkApiEngine = Engine<Missing, Configured<Arc<TokenManager>>>;
 
 /// Authkestra configured for both sessions and tokens (e.g. OpenID Connect Provider).
 #[cfg(feature = "token")]
-pub type AkEngine = AuthEngine<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>;
+pub type AkEngine = Engine<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>;

--- a/crates/authkestra-engine/src/aliases.rs
+++ b/crates/authkestra-engine/src/aliases.rs
@@ -1,5 +1,5 @@
 use crate::auth::SessionStore;
-use crate::engine::{Engine, Configured, Missing};
+use crate::engine::{Configured, Engine, Missing};
 #[cfg(feature = "token")]
 use crate::token::TokenManager;
 use std::sync::Arc;

--- a/crates/authkestra-engine/src/aliases.rs
+++ b/crates/authkestra-engine/src/aliases.rs
@@ -1,5 +1,5 @@
-use crate::engine::{AkBase, Configured, Missing};
 use crate::auth::SessionStore;
+use crate::engine::{AkBase, Configured, Missing};
 #[cfg(feature = "token")]
 use crate::token::TokenManager;
 use std::sync::Arc;

--- a/crates/authkestra-engine/src/aliases.rs
+++ b/crates/authkestra-engine/src/aliases.rs
@@ -1,16 +1,16 @@
-use crate::engine::{AuthEngine, Configured, Missing};
+use crate::engine::{AkBase, Configured, Missing};
 use crate::auth::SessionStore;
 #[cfg(feature = "token")]
 use crate::token::TokenManager;
 use std::sync::Arc;
 
 /// Authkestra configured for stateful web app sessions.
-pub type AkWebAppEngine = AuthEngine<Configured<Arc<dyn SessionStore>>, Missing>;
+pub type AkWebAppEngine = AkBase<Configured<Arc<dyn SessionStore>>, Missing>;
 
 /// Authkestra configured for stateless API tokens.
 #[cfg(feature = "token")]
-pub type AkApiEngine = AuthEngine<Missing, Configured<Arc<TokenManager>>>;
+pub type AkApiEngine = AkBase<Missing, Configured<Arc<TokenManager>>>;
 
 /// Authkestra configured for both sessions and tokens (e.g. OpenID Connect Provider).
 #[cfg(feature = "token")]
-pub type AkEngine = AuthEngine<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>;
+pub type AkEngine = AkBase<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>;

--- a/crates/authkestra-engine/src/aliases.rs
+++ b/crates/authkestra-engine/src/aliases.rs
@@ -1,0 +1,16 @@
+use crate::engine::{AuthEngine, Configured, Missing};
+use crate::auth::SessionStore;
+#[cfg(feature = "token")]
+use crate::token::TokenManager;
+use std::sync::Arc;
+
+/// Authkestra configured for stateful web app sessions.
+pub type AkWebAppEngine = AuthEngine<Configured<Arc<dyn SessionStore>>, Missing>;
+
+/// Authkestra configured for stateless API tokens.
+#[cfg(feature = "token")]
+pub type AkApiEngine = AuthEngine<Missing, Configured<Arc<TokenManager>>>;
+
+/// Authkestra configured for both sessions and tokens (e.g. OpenID Connect Provider).
+#[cfg(feature = "token")]
+pub type AkEngine = AuthEngine<Configured<Arc<dyn SessionStore>>, Configured<Arc<TokenManager>>>;

--- a/crates/authkestra-engine/src/engine.rs
+++ b/crates/authkestra-engine/src/engine.rs
@@ -13,7 +13,7 @@ pub struct Missing;
 #[derive(Clone, Debug)]
 pub struct Configured<T>(pub T);
 
-/// Trait for the session store state in the `AkBase`.
+/// Trait for the session store state in the `AuthEngine`.
 pub trait SessionStoreState: Send + Sync + Clone {
     /// Returns the session store if configured.
     fn get_store(&self) -> Arc<dyn SessionStore>;
@@ -25,7 +25,7 @@ impl SessionStoreState for Configured<Arc<dyn SessionStore>> {
     }
 }
 
-/// Trait for the token manager state in the `AkBase`.
+/// Trait for the token manager state in the `AuthEngine`.
 pub trait TokenManagerState: Send + Sync + Clone {
     /// Returns the token manager if configured.
     #[cfg(feature = "token")]
@@ -41,10 +41,10 @@ impl TokenManagerState for Configured<Arc<TokenManager>> {
 
 /// The central orchestrator for Authkestra.
 ///
-/// `AkBase` ties together authentication methods, session management, and flows.
-/// It is constructed using the [`AkEngineBuilder`] which uses the Typestate pattern
+/// `AuthEngine` ties together authentication methods, session management, and flows.
+/// It is constructed using the [`AuthEngineBuilder`] which uses the Typestate pattern
 /// to ensure that certain methods are only available when the necessary components are configured.
-pub struct AkBase<S = Missing, T = Missing> {
+pub struct AuthEngine<S = Missing, T = Missing> {
     /// Map of registered OAuth providers.
     pub providers: HashMap<String, Arc<dyn ErasedOAuthFlow>>,
     /// The session storage backend.
@@ -56,7 +56,7 @@ pub struct AkBase<S = Missing, T = Missing> {
     pub token_manager: T,
 }
 
-impl<S, T> Clone for AkBase<S, T>
+impl<S, T> Clone for AuthEngine<S, T>
 where
     S: Clone,
     T: Clone,
@@ -72,10 +72,10 @@ where
     }
 }
 
-impl AkBase<Missing, Missing> {
-    /// Start building a new `AkBase`.
-    pub fn builder() -> AkEngineBuilder<Missing, Missing> {
-        AkEngineBuilder {
+impl AuthEngine<Missing, Missing> {
+    /// Start building a new `AuthEngine`.
+    pub fn builder() -> AuthEngineBuilder<Missing, Missing> {
+        AuthEngineBuilder {
             providers: HashMap::new(),
             session_store: Missing,
             session_config: SessionConfig::default(),
@@ -85,8 +85,8 @@ impl AkBase<Missing, Missing> {
     }
 }
 
-/// A builder for configuring and creating an [`AkBase`] instance.
-pub struct AkEngineBuilder<S = Missing, T = Missing> {
+/// A builder for configuring and creating an [`AuthEngine`] instance.
+pub struct AuthEngineBuilder<S = Missing, T = Missing> {
     providers: HashMap<String, Arc<dyn ErasedOAuthFlow>>,
     session_store: S,
     session_config: SessionConfig,
@@ -94,7 +94,7 @@ pub struct AkEngineBuilder<S = Missing, T = Missing> {
     token_manager: T,
 }
 
-impl<S, T> AkEngineBuilder<S, T> {
+impl<S, T> AuthEngineBuilder<S, T> {
     /// Register an OAuth provider flow.
     pub fn provider<F>(mut self, flow: F) -> Self
     where
@@ -109,8 +109,8 @@ impl<S, T> AkEngineBuilder<S, T> {
     pub fn session_store(
         self,
         store: Arc<dyn SessionStore>,
-    ) -> AkEngineBuilder<Configured<Arc<dyn SessionStore>>, T> {
-        AkEngineBuilder {
+    ) -> AuthEngineBuilder<Configured<Arc<dyn SessionStore>>, T> {
+        AuthEngineBuilder {
             providers: self.providers,
             session_store: Configured(store),
             session_config: self.session_config,
@@ -124,8 +124,8 @@ impl<S, T> AkEngineBuilder<S, T> {
     pub fn token_manager(
         self,
         manager: Arc<TokenManager>,
-    ) -> AkEngineBuilder<S, Configured<Arc<TokenManager>>> {
-        AkEngineBuilder {
+    ) -> AuthEngineBuilder<S, Configured<Arc<TokenManager>>> {
+        AuthEngineBuilder {
             providers: self.providers,
             session_store: self.session_store,
             session_config: self.session_config,
@@ -135,7 +135,7 @@ impl<S, T> AkEngineBuilder<S, T> {
 
     /// Set the JWT secret for the default token manager.
     #[cfg(feature = "token")]
-    pub fn jwt_secret(self, secret: &[u8]) -> AkEngineBuilder<S, Configured<Arc<TokenManager>>> {
+    pub fn jwt_secret(self, secret: &[u8]) -> AuthEngineBuilder<S, Configured<Arc<TokenManager>>> {
         self.token_manager(Arc::new(TokenManager::new(secret, None)))
     }
 
@@ -145,9 +145,9 @@ impl<S, T> AkEngineBuilder<S, T> {
         self
     }
 
-    /// Build the `AkBase`.
-    pub fn build(self) -> AkBase<S, T> {
-        AkBase {
+    /// Build the `AuthEngine`.
+    pub fn build(self) -> AuthEngine<S, T> {
+        AuthEngine {
             providers: self.providers,
             session_store: self.session_store,
             session_config: self.session_config,
@@ -158,7 +158,7 @@ impl<S, T> AkEngineBuilder<S, T> {
 }
 
 // Methods available only when a session store is present
-impl<T> AkBase<Configured<Arc<dyn SessionStore>>, T> {
+impl<T> AuthEngine<Configured<Arc<dyn SessionStore>>, T> {
     /// Get the session store.
     pub fn session_store(&self) -> Arc<dyn SessionStore> {
         self.session_store.0.clone()
@@ -194,7 +194,7 @@ impl<T> AkBase<Configured<Arc<dyn SessionStore>>, T> {
 }
 
 #[cfg(feature = "token")]
-impl<S> AkBase<S, Configured<Arc<TokenManager>>> {
+impl<S> AuthEngine<S, Configured<Arc<TokenManager>>> {
     /// Get the token manager.
     pub fn token_manager(&self) -> Arc<TokenManager> {
         self.token_manager.0.clone()
@@ -227,7 +227,7 @@ pub trait HasSessionStore {
     fn session_store(&self) -> Arc<dyn SessionStore>;
 }
 
-impl<T> HasSessionStore for AkBase<Configured<Arc<dyn SessionStore>>, T> {
+impl<T> HasSessionStore for AuthEngine<Configured<Arc<dyn SessionStore>>, T> {
     fn session_store(&self) -> Arc<dyn SessionStore> {
         self.session_store.0.clone()
     }
@@ -241,7 +241,7 @@ pub trait HasTokenManager {
 }
 
 #[cfg(feature = "token")]
-impl<S> HasTokenManager for AkBase<S, Configured<Arc<TokenManager>>> {
+impl<S> HasTokenManager for AuthEngine<S, Configured<Arc<TokenManager>>> {
     fn token_manager(&self) -> Arc<TokenManager> {
         self.token_manager.0.clone()
     }

--- a/crates/authkestra-engine/src/engine.rs
+++ b/crates/authkestra-engine/src/engine.rs
@@ -13,7 +13,7 @@ pub struct Missing;
 #[derive(Clone, Debug)]
 pub struct Configured<T>(pub T);
 
-/// Trait for the session store state in the `AuthEngine`.
+/// Trait for the session store state in the `AkBase`.
 pub trait SessionStoreState: Send + Sync + Clone {
     /// Returns the session store if configured.
     fn get_store(&self) -> Arc<dyn SessionStore>;
@@ -25,7 +25,7 @@ impl SessionStoreState for Configured<Arc<dyn SessionStore>> {
     }
 }
 
-/// Trait for the token manager state in the `AuthEngine`.
+/// Trait for the token manager state in the `AkBase`.
 pub trait TokenManagerState: Send + Sync + Clone {
     /// Returns the token manager if configured.
     #[cfg(feature = "token")]
@@ -41,10 +41,10 @@ impl TokenManagerState for Configured<Arc<TokenManager>> {
 
 /// The central orchestrator for Authkestra.
 ///
-/// `AuthEngine` ties together authentication methods, session management, and flows.
-/// It is constructed using the [`AuthEngineBuilder`] which uses the Typestate pattern
+/// `AkBase` ties together authentication methods, session management, and flows.
+/// It is constructed using the [`AkEngineBuilder`] which uses the Typestate pattern
 /// to ensure that certain methods are only available when the necessary components are configured.
-pub struct AuthEngine<S = Missing, T = Missing> {
+pub struct AkBase<S = Missing, T = Missing> {
     /// Map of registered OAuth providers.
     pub providers: HashMap<String, Arc<dyn ErasedOAuthFlow>>,
     /// The session storage backend.
@@ -56,7 +56,7 @@ pub struct AuthEngine<S = Missing, T = Missing> {
     pub token_manager: T,
 }
 
-impl<S, T> Clone for AuthEngine<S, T>
+impl<S, T> Clone for AkBase<S, T>
 where
     S: Clone,
     T: Clone,
@@ -72,10 +72,10 @@ where
     }
 }
 
-impl AuthEngine<Missing, Missing> {
-    /// Start building a new `AuthEngine`.
-    pub fn builder() -> AuthEngineBuilder<Missing, Missing> {
-        AuthEngineBuilder {
+impl AkBase<Missing, Missing> {
+    /// Start building a new `AkBase`.
+    pub fn builder() -> AkEngineBuilder<Missing, Missing> {
+        AkEngineBuilder {
             providers: HashMap::new(),
             session_store: Missing,
             session_config: SessionConfig::default(),
@@ -85,8 +85,8 @@ impl AuthEngine<Missing, Missing> {
     }
 }
 
-/// A builder for configuring and creating an [`AuthEngine`] instance.
-pub struct AuthEngineBuilder<S = Missing, T = Missing> {
+/// A builder for configuring and creating an [`AkBase`] instance.
+pub struct AkEngineBuilder<S = Missing, T = Missing> {
     providers: HashMap<String, Arc<dyn ErasedOAuthFlow>>,
     session_store: S,
     session_config: SessionConfig,
@@ -94,7 +94,7 @@ pub struct AuthEngineBuilder<S = Missing, T = Missing> {
     token_manager: T,
 }
 
-impl<S, T> AuthEngineBuilder<S, T> {
+impl<S, T> AkEngineBuilder<S, T> {
     /// Register an OAuth provider flow.
     pub fn provider<F>(mut self, flow: F) -> Self
     where
@@ -109,8 +109,8 @@ impl<S, T> AuthEngineBuilder<S, T> {
     pub fn session_store(
         self,
         store: Arc<dyn SessionStore>,
-    ) -> AuthEngineBuilder<Configured<Arc<dyn SessionStore>>, T> {
-        AuthEngineBuilder {
+    ) -> AkEngineBuilder<Configured<Arc<dyn SessionStore>>, T> {
+        AkEngineBuilder {
             providers: self.providers,
             session_store: Configured(store),
             session_config: self.session_config,
@@ -124,8 +124,8 @@ impl<S, T> AuthEngineBuilder<S, T> {
     pub fn token_manager(
         self,
         manager: Arc<TokenManager>,
-    ) -> AuthEngineBuilder<S, Configured<Arc<TokenManager>>> {
-        AuthEngineBuilder {
+    ) -> AkEngineBuilder<S, Configured<Arc<TokenManager>>> {
+        AkEngineBuilder {
             providers: self.providers,
             session_store: self.session_store,
             session_config: self.session_config,
@@ -135,7 +135,7 @@ impl<S, T> AuthEngineBuilder<S, T> {
 
     /// Set the JWT secret for the default token manager.
     #[cfg(feature = "token")]
-    pub fn jwt_secret(self, secret: &[u8]) -> AuthEngineBuilder<S, Configured<Arc<TokenManager>>> {
+    pub fn jwt_secret(self, secret: &[u8]) -> AkEngineBuilder<S, Configured<Arc<TokenManager>>> {
         self.token_manager(Arc::new(TokenManager::new(secret, None)))
     }
 
@@ -145,9 +145,9 @@ impl<S, T> AuthEngineBuilder<S, T> {
         self
     }
 
-    /// Build the `AuthEngine`.
-    pub fn build(self) -> AuthEngine<S, T> {
-        AuthEngine {
+    /// Build the `AkBase`.
+    pub fn build(self) -> AkBase<S, T> {
+        AkBase {
             providers: self.providers,
             session_store: self.session_store,
             session_config: self.session_config,
@@ -158,7 +158,7 @@ impl<S, T> AuthEngineBuilder<S, T> {
 }
 
 // Methods available only when a session store is present
-impl<T> AuthEngine<Configured<Arc<dyn SessionStore>>, T> {
+impl<T> AkBase<Configured<Arc<dyn SessionStore>>, T> {
     /// Get the session store.
     pub fn session_store(&self) -> Arc<dyn SessionStore> {
         self.session_store.0.clone()
@@ -194,7 +194,7 @@ impl<T> AuthEngine<Configured<Arc<dyn SessionStore>>, T> {
 }
 
 #[cfg(feature = "token")]
-impl<S> AuthEngine<S, Configured<Arc<TokenManager>>> {
+impl<S> AkBase<S, Configured<Arc<TokenManager>>> {
     /// Get the token manager.
     pub fn token_manager(&self) -> Arc<TokenManager> {
         self.token_manager.0.clone()
@@ -227,7 +227,7 @@ pub trait HasSessionStore {
     fn session_store(&self) -> Arc<dyn SessionStore>;
 }
 
-impl<T> HasSessionStore for AuthEngine<Configured<Arc<dyn SessionStore>>, T> {
+impl<T> HasSessionStore for AkBase<Configured<Arc<dyn SessionStore>>, T> {
     fn session_store(&self) -> Arc<dyn SessionStore> {
         self.session_store.0.clone()
     }
@@ -241,7 +241,7 @@ pub trait HasTokenManager {
 }
 
 #[cfg(feature = "token")]
-impl<S> HasTokenManager for AuthEngine<S, Configured<Arc<TokenManager>>> {
+impl<S> HasTokenManager for AkBase<S, Configured<Arc<TokenManager>>> {
     fn token_manager(&self) -> Arc<TokenManager> {
         self.token_manager.0.clone()
     }

--- a/crates/authkestra-engine/src/engine.rs
+++ b/crates/authkestra-engine/src/engine.rs
@@ -247,27 +247,4 @@ impl<S> HasTokenManager for AuthEngine<S, Configured<Arc<TokenManager>>> {
     }
 }
 
-/// Marker for a configured session store.
-pub type HasSessionStoreMarker = Configured<Arc<dyn SessionStore>>;
-/// Marker for a missing session store.
-pub type NoSessionStoreMarker = Missing;
 
-#[cfg(feature = "token")]
-/// Marker for a configured token manager.
-pub type HasTokenManagerMarker = Configured<Arc<TokenManager>>;
-#[cfg(feature = "token")]
-/// Marker for a missing token manager.
-pub type NoTokenManagerMarker = Missing;
-
-/// Authkestra with session support only.
-pub type StatefulAuthEngine = AuthEngine<HasSessionStoreMarker, Missing>;
-pub type StatefullAuthkestra = StatefulAuthEngine;
-
-#[cfg(feature = "token")]
-/// Authkestra with token support only.
-pub type StatelessAuthEngine = AuthEngine<Missing, HasTokenManagerMarker>;
-#[cfg(feature = "token")]
-pub type StatelessAuthkestra = StatelessAuthEngine;
-
-/// Deprecated alias for `AuthEngine`.
-pub type Authkestra<S = Missing, T = Missing> = AuthEngine<S, T>;

--- a/crates/authkestra-engine/src/engine.rs
+++ b/crates/authkestra-engine/src/engine.rs
@@ -13,7 +13,7 @@ pub struct Missing;
 #[derive(Clone, Debug)]
 pub struct Configured<T>(pub T);
 
-/// Trait for the session store state in the `AuthEngine`.
+/// Trait for the session store state in the `Engine`.
 pub trait SessionStoreState: Send + Sync + Clone {
     /// Returns the session store if configured.
     fn get_store(&self) -> Arc<dyn SessionStore>;
@@ -25,7 +25,7 @@ impl SessionStoreState for Configured<Arc<dyn SessionStore>> {
     }
 }
 
-/// Trait for the token manager state in the `AuthEngine`.
+/// Trait for the token manager state in the `Engine`.
 pub trait TokenManagerState: Send + Sync + Clone {
     /// Returns the token manager if configured.
     #[cfg(feature = "token")]
@@ -41,10 +41,10 @@ impl TokenManagerState for Configured<Arc<TokenManager>> {
 
 /// The central orchestrator for Authkestra.
 ///
-/// `AuthEngine` ties together authentication methods, session management, and flows.
-/// It is constructed using the [`AuthEngineBuilder`] which uses the Typestate pattern
+/// `Engine` ties together authentication methods, session management, and flows.
+/// It is constructed using the [`EngineBuilder`] which uses the Typestate pattern
 /// to ensure that certain methods are only available when the necessary components are configured.
-pub struct AuthEngine<S = Missing, T = Missing> {
+pub struct Engine<S = Missing, T = Missing> {
     /// Map of registered OAuth providers.
     pub providers: HashMap<String, Arc<dyn ErasedOAuthFlow>>,
     /// The session storage backend.
@@ -56,7 +56,7 @@ pub struct AuthEngine<S = Missing, T = Missing> {
     pub token_manager: T,
 }
 
-impl<S, T> Clone for AuthEngine<S, T>
+impl<S, T> Clone for Engine<S, T>
 where
     S: Clone,
     T: Clone,
@@ -72,10 +72,10 @@ where
     }
 }
 
-impl AuthEngine<Missing, Missing> {
-    /// Start building a new `AuthEngine`.
-    pub fn builder() -> AuthEngineBuilder<Missing, Missing> {
-        AuthEngineBuilder {
+impl Engine<Missing, Missing> {
+    /// Start building a new `Engine`.
+    pub fn builder() -> EngineBuilder<Missing, Missing> {
+        EngineBuilder {
             providers: HashMap::new(),
             session_store: Missing,
             session_config: SessionConfig::default(),
@@ -85,8 +85,8 @@ impl AuthEngine<Missing, Missing> {
     }
 }
 
-/// A builder for configuring and creating an [`AuthEngine`] instance.
-pub struct AuthEngineBuilder<S = Missing, T = Missing> {
+/// A builder for configuring and creating an [`Engine`] instance.
+pub struct EngineBuilder<S = Missing, T = Missing> {
     providers: HashMap<String, Arc<dyn ErasedOAuthFlow>>,
     session_store: S,
     session_config: SessionConfig,
@@ -94,7 +94,7 @@ pub struct AuthEngineBuilder<S = Missing, T = Missing> {
     token_manager: T,
 }
 
-impl<S, T> AuthEngineBuilder<S, T> {
+impl<S, T> EngineBuilder<S, T> {
     /// Register an OAuth provider flow.
     pub fn provider<F>(mut self, flow: F) -> Self
     where
@@ -109,8 +109,8 @@ impl<S, T> AuthEngineBuilder<S, T> {
     pub fn session_store(
         self,
         store: Arc<dyn SessionStore>,
-    ) -> AuthEngineBuilder<Configured<Arc<dyn SessionStore>>, T> {
-        AuthEngineBuilder {
+    ) -> EngineBuilder<Configured<Arc<dyn SessionStore>>, T> {
+        EngineBuilder {
             providers: self.providers,
             session_store: Configured(store),
             session_config: self.session_config,
@@ -124,8 +124,8 @@ impl<S, T> AuthEngineBuilder<S, T> {
     pub fn token_manager(
         self,
         manager: Arc<TokenManager>,
-    ) -> AuthEngineBuilder<S, Configured<Arc<TokenManager>>> {
-        AuthEngineBuilder {
+    ) -> EngineBuilder<S, Configured<Arc<TokenManager>>> {
+        EngineBuilder {
             providers: self.providers,
             session_store: self.session_store,
             session_config: self.session_config,
@@ -135,7 +135,7 @@ impl<S, T> AuthEngineBuilder<S, T> {
 
     /// Set the JWT secret for the default token manager.
     #[cfg(feature = "token")]
-    pub fn jwt_secret(self, secret: &[u8]) -> AuthEngineBuilder<S, Configured<Arc<TokenManager>>> {
+    pub fn jwt_secret(self, secret: &[u8]) -> EngineBuilder<S, Configured<Arc<TokenManager>>> {
         self.token_manager(Arc::new(TokenManager::new(secret, None)))
     }
 
@@ -145,9 +145,9 @@ impl<S, T> AuthEngineBuilder<S, T> {
         self
     }
 
-    /// Build the `AuthEngine`.
-    pub fn build(self) -> AuthEngine<S, T> {
-        AuthEngine {
+    /// Build the `Engine`.
+    pub fn build(self) -> Engine<S, T> {
+        Engine {
             providers: self.providers,
             session_store: self.session_store,
             session_config: self.session_config,
@@ -158,7 +158,7 @@ impl<S, T> AuthEngineBuilder<S, T> {
 }
 
 // Methods available only when a session store is present
-impl<T> AuthEngine<Configured<Arc<dyn SessionStore>>, T> {
+impl<T> Engine<Configured<Arc<dyn SessionStore>>, T> {
     /// Get the session store.
     pub fn session_store(&self) -> Arc<dyn SessionStore> {
         self.session_store.0.clone()
@@ -194,7 +194,7 @@ impl<T> AuthEngine<Configured<Arc<dyn SessionStore>>, T> {
 }
 
 #[cfg(feature = "token")]
-impl<S> AuthEngine<S, Configured<Arc<TokenManager>>> {
+impl<S> Engine<S, Configured<Arc<TokenManager>>> {
     /// Get the token manager.
     pub fn token_manager(&self) -> Arc<TokenManager> {
         self.token_manager.0.clone()
@@ -227,7 +227,7 @@ pub trait HasSessionStore {
     fn session_store(&self) -> Arc<dyn SessionStore>;
 }
 
-impl<T> HasSessionStore for AuthEngine<Configured<Arc<dyn SessionStore>>, T> {
+impl<T> HasSessionStore for Engine<Configured<Arc<dyn SessionStore>>, T> {
     fn session_store(&self) -> Arc<dyn SessionStore> {
         self.session_store.0.clone()
     }
@@ -241,7 +241,7 @@ pub trait HasTokenManager {
 }
 
 #[cfg(feature = "token")]
-impl<S> HasTokenManager for AuthEngine<S, Configured<Arc<TokenManager>>> {
+impl<S> HasTokenManager for Engine<S, Configured<Arc<TokenManager>>> {
     fn token_manager(&self) -> Arc<TokenManager> {
         self.token_manager.0.clone()
     }

--- a/crates/authkestra-engine/src/engine.rs
+++ b/crates/authkestra-engine/src/engine.rs
@@ -246,5 +246,3 @@ impl<S> HasTokenManager for AkBase<S, Configured<Arc<TokenManager>>> {
         self.token_manager.0.clone()
     }
 }
-
-

--- a/crates/authkestra-engine/src/flow/mod.rs
+++ b/crates/authkestra-engine/src/flow/mod.rs
@@ -52,7 +52,7 @@ pub trait Flow: Send + Sync {
 
 use std::collections::HashMap;
 
-pub use crate::engine::{AkBase, AkEngineBuilder, Configured, Missing};
+pub use crate::engine::{AuthEngine, AuthEngineBuilder, Configured, Missing};
 
 /// Client Credentials flow implementation.
 pub mod client_credentials_flow;

--- a/crates/authkestra-engine/src/flow/mod.rs
+++ b/crates/authkestra-engine/src/flow/mod.rs
@@ -52,7 +52,7 @@ pub trait Flow: Send + Sync {
 
 use std::collections::HashMap;
 
-pub use crate::engine::{AuthEngine, AuthEngineBuilder, Configured, Missing};
+pub use crate::engine::{Engine, EngineBuilder, Configured, Missing};
 
 /// Client Credentials flow implementation.
 pub mod client_credentials_flow;

--- a/crates/authkestra-engine/src/flow/mod.rs
+++ b/crates/authkestra-engine/src/flow/mod.rs
@@ -53,8 +53,7 @@ pub trait Flow: Send + Sync {
 use std::collections::HashMap;
 
 pub use crate::engine::{
-    AuthEngine, AuthEngineBuilder, Authkestra, Configured, Missing, StatefulAuthEngine,
-    StatelessAuthEngine,
+    AuthEngine, AuthEngineBuilder, Configured, Missing,
 };
 
 /// Client Credentials flow implementation.

--- a/crates/authkestra-engine/src/flow/mod.rs
+++ b/crates/authkestra-engine/src/flow/mod.rs
@@ -52,7 +52,7 @@ pub trait Flow: Send + Sync {
 
 use std::collections::HashMap;
 
-pub use crate::engine::{Engine, EngineBuilder, Configured, Missing};
+pub use crate::engine::{Configured, Engine, EngineBuilder, Missing};
 
 /// Client Credentials flow implementation.
 pub mod client_credentials_flow;

--- a/crates/authkestra-engine/src/flow/mod.rs
+++ b/crates/authkestra-engine/src/flow/mod.rs
@@ -52,9 +52,7 @@ pub trait Flow: Send + Sync {
 
 use std::collections::HashMap;
 
-pub use crate::engine::{
-    AkBase, AkEngineBuilder, Configured, Missing,
-};
+pub use crate::engine::{AkBase, AkEngineBuilder, Configured, Missing};
 
 /// Client Credentials flow implementation.
 pub mod client_credentials_flow;

--- a/crates/authkestra-engine/src/flow/mod.rs
+++ b/crates/authkestra-engine/src/flow/mod.rs
@@ -53,7 +53,7 @@ pub trait Flow: Send + Sync {
 use std::collections::HashMap;
 
 pub use crate::engine::{
-    AuthEngine, AuthEngineBuilder, Configured, Missing,
+    AkBase, AkEngineBuilder, Configured, Missing,
 };
 
 /// Client Credentials flow implementation.

--- a/crates/authkestra-engine/src/lib.rs
+++ b/crates/authkestra-engine/src/lib.rs
@@ -7,11 +7,11 @@ pub mod token;
 
 pub mod aliases;
 
+pub use aliases::*;
 pub use auth::*;
 pub use engine::*;
 pub use flow::*;
 pub use token::*;
-pub use aliases::*;
 
 #[cfg(test)]
 mod tests;

--- a/crates/authkestra-engine/src/lib.rs
+++ b/crates/authkestra-engine/src/lib.rs
@@ -5,10 +5,13 @@ pub mod protocol;
 pub mod store;
 pub mod token;
 
+pub mod aliases;
+
 pub use auth::*;
 pub use engine::*;
 pub use flow::*;
 pub use token::*;
+pub use aliases::*;
 
 #[cfg(test)]
 mod tests;

--- a/crates/authkestra-engine/src/tests.rs
+++ b/crates/authkestra-engine/src/tests.rs
@@ -64,7 +64,6 @@ impl SessionStore for MockSessionStore {
     }
 }
 
-
 #[tokio::test]
 async fn test_auth_method_mock() {
     let method = MockAuthMethod;
@@ -95,8 +94,6 @@ async fn test_flow_mock() {
         panic!("Expected FlowResult::Complete");
     }
 }
-
-
 
 #[tokio::test]
 async fn test_session_store_mock() {

--- a/crates/authkestra-engine/src/tests.rs
+++ b/crates/authkestra-engine/src/tests.rs
@@ -107,14 +107,14 @@ async fn test_session_store_mock() {
 
 #[test]
 fn test_auth_engine_builder_typestate() {
-    use crate::engine::AuthEngine;
+    use crate::engine::AkBase;
     use std::sync::Arc;
 
-    let builder = AuthEngine::builder();
+    let builder = AkBase::builder();
     let _engine = builder.build();
 
     let store = MockSessionStore;
-    let engine_with_session = AuthEngine::builder().session_store(Arc::new(store)).build();
+    let engine_with_session = AkBase::builder().session_store(Arc::new(store)).build();
 
     let _s = engine_with_session.session_store();
 }

--- a/crates/authkestra-engine/src/tests.rs
+++ b/crates/authkestra-engine/src/tests.rs
@@ -1,7 +1,6 @@
 use crate::auth::session::{Session, SessionStore};
 use crate::auth::{AuthError, AuthInput, AuthMethod, Identity, Provider, ProviderConfig};
 use crate::flow::{Flow, FlowContext, FlowResult};
-use crate::token::TokenService;
 use async_trait::async_trait;
 use std::collections::HashMap;
 
@@ -65,26 +64,6 @@ impl SessionStore for MockSessionStore {
     }
 }
 
-struct MockTokenService;
-#[async_trait]
-impl TokenService for MockTokenService {
-    async fn issue(
-        &self,
-        _identity: &Identity,
-        _expires_in_secs: u64,
-    ) -> Result<String, AuthError> {
-        Ok("mock-token".to_string())
-    }
-    async fn verify(&self, _token: &str) -> Result<Identity, AuthError> {
-        Ok(Identity {
-            provider_id: "mock".to_string(),
-            external_id: "user123".to_string(),
-            email: Some("mock@example.com".to_string()),
-            username: Some("Mock User".to_string()),
-            attributes: HashMap::new(),
-        })
-    }
-}
 
 #[tokio::test]
 async fn test_auth_method_mock() {
@@ -117,21 +96,7 @@ async fn test_flow_mock() {
     }
 }
 
-#[tokio::test]
-async fn test_token_service_mock() {
-    let service = MockTokenService;
-    let identity = Identity {
-        provider_id: "mock".to_string(),
-        external_id: "user123".to_string(),
-        email: None,
-        username: None,
-        attributes: HashMap::new(),
-    };
-    let token = service.issue(&identity, 3600).await.unwrap();
-    assert_eq!(token, "mock-token");
-    let verified = service.verify(&token).await.unwrap();
-    assert_eq!(verified.external_id, "user123");
-}
+
 
 #[tokio::test]
 async fn test_session_store_mock() {

--- a/crates/authkestra-engine/src/tests.rs
+++ b/crates/authkestra-engine/src/tests.rs
@@ -104,14 +104,14 @@ async fn test_session_store_mock() {
 
 #[test]
 fn test_auth_engine_builder_typestate() {
-    use crate::engine::AuthEngine;
+    use crate::engine::Engine;
     use std::sync::Arc;
 
-    let builder = AuthEngine::builder();
+    let builder = Engine::builder();
     let _engine = builder.build();
 
     let store = MockSessionStore;
-    let engine_with_session = AuthEngine::builder().session_store(Arc::new(store)).build();
+    let engine_with_session = Engine::builder().session_store(Arc::new(store)).build();
 
     let _s = engine_with_session.session_store();
 }

--- a/crates/authkestra-engine/src/tests.rs
+++ b/crates/authkestra-engine/src/tests.rs
@@ -104,14 +104,14 @@ async fn test_session_store_mock() {
 
 #[test]
 fn test_auth_engine_builder_typestate() {
-    use crate::engine::AkBase;
+    use crate::engine::AuthEngine;
     use std::sync::Arc;
 
-    let builder = AkBase::builder();
+    let builder = AuthEngine::builder();
     let _engine = builder.build();
 
     let store = MockSessionStore;
-    let engine_with_session = AkBase::builder().session_store(Arc::new(store)).build();
+    let engine_with_session = AuthEngine::builder().session_store(Arc::new(store)).build();
 
     let _s = engine_with_session.session_store();
 }

--- a/crates/authkestra-engine/src/token/mod.rs
+++ b/crates/authkestra-engine/src/token/mod.rs
@@ -4,8 +4,6 @@ use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Claims {
     // Standard OIDC claims
@@ -233,8 +231,6 @@ impl TokenManager {
         Ok(token_data.claims)
     }
 }
-
-
 
 #[cfg(test)]
 mod tests {

--- a/crates/authkestra-engine/src/token/mod.rs
+++ b/crates/authkestra-engine/src/token/mod.rs
@@ -1,19 +1,10 @@
 use crate::auth::{error::AuthError, state::Identity};
-use async_trait::async_trait;
+
 use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-/// Interface for issuing and verifying tokens.
-/// This can be implemented by JWT-based services, opaque token services, etc.
-#[async_trait]
-pub trait TokenService: Send + Sync {
-    /// Issues a new token for the given identity.
-    async fn issue(&self, identity: &Identity, expires_in_secs: u64) -> Result<String, AuthError>;
 
-    /// Verifies a token and returns the associated identity.
-    async fn verify(&self, token: &str) -> Result<Identity, AuthError>;
-}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Claims {
@@ -243,19 +234,7 @@ impl TokenManager {
     }
 }
 
-#[async_trait]
-impl TokenService for TokenManager {
-    async fn issue(&self, identity: &Identity, expires_in_secs: u64) -> Result<String, AuthError> {
-        self.issue_user_token(identity.clone(), expires_in_secs, None, None)
-    }
 
-    async fn verify(&self, token: &str) -> Result<Identity, AuthError> {
-        let claims = self.validate_token(token, None)?;
-        claims
-            .identity
-            .ok_or_else(|| AuthError::Token("No identity in token".to_string()))
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/authkestra-macros/Cargo.toml
+++ b/crates/authkestra-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-macros"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors = ["Authkestra Contributors"]
 license.workspace = true

--- a/crates/authkestra-macros/README.md
+++ b/crates/authkestra-macros/README.md
@@ -38,9 +38,9 @@ struct AppState {
 
 This macro eliminates the need to manually implement `FromRef` for:
 - `Authkestra<S, T>`
-- `Result<Arc<dyn SessionStore>, AuthkestraAxumError>` (if sessions are configured)
+- `Result<Arc<dyn SessionStore>, AkAxumError>` (if sessions are configured)
 - `SessionConfig`
-- `Result<Arc<TokenManager>, AuthkestraAxumError>` (if tokens are configured)
+- `Result<Arc<TokenManager>, AkAxumError>` (if tokens are configured)
 
 ## Part of authkestra
 

--- a/crates/authkestra-macros/README.md
+++ b/crates/authkestra-macros/README.md
@@ -6,7 +6,7 @@ This crate provides procedural macros to eliminate boilerplate code when integra
 
 ## Features
 
-- **AuthkestraFromRef**: A derive macro that automatically generates the 4 required `FromRef` trait implementations for Axum.
+- **FromRef**: A derive macro that automatically generates the 4 required `FromRef` trait implementations for Axum.
 
 ## Usage
 
@@ -17,18 +17,18 @@ Add this to your `Cargo.toml`:
 authkestra-macros = "0.1.0"
 ```
 
-### AuthkestraFromRef
+### FromRef
 
-The `AuthkestraFromRef` macro is designed to work with the `Authkestra<S, T>` type from `authkestra-flow`. It automatically implements `FromRef` for the state, the session store, the session config, and the token manager.
+The `FromRef` macro is designed to work with the `Authkestra<S, T>` type from `authkestra-flow`. It automatically implements `FromRef` for the state, the session store, the session config, and the token manager.
 
 ```rust
-use authkestra_axum::AuthkestraFromRef;
+use authkestra_axum::FromRef;
 use authkestra::flow::Authkestra;
 use authkestra_flow::{Configured, Missing};
 use authkestra_session::SessionStore;
 use std::sync::Arc;
 
-#[derive(Clone, AuthkestraFromRef)]
+#[derive(Clone, FromRef)]
 struct AppState {
     #[authkestra]
     auth: Authkestra<Configured<Arc<dyn SessionStore>>, Missing>,
@@ -38,9 +38,9 @@ struct AppState {
 
 This macro eliminates the need to manually implement `FromRef` for:
 - `Authkestra<S, T>`
-- `Result<Arc<dyn SessionStore>, AuthEngineAxumError>` (if sessions are configured)
+- `Result<Arc<dyn SessionStore>, Error>` (if sessions are configured)
 - `SessionConfig`
-- `Result<Arc<TokenManager>, AuthEngineAxumError>` (if tokens are configured)
+- `Result<Arc<TokenManager>, Error>` (if tokens are configured)
 
 ## Part of authkestra
 

--- a/crates/authkestra-macros/README.md
+++ b/crates/authkestra-macros/README.md
@@ -38,9 +38,9 @@ struct AppState {
 
 This macro eliminates the need to manually implement `FromRef` for:
 - `Authkestra<S, T>`
-- `Result<Arc<dyn SessionStore>, AkAxumError>` (if sessions are configured)
+- `Result<Arc<dyn SessionStore>, AuthEngineAxumError>` (if sessions are configured)
 - `SessionConfig`
-- `Result<Arc<TokenManager>, AkAxumError>` (if tokens are configured)
+- `Result<Arc<TokenManager>, AuthEngineAxumError>` (if tokens are configured)
 
 ## Part of authkestra
 

--- a/crates/authkestra-macros/src/axum.rs
+++ b/crates/authkestra-macros/src/axum.rs
@@ -41,25 +41,17 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
             Fields::Named(fields) => {
                 for field in &fields.named {
                     for attr in &field.attrs {
-                        let is_legacy = attr.path().is_ident("auth_engine");
                         let is_authkestra = attr.path().is_ident("authkestra");
 
-                        if is_legacy {
-                            engine_field = Some(field);
-                        } else if is_authkestra {
-                            if let syn::Meta::Path(_) = attr.meta {
-                                // Backward compatibility: #[authkestra] implies engine
-                                engine_field = Some(field);
-                            } else {
-                                let _ = attr.parse_nested_meta(|meta| {
-                                    if meta.path.is_ident("engine") {
-                                        engine_field = Some(field);
-                                    } else if meta.path.is_ident("store") {
-                                        store_fields.push(field);
-                                    }
-                                    Ok(())
-                                });
-                            }
+                        if is_authkestra {
+                            let _ = attr.parse_nested_meta(|meta| {
+                                if meta.path.is_ident("engine") {
+                                    engine_field = Some(field);
+                                } else if meta.path.is_ident("store") {
+                                    store_fields.push(field);
+                                }
+                                Ok(())
+                            });
                         }
                     }
                 }
@@ -109,7 +101,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                         syn::parse_quote!(authkestra_engine::Configured<::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>>),
                         syn::parse_quote!(authkestra_engine::Configured<::std::sync::Arc<authkestra_engine::TokenManager>>)
                     )
-                } else if ident_str == "Authkestra" || ident_str == "AkBase" {
+                } else if ident_str == "AkBase" {
                     match &last_segment.arguments {
                         syn::PathArguments::AngleBracketed(args) => {
                             if args.args.len() != 2 {

--- a/crates/authkestra-macros/src/axum.rs
+++ b/crates/authkestra-macros/src/axum.rs
@@ -66,12 +66,9 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
             }
         },
         _ => {
-            return syn::Error::new_spanned(
-                &input,
-                "AxumState can only be derived for structs",
-            )
-            .to_compile_error()
-            .into();
+            return syn::Error::new_spanned(&input, "AxumState can only be derived for structs")
+                .to_compile_error()
+                .into();
         }
     };
 

--- a/crates/authkestra-macros/src/axum.rs
+++ b/crates/authkestra-macros/src/axum.rs
@@ -6,13 +6,13 @@
 //! ## Usage
 //!
 //! ```rust,ignore
-//! use authkestra_axum::AuthkestraState;
-//! use authkestra::flow::AuthEngine;
+//! use authkestra_axum::State;
+//! use authkestra::flow::Engine;
 //!
-//! #[derive(Clone, AuthkestraState)]
+//! #[derive(Clone, State)]
 //! struct AppState {
 //!     #[authkestra(engine)]
-//!     auth: AuthEngine<Configured<Arc<dyn SessionStore>>, Missing>,
+//!     auth: Engine<Configured<Arc<dyn SessionStore>>, Missing>,
 //!     
 //!     #[authkestra(store)]
 //!     clients: Arc<dyn ClientStore>,
@@ -41,25 +41,17 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
             Fields::Named(fields) => {
                 for field in &fields.named {
                     for attr in &field.attrs {
-                        let is_legacy = attr.path().is_ident("auth_engine");
                         let is_authkestra = attr.path().is_ident("authkestra");
 
-                        if is_legacy {
-                            engine_field = Some(field);
-                        } else if is_authkestra {
-                            if let syn::Meta::Path(_) = attr.meta {
-                                // Backward compatibility: #[authkestra] implies engine
-                                engine_field = Some(field);
-                            } else {
-                                let _ = attr.parse_nested_meta(|meta| {
-                                    if meta.path.is_ident("engine") {
-                                        engine_field = Some(field);
-                                    } else if meta.path.is_ident("store") {
-                                        store_fields.push(field);
-                                    }
-                                    Ok(())
-                                });
-                            }
+                        if is_authkestra {
+                            let _ = attr.parse_nested_meta(|meta| {
+                                if meta.path.is_ident("engine") {
+                                    engine_field = Some(field);
+                                } else if meta.path.is_ident("store") {
+                                    store_fields.push(field);
+                                }
+                                Ok(())
+                            });
                         }
                     }
                 }
@@ -67,7 +59,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
             _ => {
                 return syn::Error::new_spanned(
                     &input,
-                    "AuthkestraState can only be derived for structs with named fields",
+                    "State can only be derived for structs with named fields",
                 )
                 .to_compile_error()
                 .into();
@@ -76,7 +68,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
         _ => {
             return syn::Error::new_spanned(
                 &input,
-                "AuthkestraState can only be derived for structs",
+                "State can only be derived for structs",
             )
             .to_compile_error()
             .into();
@@ -125,13 +117,13 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                             >
                         ),
                     )
-                } else if ident_str == "Authkestra" || ident_str == "AuthEngine" {
+                } else if ident_str == "Authkestra" || ident_str == "Engine" {
                     match &last_segment.arguments {
                         syn::PathArguments::AngleBracketed(args) => {
                             if args.args.len() != 2 {
                                 return syn::Error::new_spanned(
                                     &field.ty,
-                                    "AuthEngine must have exactly 2 type parameters: AuthEngine<S, T>",
+                                    "Engine must have exactly 2 type parameters: Engine<S, T>",
                                 )
                                 .to_compile_error()
                                 .into();
@@ -143,7 +135,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                         _ => {
                             return syn::Error::new_spanned(
                                 &field.ty,
-                                "AuthEngine must have type parameters: AuthEngine<S, T>",
+                                "Engine must have type parameters: Engine<S, T>",
                             )
                             .to_compile_error()
                             .into();
@@ -152,7 +144,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                 } else {
                     return syn::Error::new_spanned(
                         &field.ty,
-                        "Field marked with #[authkestra(engine)] must be of type AuthEngine<S, T>, AkWebAppEngine, AkApiEngine, or AkEngine",
+                        "Field marked with #[authkestra(engine)] must be of type Engine<S, T>, AkWebAppEngine, AkApiEngine, or AkEngine",
                     )
                     .to_compile_error()
                     .into();
@@ -169,7 +161,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
         };
 
         generated_impls.push(quote! {
-            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for authkestra_engine::AuthEngine<#s_param, #t_param>
+            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for authkestra_engine::Engine<#s_param, #t_param>
             where
                 #s_param: Clone,
                 #t_param: Clone,
@@ -184,7 +176,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
             use authkestra_engine::{SessionStoreState as _, TokenManagerState as _};
 
             impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics>
-                for ::std::result::Result<::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>, authkestra_axum::AuthEngineAxumError>
+                for ::std::result::Result<::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>, authkestra_axum::Error>
             where
                 #s_param: authkestra_engine::SessionStoreState,
                 #where_clause
@@ -207,7 +199,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
         if !t_param_str.contains("Missing") {
             generated_impls.push(quote! {
                 impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics>
-                    for ::std::result::Result<::std::sync::Arc<authkestra_engine::TokenManager>, authkestra_axum::AuthEngineAxumError>
+                    for ::std::result::Result<::std::sync::Arc<authkestra_engine::TokenManager>, authkestra_axum::Error>
                 where
                     #t_param: authkestra_engine::TokenManagerState,
                     #where_clause
@@ -234,7 +226,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                 }
             }
 
-            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for ::std::result::Result<#field_ty, authkestra_axum::AuthEngineAxumError>
+            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for ::std::result::Result<#field_ty, authkestra_axum::Error>
             #where_clause
             {
                 fn from_ref(state: &#struct_name #ty_generics) -> Self {
@@ -247,7 +239,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
     if engine_field.is_none() && generated_impls.is_empty() {
         return syn::Error::new_spanned(
             &input,
-            "No field marked with #[authkestra(engine)] found. Add #[authkestra(engine)] to your AuthEngine field."
+            "No field marked with #[authkestra(engine)] found. Add #[authkestra(engine)] to your Engine field."
         )
         .to_compile_error()
         .into();

--- a/crates/authkestra-macros/src/axum.rs
+++ b/crates/authkestra-macros/src/axum.rs
@@ -89,45 +89,63 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
     if let Some(field) = engine_field {
         let field_name = field.ident.as_ref().unwrap();
 
-        let (s_param, t_param) = match &field.ty {
+        let (s_param, t_param): (syn::Type, syn::Type) = match &field.ty {
             Type::Path(type_path) => {
                 let last_segment = type_path.path.segments.last().unwrap();
-                if last_segment.ident != "Authkestra" && last_segment.ident != "AuthEngine" {
-                    return syn::Error::new_spanned(
-                        &field.ty,
-                        "Field marked with #[authkestra(engine)] must be of type AuthEngine<S, T> or Authkestra<S, T>",
-                    )
-                    .to_compile_error()
-                    .into();
-                }
+                let ident_str = last_segment.ident.to_string();
 
-                match &last_segment.arguments {
-                    syn::PathArguments::AngleBracketed(args) => {
-                        if args.args.len() != 2 {
+                if ident_str == "AkWebAppEngine" {
+                    (
+                        syn::parse_quote!(authkestra_engine::Configured<::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>>),
+                        syn::parse_quote!(authkestra_engine::Missing)
+                    )
+                } else if ident_str == "AkApiEngine" {
+                    (
+                        syn::parse_quote!(authkestra_engine::Missing),
+                        syn::parse_quote!(authkestra_engine::Configured<::std::sync::Arc<authkestra_engine::TokenManager>>)
+                    )
+                } else if ident_str == "AkEngine" {
+                    (
+                        syn::parse_quote!(authkestra_engine::Configured<::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>>),
+                        syn::parse_quote!(authkestra_engine::Configured<::std::sync::Arc<authkestra_engine::TokenManager>>)
+                    )
+                } else if ident_str == "Authkestra" || ident_str == "AuthEngine" {
+                    match &last_segment.arguments {
+                        syn::PathArguments::AngleBracketed(args) => {
+                            if args.args.len() != 2 {
+                                return syn::Error::new_spanned(
+                                    &field.ty,
+                                    "AuthEngine must have exactly 2 type parameters: AuthEngine<S, T>",
+                                )
+                                .to_compile_error()
+                                .into();
+                            }
+                            let s = &args.args[0];
+                            let t = &args.args[1];
+                            (syn::parse_quote!(#s), syn::parse_quote!(#t))
+                        }
+                        _ => {
                             return syn::Error::new_spanned(
                                 &field.ty,
-                                "AuthEngine must have exactly 2 type parameters: AuthEngine<S, T>",
+                                "AuthEngine must have type parameters: AuthEngine<S, T>",
                             )
                             .to_compile_error()
                             .into();
                         }
-
-                        (&args.args[0], &args.args[1])
                     }
-                    _ => {
-                        return syn::Error::new_spanned(
-                            &field.ty,
-                            "AuthEngine must have type parameters: AuthEngine<S, T>",
-                        )
-                        .to_compile_error()
-                        .into();
-                    }
+                } else {
+                    return syn::Error::new_spanned(
+                        &field.ty,
+                        "Field marked with #[authkestra(engine)] must be of type AuthEngine<S, T>, AkWebAppEngine, AkApiEngine, or AkEngine",
+                    )
+                    .to_compile_error()
+                    .into();
                 }
             }
             _ => {
                 return syn::Error::new_spanned(
                     &field.ty,
-                    "Field marked with #[authkestra(engine)] must be of type AuthEngine<S, T> or Authkestra<S, T>",
+                    "Field marked with #[authkestra(engine)] must be a valid path type",
                 )
                 .to_compile_error()
                 .into();

--- a/crates/authkestra-macros/src/axum.rs
+++ b/crates/authkestra-macros/src/axum.rs
@@ -88,18 +88,34 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
 
                 if ident_str == "AkWebAppEngine" {
                     (
-                        syn::parse_quote!(authkestra_engine::Configured<::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>>),
-                        syn::parse_quote!(authkestra_engine::Missing)
+                        syn::parse_quote!(
+                            authkestra_engine::Configured<
+                                ::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>,
+                            >
+                        ),
+                        syn::parse_quote!(authkestra_engine::Missing),
                     )
                 } else if ident_str == "AkApiEngine" {
                     (
                         syn::parse_quote!(authkestra_engine::Missing),
-                        syn::parse_quote!(authkestra_engine::Configured<::std::sync::Arc<authkestra_engine::TokenManager>>)
+                        syn::parse_quote!(
+                            authkestra_engine::Configured<
+                                ::std::sync::Arc<authkestra_engine::TokenManager>,
+                            >
+                        ),
                     )
                 } else if ident_str == "AkEngine" {
                     (
-                        syn::parse_quote!(authkestra_engine::Configured<::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>>),
-                        syn::parse_quote!(authkestra_engine::Configured<::std::sync::Arc<authkestra_engine::TokenManager>>)
+                        syn::parse_quote!(
+                            authkestra_engine::Configured<
+                                ::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>,
+                            >
+                        ),
+                        syn::parse_quote!(
+                            authkestra_engine::Configured<
+                                ::std::sync::Arc<authkestra_engine::TokenManager>,
+                            >
+                        ),
                     )
                 } else if ident_str == "AkBase" {
                     match &last_segment.arguments {

--- a/crates/authkestra-macros/src/axum.rs
+++ b/crates/authkestra-macros/src/axum.rs
@@ -6,10 +6,10 @@
 //! ## Usage
 //!
 //! ```rust,ignore
-//! use authkestra_axum::State;
+//! use authkestra_axum::AxumState;
 //! use authkestra::flow::Engine;
 //!
-//! #[derive(Clone, State)]
+//! #[derive(Clone, AxumState)]
 //! struct AppState {
 //!     #[authkestra(engine)]
 //!     auth: Engine<Configured<Arc<dyn SessionStore>>, Missing>,
@@ -59,7 +59,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
             _ => {
                 return syn::Error::new_spanned(
                     &input,
-                    "State can only be derived for structs with named fields",
+                    "AxumState can only be derived for structs with named fields",
                 )
                 .to_compile_error()
                 .into();
@@ -68,7 +68,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
         _ => {
             return syn::Error::new_spanned(
                 &input,
-                "State can only be derived for structs",
+                "AxumState can only be derived for structs",
             )
             .to_compile_error()
             .into();
@@ -176,7 +176,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
             use authkestra_engine::{SessionStoreState as _, TokenManagerState as _};
 
             impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics>
-                for ::std::result::Result<::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>, authkestra_axum::Error>
+                for ::std::result::Result<::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>, authkestra_axum::AxumError>
             where
                 #s_param: authkestra_engine::SessionStoreState,
                 #where_clause
@@ -199,7 +199,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
         if !t_param_str.contains("Missing") {
             generated_impls.push(quote! {
                 impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics>
-                    for ::std::result::Result<::std::sync::Arc<authkestra_engine::TokenManager>, authkestra_axum::Error>
+                    for ::std::result::Result<::std::sync::Arc<authkestra_engine::TokenManager>, authkestra_axum::AxumError>
                 where
                     #t_param: authkestra_engine::TokenManagerState,
                     #where_clause
@@ -226,7 +226,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                 }
             }
 
-            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for ::std::result::Result<#field_ty, authkestra_axum::Error>
+            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for ::std::result::Result<#field_ty, authkestra_axum::AxumError>
             #where_clause
             {
                 fn from_ref(state: &#struct_name #ty_generics) -> Self {

--- a/crates/authkestra-macros/src/axum.rs
+++ b/crates/authkestra-macros/src/axum.rs
@@ -7,12 +7,12 @@
 //!
 //! ```rust,ignore
 //! use authkestra_axum::AuthkestraState;
-//! use authkestra::flow::AuthEngine;
+//! use authkestra::flow::AkBase;
 //!
 //! #[derive(Clone, AuthkestraState)]
 //! struct AppState {
 //!     #[authkestra(engine)]
-//!     auth: AuthEngine<Configured<Arc<dyn SessionStore>>, Missing>,
+//!     auth: AkBase<Configured<Arc<dyn SessionStore>>, Missing>,
 //!     
 //!     #[authkestra(store)]
 //!     clients: Arc<dyn ClientStore>,
@@ -109,13 +109,13 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                         syn::parse_quote!(authkestra_engine::Configured<::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>>),
                         syn::parse_quote!(authkestra_engine::Configured<::std::sync::Arc<authkestra_engine::TokenManager>>)
                     )
-                } else if ident_str == "Authkestra" || ident_str == "AuthEngine" {
+                } else if ident_str == "Authkestra" || ident_str == "AkBase" {
                     match &last_segment.arguments {
                         syn::PathArguments::AngleBracketed(args) => {
                             if args.args.len() != 2 {
                                 return syn::Error::new_spanned(
                                     &field.ty,
-                                    "AuthEngine must have exactly 2 type parameters: AuthEngine<S, T>",
+                                    "AkBase must have exactly 2 type parameters: AkBase<S, T>",
                                 )
                                 .to_compile_error()
                                 .into();
@@ -127,7 +127,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                         _ => {
                             return syn::Error::new_spanned(
                                 &field.ty,
-                                "AuthEngine must have type parameters: AuthEngine<S, T>",
+                                "AkBase must have type parameters: AkBase<S, T>",
                             )
                             .to_compile_error()
                             .into();
@@ -136,7 +136,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                 } else {
                     return syn::Error::new_spanned(
                         &field.ty,
-                        "Field marked with #[authkestra(engine)] must be of type AuthEngine<S, T>, AkWebAppEngine, AkApiEngine, or AkEngine",
+                        "Field marked with #[authkestra(engine)] must be of type AkBase<S, T>, AkWebAppEngine, AkApiEngine, or AkEngine",
                     )
                     .to_compile_error()
                     .into();
@@ -153,7 +153,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
         };
 
         generated_impls.push(quote! {
-            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for authkestra_engine::AuthEngine<#s_param, #t_param>
+            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for authkestra_engine::AkBase<#s_param, #t_param>
             where
                 #s_param: Clone,
                 #t_param: Clone,
@@ -168,7 +168,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
             use authkestra_engine::{SessionStoreState as _, TokenManagerState as _};
 
             impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics>
-                for ::std::result::Result<::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>, authkestra_axum::AuthkestraAxumError>
+                for ::std::result::Result<::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>, authkestra_axum::AkAxumError>
             where
                 #s_param: authkestra_engine::SessionStoreState,
                 #where_clause
@@ -191,7 +191,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
         if !t_param_str.contains("Missing") {
             generated_impls.push(quote! {
                 impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics>
-                    for ::std::result::Result<::std::sync::Arc<authkestra_engine::TokenManager>, authkestra_axum::AuthkestraAxumError>
+                    for ::std::result::Result<::std::sync::Arc<authkestra_engine::TokenManager>, authkestra_axum::AkAxumError>
                 where
                     #t_param: authkestra_engine::TokenManagerState,
                     #where_clause
@@ -218,7 +218,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                 }
             }
 
-            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for ::std::result::Result<#field_ty, authkestra_axum::AuthkestraAxumError>
+            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for ::std::result::Result<#field_ty, authkestra_axum::AkAxumError>
             #where_clause
             {
                 fn from_ref(state: &#struct_name #ty_generics) -> Self {
@@ -231,7 +231,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
     if engine_field.is_none() && generated_impls.is_empty() {
         return syn::Error::new_spanned(
             &input,
-            "No field marked with #[authkestra(engine)] found. Add #[authkestra(engine)] to your AuthEngine field."
+            "No field marked with #[authkestra(engine)] found. Add #[authkestra(engine)] to your AkBase field."
         )
         .to_compile_error()
         .into();

--- a/crates/authkestra-macros/src/axum.rs
+++ b/crates/authkestra-macros/src/axum.rs
@@ -7,12 +7,12 @@
 //!
 //! ```rust,ignore
 //! use authkestra_axum::AuthkestraState;
-//! use authkestra::flow::AkBase;
+//! use authkestra::flow::AuthEngine;
 //!
 //! #[derive(Clone, AuthkestraState)]
 //! struct AppState {
 //!     #[authkestra(engine)]
-//!     auth: AkBase<Configured<Arc<dyn SessionStore>>, Missing>,
+//!     auth: AuthEngine<Configured<Arc<dyn SessionStore>>, Missing>,
 //!     
 //!     #[authkestra(store)]
 //!     clients: Arc<dyn ClientStore>,
@@ -41,17 +41,25 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
             Fields::Named(fields) => {
                 for field in &fields.named {
                     for attr in &field.attrs {
+                        let is_legacy = attr.path().is_ident("auth_engine");
                         let is_authkestra = attr.path().is_ident("authkestra");
 
-                        if is_authkestra {
-                            let _ = attr.parse_nested_meta(|meta| {
-                                if meta.path.is_ident("engine") {
-                                    engine_field = Some(field);
-                                } else if meta.path.is_ident("store") {
-                                    store_fields.push(field);
-                                }
-                                Ok(())
-                            });
+                        if is_legacy {
+                            engine_field = Some(field);
+                        } else if is_authkestra {
+                            if let syn::Meta::Path(_) = attr.meta {
+                                // Backward compatibility: #[authkestra] implies engine
+                                engine_field = Some(field);
+                            } else {
+                                let _ = attr.parse_nested_meta(|meta| {
+                                    if meta.path.is_ident("engine") {
+                                        engine_field = Some(field);
+                                    } else if meta.path.is_ident("store") {
+                                        store_fields.push(field);
+                                    }
+                                    Ok(())
+                                });
+                            }
                         }
                     }
                 }
@@ -117,13 +125,13 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                             >
                         ),
                     )
-                } else if ident_str == "AkBase" {
+                } else if ident_str == "Authkestra" || ident_str == "AuthEngine" {
                     match &last_segment.arguments {
                         syn::PathArguments::AngleBracketed(args) => {
                             if args.args.len() != 2 {
                                 return syn::Error::new_spanned(
                                     &field.ty,
-                                    "AkBase must have exactly 2 type parameters: AkBase<S, T>",
+                                    "AuthEngine must have exactly 2 type parameters: AuthEngine<S, T>",
                                 )
                                 .to_compile_error()
                                 .into();
@@ -135,7 +143,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                         _ => {
                             return syn::Error::new_spanned(
                                 &field.ty,
-                                "AkBase must have type parameters: AkBase<S, T>",
+                                "AuthEngine must have type parameters: AuthEngine<S, T>",
                             )
                             .to_compile_error()
                             .into();
@@ -144,7 +152,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                 } else {
                     return syn::Error::new_spanned(
                         &field.ty,
-                        "Field marked with #[authkestra(engine)] must be of type AkBase<S, T>, AkWebAppEngine, AkApiEngine, or AkEngine",
+                        "Field marked with #[authkestra(engine)] must be of type AuthEngine<S, T>, AkWebAppEngine, AkApiEngine, or AkEngine",
                     )
                     .to_compile_error()
                     .into();
@@ -161,7 +169,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
         };
 
         generated_impls.push(quote! {
-            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for authkestra_engine::AkBase<#s_param, #t_param>
+            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for authkestra_engine::AuthEngine<#s_param, #t_param>
             where
                 #s_param: Clone,
                 #t_param: Clone,
@@ -176,7 +184,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
             use authkestra_engine::{SessionStoreState as _, TokenManagerState as _};
 
             impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics>
-                for ::std::result::Result<::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>, authkestra_axum::AkAxumError>
+                for ::std::result::Result<::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>, authkestra_axum::AuthEngineAxumError>
             where
                 #s_param: authkestra_engine::SessionStoreState,
                 #where_clause
@@ -199,7 +207,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
         if !t_param_str.contains("Missing") {
             generated_impls.push(quote! {
                 impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics>
-                    for ::std::result::Result<::std::sync::Arc<authkestra_engine::TokenManager>, authkestra_axum::AkAxumError>
+                    for ::std::result::Result<::std::sync::Arc<authkestra_engine::TokenManager>, authkestra_axum::AuthEngineAxumError>
                 where
                     #t_param: authkestra_engine::TokenManagerState,
                     #where_clause
@@ -226,7 +234,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                 }
             }
 
-            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for ::std::result::Result<#field_ty, authkestra_axum::AkAxumError>
+            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for ::std::result::Result<#field_ty, authkestra_axum::AuthEngineAxumError>
             #where_clause
             {
                 fn from_ref(state: &#struct_name #ty_generics) -> Self {
@@ -239,7 +247,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
     if engine_field.is_none() && generated_impls.is_empty() {
         return syn::Error::new_spanned(
             &input,
-            "No field marked with #[authkestra(engine)] found. Add #[authkestra(engine)] to your AkBase field."
+            "No field marked with #[authkestra(engine)] found. Add #[authkestra(engine)] to your AuthEngine field."
         )
         .to_compile_error()
         .into();

--- a/crates/authkestra-macros/src/lib.rs
+++ b/crates/authkestra-macros/src/lib.rs
@@ -6,15 +6,8 @@ mod axum;
 mod derive;
 
 #[cfg(feature = "axum")]
-#[proc_macro_derive(AuthkestraState, attributes(authkestra, auth_engine))]
+#[proc_macro_derive(AuthkestraState, attributes(authkestra))]
 pub fn derive_authkestra_state(input: TokenStream) -> TokenStream {
-    axum::derive_authkestra_state_impl(input)
-}
-
-#[cfg(feature = "axum")]
-#[proc_macro_derive(AuthkestraFromRef, attributes(authkestra, auth_engine))]
-pub fn derive_authkestra_from_ref(input: TokenStream) -> TokenStream {
-    // Alias for backwards compatibility
     axum::derive_authkestra_state_impl(input)
 }
 

--- a/crates/authkestra-macros/src/lib.rs
+++ b/crates/authkestra-macros/src/lib.rs
@@ -11,8 +11,6 @@ pub fn derive_authkestra_state(input: TokenStream) -> TokenStream {
     axum::derive_authkestra_state_impl(input)
 }
 
-
-
 #[proc_macro_derive(KvStore, attributes(authkestra))]
 pub fn derive_authkestra_kv_store(input: TokenStream) -> TokenStream {
     derive::derive_authkestra_kv_store_impl(input)

--- a/crates/authkestra-macros/src/lib.rs
+++ b/crates/authkestra-macros/src/lib.rs
@@ -11,6 +11,13 @@ pub fn derive_authkestra_state(input: TokenStream) -> TokenStream {
     axum::derive_authkestra_state_impl(input)
 }
 
+#[cfg(feature = "axum")]
+#[proc_macro_derive(AuthkestraFromRef, attributes(authkestra))]
+pub fn derive_authkestra_from_ref(input: TokenStream) -> TokenStream {
+    // Alias for backwards compatibility
+    axum::derive_authkestra_state_impl(input)
+}
+
 #[proc_macro_derive(AuthkestraKvStore, attributes(authkestra))]
 pub fn derive_authkestra_kv_store(input: TokenStream) -> TokenStream {
     derive::derive_authkestra_kv_store_impl(input)

--- a/crates/authkestra-macros/src/lib.rs
+++ b/crates/authkestra-macros/src/lib.rs
@@ -6,19 +6,14 @@ mod axum;
 mod derive;
 
 #[cfg(feature = "axum")]
-#[proc_macro_derive(AuthkestraState, attributes(authkestra))]
+#[proc_macro_derive(State, attributes(authkestra))]
 pub fn derive_authkestra_state(input: TokenStream) -> TokenStream {
     axum::derive_authkestra_state_impl(input)
 }
 
-#[cfg(feature = "axum")]
-#[proc_macro_derive(AuthkestraFromRef, attributes(authkestra))]
-pub fn derive_authkestra_from_ref(input: TokenStream) -> TokenStream {
-    // Alias for backwards compatibility
-    axum::derive_authkestra_state_impl(input)
-}
 
-#[proc_macro_derive(AuthkestraKvStore, attributes(authkestra))]
+
+#[proc_macro_derive(KvStore, attributes(authkestra))]
 pub fn derive_authkestra_kv_store(input: TokenStream) -> TokenStream {
     derive::derive_authkestra_kv_store_impl(input)
 }

--- a/crates/authkestra-macros/src/lib.rs
+++ b/crates/authkestra-macros/src/lib.rs
@@ -6,7 +6,7 @@ mod axum;
 mod derive;
 
 #[cfg(feature = "axum")]
-#[proc_macro_derive(State, attributes(authkestra))]
+#[proc_macro_derive(AxumState, attributes(authkestra))]
 pub fn derive_authkestra_state(input: TokenStream) -> TokenStream {
     axum::derive_authkestra_state_impl(input)
 }

--- a/crates/authkestra-oidc/Cargo.toml
+++ b/crates/authkestra-oidc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-oidc"
-version = "0.1.2"
+version = "0.2.0"
 edition.workspace = true
 description = "OIDC support for the authkestra framework"
 repository.workspace = true

--- a/crates/authkestra-op/Cargo.toml
+++ b/crates/authkestra-op/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-op"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 description = "OpenID Provider (OP) support for the authkestra framework — issue tokens and run the authorization code grant, rather than only consuming an external IdP"
 repository.workspace = true

--- a/crates/authkestra-op/src/error.rs
+++ b/crates/authkestra-op/src/error.rs
@@ -35,7 +35,7 @@ pub enum OpError {
     #[error("storage error")]
     Storage,
 
-    /// Token issuance failed at the `authkestra_engine::TokenService` layer.
+    /// Token issuance failed at the `authkestra_engine::TokenManager` layer.
     #[error("token issuance failed: {0}")]
     TokenIssuance(String),
 }

--- a/crates/authkestra-providers/Cargo.toml
+++ b/crates/authkestra-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-providers"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 description = "Consolidated OAuth providers for the authkestra framework"
 repository.workspace = true

--- a/crates/authkestra-resource/Cargo.toml
+++ b/crates/authkestra-resource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-resource"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 description = "Resource server enforcement and validation for the authkestra framework"
 repository.workspace = true

--- a/crates/authkestra-resource/README.md
+++ b/crates/authkestra-resource/README.md
@@ -6,20 +6,20 @@ This crate focuses strictly on validation and enforcement (middleware/extractors
 
 ## Features
 
-- `AuthEngineGuard`: A flexible orchestrator for multiple authentication strategies.
+- `AkResourceGuard`: A flexible orchestrator for multiple authentication strategies.
 - JWT Validation: Offline validation of JWT tokens using JWKS or local keys.
 - Framework Agnostic: Core logic remains independent of web frameworks.
 
 ## Usage
 
-### Using AuthEngineGuard
+### Using AkResourceGuard
 
 ```rust
-use authkestra_resource::{AuthEngineGuard, AuthPolicy};
+use authkestra_resource::{AkResourceGuard, AuthPolicy};
 use authkestra_resource::jwt::JwtStrategy;
 
 // Create a guard with a JWT strategy
-let guard = AuthEngineGuard::builder()
+let guard = AkResourceGuard::builder()
     .strategy(JwtStrategy::new(validation_config))
     .policy(AuthPolicy::FirstSuccess)
     .build();
@@ -46,6 +46,6 @@ let strategy = JwtStrategy::new(config);
 
 ## Related Crates
 
-- `authkestra-engine`: Foundational types and the AuthEngine orchestrator.
+- `authkestra-engine`: Foundational types and the AkBase orchestrator.
 - `authkestra-axum`: Axum extractors and middleware.
 - `authkestra-actix`: Actix-web extractors and middleware.

--- a/crates/authkestra-resource/README.md
+++ b/crates/authkestra-resource/README.md
@@ -6,20 +6,20 @@ This crate focuses strictly on validation and enforcement (middleware/extractors
 
 ## Features
 
-- `AkResourceGuard`: A flexible orchestrator for multiple authentication strategies.
+- `AuthEngineGuard`: A flexible orchestrator for multiple authentication strategies.
 - JWT Validation: Offline validation of JWT tokens using JWKS or local keys.
 - Framework Agnostic: Core logic remains independent of web frameworks.
 
 ## Usage
 
-### Using AkResourceGuard
+### Using AuthEngineGuard
 
 ```rust
-use authkestra_resource::{AkResourceGuard, AuthPolicy};
+use authkestra_resource::{AuthEngineGuard, AuthPolicy};
 use authkestra_resource::jwt::JwtStrategy;
 
 // Create a guard with a JWT strategy
-let guard = AkResourceGuard::builder()
+let guard = AuthEngineGuard::builder()
     .strategy(JwtStrategy::new(validation_config))
     .policy(AuthPolicy::FirstSuccess)
     .build();
@@ -46,6 +46,6 @@ let strategy = JwtStrategy::new(config);
 
 ## Related Crates
 
-- `authkestra-engine`: Foundational types and the AkBase orchestrator.
+- `authkestra-engine`: Foundational types and the AuthEngine orchestrator.
 - `authkestra-axum`: Axum extractors and middleware.
 - `authkestra-actix`: Actix-web extractors and middleware.

--- a/crates/authkestra-resource/README.md
+++ b/crates/authkestra-resource/README.md
@@ -6,20 +6,20 @@ This crate focuses strictly on validation and enforcement (middleware/extractors
 
 ## Features
 
-- `AuthEngineGuard`: A flexible orchestrator for multiple authentication strategies.
+- `Guard`: A flexible orchestrator for multiple authentication strategies.
 - JWT Validation: Offline validation of JWT tokens using JWKS or local keys.
 - Framework Agnostic: Core logic remains independent of web frameworks.
 
 ## Usage
 
-### Using AuthEngineGuard
+### Using Guard
 
 ```rust
-use authkestra_resource::{AuthEngineGuard, AuthPolicy};
+use authkestra_resource::{Guard, AuthPolicy};
 use authkestra_resource::jwt::JwtStrategy;
 
 // Create a guard with a JWT strategy
-let guard = AuthEngineGuard::builder()
+let guard = Guard::builder()
     .strategy(JwtStrategy::new(validation_config))
     .policy(AuthPolicy::FirstSuccess)
     .build();
@@ -46,6 +46,6 @@ let strategy = JwtStrategy::new(config);
 
 ## Related Crates
 
-- `authkestra-engine`: Foundational types and the AuthEngine orchestrator.
+- `authkestra-engine`: Foundational types and the Engine orchestrator.
 - `authkestra-axum`: Axum extractors and middleware.
 - `authkestra-actix`: Actix-web extractors and middleware.

--- a/crates/authkestra-resource/src/lib.rs
+++ b/crates/authkestra-resource/src/lib.rs
@@ -4,8 +4,8 @@ use http::request::Parts;
 
 pub mod jwt;
 
-pub use AuthEngineGuard as ResourceEnforcer;
-pub use AuthEngineGuardBuilder as ResourceEnforcerBuilder;
+pub use Guard as ResourceEnforcer;
+pub use GuardBuilder as ResourceEnforcerBuilder;
 
 /// Policy for controlling the behavior of chained authentication strategies.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -23,15 +23,15 @@ pub enum AuthPolicy {
 }
 
 /// A service that orchestrates multiple authentication strategies.
-pub struct AuthEngineGuard<I> {
+pub struct Guard<I> {
     strategies: Vec<Box<dyn AuthenticationStrategy<I>>>,
     policy: AuthPolicy,
 }
 
-impl<I> AuthEngineGuard<I> {
+impl<I> Guard<I> {
     /// Create a new builder for the Guard.
-    pub fn builder() -> AuthEngineGuardBuilder<I> {
-        AuthEngineGuardBuilder::default()
+    pub fn builder() -> GuardBuilder<I> {
+        GuardBuilder::default()
     }
 
     /// Attempt to authenticate the request using the configured strategies and policy.
@@ -69,13 +69,13 @@ impl<I> AuthEngineGuard<I> {
     }
 }
 
-/// Builder for the `AuthEngineGuard`.
-pub struct AuthEngineGuardBuilder<I> {
+/// Builder for the `Guard`.
+pub struct GuardBuilder<I> {
     strategies: Vec<Box<dyn AuthenticationStrategy<I>>>,
     policy: AuthPolicy,
 }
 
-impl<I> Default for AuthEngineGuardBuilder<I> {
+impl<I> Default for GuardBuilder<I> {
     fn default() -> Self {
         Self {
             strategies: Vec::new(),
@@ -84,7 +84,7 @@ impl<I> Default for AuthEngineGuardBuilder<I> {
     }
 }
 
-impl<I> AuthEngineGuardBuilder<I>
+impl<I> GuardBuilder<I>
 where
     I: Send + Sync + 'static,
 {
@@ -103,9 +103,9 @@ where
         self
     }
 
-    /// Build the `AuthEngineGuard`.
-    pub fn build(self) -> AuthEngineGuard<I> {
-        AuthEngineGuard {
+    /// Build the `Guard`.
+    pub fn build(self) -> Guard<I> {
+        Guard {
             strategies: self.strategies,
             policy: self.policy,
         }

--- a/crates/authkestra-resource/src/lib.rs
+++ b/crates/authkestra-resource/src/lib.rs
@@ -4,8 +4,8 @@ use http::request::Parts;
 
 pub mod jwt;
 
-pub use AuthEngineGuard as ResourceEnforcer;
-pub use AuthEngineGuardBuilder as ResourceEnforcerBuilder;
+pub use AkResourceGuard as ResourceEnforcer;
+pub use AkResourceGuardBuilder as ResourceEnforcerBuilder;
 
 /// Policy for controlling the behavior of chained authentication strategies.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -23,15 +23,15 @@ pub enum AuthPolicy {
 }
 
 /// A service that orchestrates multiple authentication strategies.
-pub struct AuthEngineGuard<I> {
+pub struct AkResourceGuard<I> {
     strategies: Vec<Box<dyn AuthenticationStrategy<I>>>,
     policy: AuthPolicy,
 }
 
-impl<I> AuthEngineGuard<I> {
+impl<I> AkResourceGuard<I> {
     /// Create a new builder for the Guard.
-    pub fn builder() -> AuthEngineGuardBuilder<I> {
-        AuthEngineGuardBuilder::default()
+    pub fn builder() -> AkResourceGuardBuilder<I> {
+        AkResourceGuardBuilder::default()
     }
 
     /// Attempt to authenticate the request using the configured strategies and policy.
@@ -69,13 +69,13 @@ impl<I> AuthEngineGuard<I> {
     }
 }
 
-/// Builder for the `AuthEngineGuard`.
-pub struct AuthEngineGuardBuilder<I> {
+/// Builder for the `AkResourceGuard`.
+pub struct AkResourceGuardBuilder<I> {
     strategies: Vec<Box<dyn AuthenticationStrategy<I>>>,
     policy: AuthPolicy,
 }
 
-impl<I> Default for AuthEngineGuardBuilder<I> {
+impl<I> Default for AkResourceGuardBuilder<I> {
     fn default() -> Self {
         Self {
             strategies: Vec::new(),
@@ -84,7 +84,7 @@ impl<I> Default for AuthEngineGuardBuilder<I> {
     }
 }
 
-impl<I> AuthEngineGuardBuilder<I>
+impl<I> AkResourceGuardBuilder<I>
 where
     I: Send + Sync + 'static,
 {
@@ -103,9 +103,9 @@ where
         self
     }
 
-    /// Build the `AuthEngineGuard`.
-    pub fn build(self) -> AuthEngineGuard<I> {
-        AuthEngineGuard {
+    /// Build the `AkResourceGuard`.
+    pub fn build(self) -> AkResourceGuard<I> {
+        AkResourceGuard {
             strategies: self.strategies,
             policy: self.policy,
         }

--- a/crates/authkestra-resource/src/lib.rs
+++ b/crates/authkestra-resource/src/lib.rs
@@ -4,8 +4,8 @@ use http::request::Parts;
 
 pub mod jwt;
 
-pub use AkResourceGuard as ResourceEnforcer;
-pub use AkResourceGuardBuilder as ResourceEnforcerBuilder;
+pub use AuthEngineGuard as ResourceEnforcer;
+pub use AuthEngineGuardBuilder as ResourceEnforcerBuilder;
 
 /// Policy for controlling the behavior of chained authentication strategies.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -23,15 +23,15 @@ pub enum AuthPolicy {
 }
 
 /// A service that orchestrates multiple authentication strategies.
-pub struct AkResourceGuard<I> {
+pub struct AuthEngineGuard<I> {
     strategies: Vec<Box<dyn AuthenticationStrategy<I>>>,
     policy: AuthPolicy,
 }
 
-impl<I> AkResourceGuard<I> {
+impl<I> AuthEngineGuard<I> {
     /// Create a new builder for the Guard.
-    pub fn builder() -> AkResourceGuardBuilder<I> {
-        AkResourceGuardBuilder::default()
+    pub fn builder() -> AuthEngineGuardBuilder<I> {
+        AuthEngineGuardBuilder::default()
     }
 
     /// Attempt to authenticate the request using the configured strategies and policy.
@@ -69,13 +69,13 @@ impl<I> AkResourceGuard<I> {
     }
 }
 
-/// Builder for the `AkResourceGuard`.
-pub struct AkResourceGuardBuilder<I> {
+/// Builder for the `AuthEngineGuard`.
+pub struct AuthEngineGuardBuilder<I> {
     strategies: Vec<Box<dyn AuthenticationStrategy<I>>>,
     policy: AuthPolicy,
 }
 
-impl<I> Default for AkResourceGuardBuilder<I> {
+impl<I> Default for AuthEngineGuardBuilder<I> {
     fn default() -> Self {
         Self {
             strategies: Vec::new(),
@@ -84,7 +84,7 @@ impl<I> Default for AkResourceGuardBuilder<I> {
     }
 }
 
-impl<I> AkResourceGuardBuilder<I>
+impl<I> AuthEngineGuardBuilder<I>
 where
     I: Send + Sync + 'static,
 {
@@ -103,9 +103,9 @@ where
         self
     }
 
-    /// Build the `AkResourceGuard`.
-    pub fn build(self) -> AkResourceGuard<I> {
-        AkResourceGuard {
+    /// Build the `AuthEngineGuard`.
+    pub fn build(self) -> AuthEngineGuard<I> {
+        AuthEngineGuard {
             strategies: self.strategies,
             policy: self.policy,
         }

--- a/crates/authkestra/Cargo.toml
+++ b/crates/authkestra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra"
-version = "0.1.2"
+version = "0.2.0"
 edition.workspace = true
 description = "A modular authentication framework for Rust"
 repository.workspace = true

--- a/crates/authkestra/examples/actix_basic_setup.rs
+++ b/crates/authkestra/examples/actix_basic_setup.rs
@@ -1,12 +1,12 @@
 //! # Actix Basic Setup Example
 //!
-//! This example demonstrates the most basic setup of AuthEngine with Actix.
+//! This example demonstrates the most basic setup of AkBase with Actix.
 //! It uses an in-memory session store.
 
 use actix_files::Files;
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
-use authkestra::flow::AuthEngine;
-use authkestra_actix::{AuthSession, AuthkestraActixExt};
+use authkestra::flow::AkBase;
+use authkestra_actix::{AuthSession, AkActixExt};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::SessionConfig;
 use serde_json::json;
@@ -18,7 +18,7 @@ async fn main() -> std::io::Result<()> {
     let session_store: Arc<dyn SessionStore> =
         Arc::new(authkestra_engine::store::memory::MemoryStore::default());
 
-    let auth_engine = AuthEngine::builder()
+    let auth_engine = AkBase::builder()
         .session_store(session_store)
         .session_config(SessionConfig {
             secure: false, // For local development

--- a/crates/authkestra/examples/actix_basic_setup.rs
+++ b/crates/authkestra/examples/actix_basic_setup.rs
@@ -6,7 +6,7 @@
 use actix_files::Files;
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
 use authkestra::flow::AkBase;
-use authkestra_actix::{AuthSession, AkActixExt};
+use authkestra_actix::{AkActixExt, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::SessionConfig;
 use serde_json::json;

--- a/crates/authkestra/examples/actix_basic_setup.rs
+++ b/crates/authkestra/examples/actix_basic_setup.rs
@@ -1,12 +1,12 @@
 //! # Actix Basic Setup Example
 //!
-//! This example demonstrates the most basic setup of AkBase with Actix.
+//! This example demonstrates the most basic setup of AuthEngine with Actix.
 //! It uses an in-memory session store.
 
 use actix_files::Files;
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
-use authkestra::flow::AkBase;
-use authkestra_actix::{AkActixExt, AuthSession};
+use authkestra::flow::AuthEngine;
+use authkestra_actix::{AuthEngineActixExt, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::SessionConfig;
 use serde_json::json;
@@ -18,7 +18,7 @@ async fn main() -> std::io::Result<()> {
     let session_store: Arc<dyn SessionStore> =
         Arc::new(authkestra_engine::store::memory::MemoryStore::default());
 
-    let auth_engine = AkBase::builder()
+    let auth_engine = AuthEngine::builder()
         .session_store(session_store)
         .session_config(SessionConfig {
             secure: false, // For local development

--- a/crates/authkestra/examples/actix_basic_setup.rs
+++ b/crates/authkestra/examples/actix_basic_setup.rs
@@ -1,12 +1,12 @@
 //! # Actix Basic Setup Example
 //!
-//! This example demonstrates the most basic setup of AuthEngine with Actix.
+//! This example demonstrates the most basic setup of Engine with Actix.
 //! It uses an in-memory session store.
 
 use actix_files::Files;
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
-use authkestra::flow::AuthEngine;
-use authkestra_actix::{AuthEngineActixExt, AuthSession};
+use authkestra::flow::Engine;
+use authkestra_actix::{ActixExt, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::SessionConfig;
 use serde_json::json;
@@ -18,7 +18,7 @@ async fn main() -> std::io::Result<()> {
     let session_store: Arc<dyn SessionStore> =
         Arc::new(authkestra_engine::store::memory::MemoryStore::default());
 
-    let auth_engine = AuthEngine::builder()
+    let auth_engine = Engine::builder()
         .session_store(session_store)
         .session_config(SessionConfig {
             secure: false, // For local development

--- a/crates/authkestra/examples/actix_op_server.rs
+++ b/crates/authkestra/examples/actix_op_server.rs
@@ -4,7 +4,7 @@
 use authkestra_engine::store::KvStore;
 
 use actix_web::{App, HttpServer};
-use authkestra_actix::AuthEngineActixOpExt;
+use authkestra_actix::AkActixOpExt;
 use authkestra_engine::TokenManager;
 use authkestra_op::{client::ClientRegistration, config::OpConfig};
 use std::sync::Arc;

--- a/crates/authkestra/examples/actix_op_server.rs
+++ b/crates/authkestra/examples/actix_op_server.rs
@@ -4,7 +4,7 @@
 use authkestra_engine::store::KvStore;
 
 use actix_web::{App, HttpServer};
-use authkestra_actix::AkActixOpExt;
+use authkestra_actix::AuthEngineActixOpExt;
 use authkestra_engine::TokenManager;
 use authkestra_op::{client::ClientRegistration, config::OpConfig};
 use std::sync::Arc;

--- a/crates/authkestra/examples/actix_op_server.rs
+++ b/crates/authkestra/examples/actix_op_server.rs
@@ -4,7 +4,7 @@
 use authkestra_engine::store::KvStore;
 
 use actix_web::{App, HttpServer};
-use authkestra_actix::AuthEngineActixOpExt;
+use authkestra_actix::OpExt;
 use authkestra_engine::TokenManager;
 use authkestra_op::{client::ClientRegistration, config::OpConfig};
 use std::sync::Arc;

--- a/crates/authkestra/examples/axum_basic_setup.rs
+++ b/crates/authkestra/examples/axum_basic_setup.rs
@@ -4,7 +4,7 @@
 //! It uses an in-memory session store and a mock authentication provider.
 
 use authkestra::flow::Engine;
-use authkestra_axum::{Error, AxumExt, State, AuthSession};
+use authkestra_axum::{AxumError, AxumExt, AxumState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use axum::{
@@ -18,7 +18,7 @@ use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
 /// Engine state with support for session only.
-type AppState = State<Configured<Arc<dyn SessionStore>>>;
+type AppState = AxumState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {
@@ -53,7 +53,7 @@ async fn main() {
 }
 
 /// API endpoint to get current user info from session
-async fn get_user(session: Result<AuthSession, Error>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, AxumError>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_basic_setup.rs
+++ b/crates/authkestra/examples/axum_basic_setup.rs
@@ -1,10 +1,10 @@
 //! # Axum Basic Setup Example
 //!
-//! This example demonstrates the most basic setup of AkBase with Axum.
+//! This example demonstrates the most basic setup of AuthEngine with Axum.
 //! It uses an in-memory session store and a mock authentication provider.
 
-use authkestra::flow::AkBase;
-use authkestra_axum::{AkAxumError, AkAxumExt, AkState, AuthSession};
+use authkestra::flow::AuthEngine;
+use authkestra_axum::{AuthEngineAxumError, AuthEngineAxumExt, AuthEngineState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use axum::{
@@ -17,8 +17,8 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// AkBase state with support for session only.
-type AppState = AkState<Configured<Arc<dyn SessionStore>>>;
+/// AuthEngine state with support for session only.
+type AppState = AuthEngineState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {
@@ -26,7 +26,7 @@ async fn main() {
     let session_store: Arc<dyn SessionStore> =
         Arc::new(authkestra_engine::store::memory::MemoryStore::default());
 
-    let auth_engine = AkBase::builder()
+    let auth_engine = AuthEngine::builder()
         .session_store(session_store)
         .session_config(SessionConfig {
             secure: false, // For local development
@@ -53,7 +53,7 @@ async fn main() {
 }
 
 /// API endpoint to get current user info from session
-async fn get_user(session: Result<AuthSession, AkAxumError>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, AuthEngineAxumError>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_basic_setup.rs
+++ b/crates/authkestra/examples/axum_basic_setup.rs
@@ -1,10 +1,10 @@
 //! # Axum Basic Setup Example
 //!
-//! This example demonstrates the most basic setup of AuthEngine with Axum.
+//! This example demonstrates the most basic setup of Engine with Axum.
 //! It uses an in-memory session store and a mock authentication provider.
 
-use authkestra::flow::AuthEngine;
-use authkestra_axum::{AuthEngineAxumError, AuthEngineAxumExt, AuthEngineState, AuthSession};
+use authkestra::flow::Engine;
+use authkestra_axum::{Error, AxumExt, State, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use axum::{
@@ -17,8 +17,8 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// AuthEngine state with support for session only.
-type AppState = AuthEngineState<Configured<Arc<dyn SessionStore>>>;
+/// Engine state with support for session only.
+type AppState = State<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {
@@ -26,7 +26,7 @@ async fn main() {
     let session_store: Arc<dyn SessionStore> =
         Arc::new(authkestra_engine::store::memory::MemoryStore::default());
 
-    let auth_engine = AuthEngine::builder()
+    let auth_engine = Engine::builder()
         .session_store(session_store)
         .session_config(SessionConfig {
             secure: false, // For local development
@@ -53,7 +53,7 @@ async fn main() {
 }
 
 /// API endpoint to get current user info from session
-async fn get_user(session: Result<AuthSession, AuthEngineAxumError>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, Error>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_basic_setup.rs
+++ b/crates/authkestra/examples/axum_basic_setup.rs
@@ -4,7 +4,7 @@
 //! It uses an in-memory session store and a mock authentication provider.
 
 use authkestra::flow::Engine;
-use authkestra_axum::{AxumError, AxumExt, AxumState, AuthSession};
+use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use axum::{

--- a/crates/authkestra/examples/axum_basic_setup.rs
+++ b/crates/authkestra/examples/axum_basic_setup.rs
@@ -4,7 +4,7 @@
 //! It uses an in-memory session store and a mock authentication provider.
 
 use authkestra::flow::AkBase;
-use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AkState};
+use authkestra_axum::{AkAxumError, AkAxumExt, AkState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use axum::{

--- a/crates/authkestra/examples/axum_basic_setup.rs
+++ b/crates/authkestra/examples/axum_basic_setup.rs
@@ -1,10 +1,10 @@
 //! # Axum Basic Setup Example
 //!
-//! This example demonstrates the most basic setup of AuthEngine with Axum.
+//! This example demonstrates the most basic setup of AkBase with Axum.
 //! It uses an in-memory session store and a mock authentication provider.
 
-use authkestra::flow::AuthEngine;
-use authkestra_axum::{AuthSession, AuthkestraAxumError, AuthkestraAxumExt, AuthkestraState};
+use authkestra::flow::AkBase;
+use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AuthkestraState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use axum::{
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// AuthEngine state with support for session only.
+/// AkBase state with support for session only.
 type AppState = AuthkestraState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
@@ -26,7 +26,7 @@ async fn main() {
     let session_store: Arc<dyn SessionStore> =
         Arc::new(authkestra_engine::store::memory::MemoryStore::default());
 
-    let auth_engine = AuthEngine::builder()
+    let auth_engine = AkBase::builder()
         .session_store(session_store)
         .session_config(SessionConfig {
             secure: false, // For local development
@@ -53,7 +53,7 @@ async fn main() {
 }
 
 /// API endpoint to get current user info from session
-async fn get_user(session: Result<AuthSession, AuthkestraAxumError>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, AkAxumError>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_basic_setup.rs
+++ b/crates/authkestra/examples/axum_basic_setup.rs
@@ -4,7 +4,7 @@
 //! It uses an in-memory session store and a mock authentication provider.
 
 use authkestra::flow::AkBase;
-use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AuthkestraState};
+use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AkState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use axum::{
@@ -18,7 +18,7 @@ use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
 /// AkBase state with support for session only.
-type AppState = AuthkestraState<Configured<Arc<dyn SessionStore>>>;
+type AppState = AkState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {

--- a/crates/authkestra/examples/axum_data_layer_macros.rs
+++ b/crates/authkestra/examples/axum_data_layer_macros.rs
@@ -8,7 +8,7 @@
 //! to the internal unified `SqlKvStore`.
 
 use authkestra::flow::Engine;
-use authkestra_axum::{AxumError, AxumExt, AuthSession, AxumState};
+use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_macros::KvStore;

--- a/crates/authkestra/examples/axum_data_layer_macros.rs
+++ b/crates/authkestra/examples/axum_data_layer_macros.rs
@@ -7,8 +7,8 @@
 //! it automatically generates the implementations for the data layer traits by delegating
 //! to the internal unified `SqlKvStore`.
 
-use authkestra::flow::AuthEngine;
-use authkestra_axum::{AuthSession, AuthkestraAxumError, AuthkestraAxumExt, AuthkestraState};
+use authkestra::flow::AkBase;
+use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AuthkestraState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_macros::AuthkestraKvStore;
@@ -36,7 +36,7 @@ pub struct MySqliteSessionStore(authkestra_engine::store::sql::SqlKvStore<sqlx::
 struct AppState {
     // Automatically extracts SessionStore and SessionConfig
     #[authkestra(engine)]
-    auth: AuthEngine<Configured<Arc<dyn SessionStore>>, authkestra_engine::Missing>,
+    auth: AkBase<Configured<Arc<dyn SessionStore>>, authkestra_engine::Missing>,
 }
 
 // ============================================================================
@@ -73,7 +73,7 @@ async fn main() {
 
     let session_store_arc: Arc<dyn SessionStore> = Arc::new(session_store);
 
-    let auth_engine = AuthEngine::builder()
+    let auth_engine = AkBase::builder()
         .session_store(session_store_arc)
         .session_config(SessionConfig {
             secure: false,

--- a/crates/authkestra/examples/axum_data_layer_macros.rs
+++ b/crates/authkestra/examples/axum_data_layer_macros.rs
@@ -7,8 +7,8 @@
 //! it automatically generates the implementations for the data layer traits by delegating
 //! to the internal unified `SqlKvStore`.
 
-use authkestra::flow::AkBase;
-use authkestra_axum::{AkAxumError, AkAxumExt, AuthSession, AuthkestraState};
+use authkestra::flow::AuthEngine;
+use authkestra_axum::{AuthEngineAxumError, AuthEngineAxumExt, AuthSession, AuthkestraState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_macros::AuthkestraKvStore;
@@ -36,7 +36,7 @@ pub struct MySqliteSessionStore(authkestra_engine::store::sql::SqlKvStore<sqlx::
 struct AppState {
     // Automatically extracts SessionStore and SessionConfig
     #[authkestra(engine)]
-    auth: AkBase<Configured<Arc<dyn SessionStore>>, authkestra_engine::Missing>,
+    auth: AuthEngine<Configured<Arc<dyn SessionStore>>, authkestra_engine::Missing>,
 }
 
 // ============================================================================
@@ -73,7 +73,7 @@ async fn main() {
 
     let session_store_arc: Arc<dyn SessionStore> = Arc::new(session_store);
 
-    let auth_engine = AkBase::builder()
+    let auth_engine = AuthEngine::builder()
         .session_store(session_store_arc)
         .session_config(SessionConfig {
             secure: false,

--- a/crates/authkestra/examples/axum_data_layer_macros.rs
+++ b/crates/authkestra/examples/axum_data_layer_macros.rs
@@ -1,17 +1,17 @@
 //! # Axum Data Layer Macros Example
 //!
-//! This example demonstrates how to use the `AuthkestraKvStore`
+//! This example demonstrates how to use the `KvStore`
 //! derive macro to eliminate SQL boilerplate.
 //!
 //! By wrapping a `sqlx::Pool` in a tuple struct and decorating it with the macros,
 //! it automatically generates the implementations for the data layer traits by delegating
 //! to the internal unified `SqlKvStore`.
 
-use authkestra::flow::AuthEngine;
-use authkestra_axum::{AuthEngineAxumError, AuthEngineAxumExt, AuthSession, AuthkestraState};
+use authkestra::flow::Engine;
+use authkestra_axum::{Error, AxumExt, AuthSession, State};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
-use authkestra_macros::AuthkestraKvStore;
+use authkestra_macros::KvStore;
 use axum::Router;
 use sqlx::sqlite::SqlitePoolOptions;
 use std::sync::Arc;
@@ -24,19 +24,19 @@ use tower_http::services::ServeDir;
 
 /// A custom session store derived via macro, wrapping an existing KvStore implementation.
 /// The macro delegates all KvStore methods to the internal `SqlKvStore`.
-#[derive(AuthkestraKvStore)]
+#[derive(KvStore)]
 pub struct MySqliteSessionStore(authkestra_engine::store::sql::SqlKvStore<sqlx::Sqlite>);
 
 // ============================================================================
 // 2. Zero-Boilerplate Application State Extraction
 // ============================================================================
 
-/// The AuthkestraState macro generates all the axum FromRef implementations.
-#[derive(Clone, AuthkestraState)]
+/// The State macro generates all the axum FromRef implementations.
+#[derive(Clone, State)]
 struct AppState {
     // Automatically extracts SessionStore and SessionConfig
     #[authkestra(engine)]
-    auth: AuthEngine<Configured<Arc<dyn SessionStore>>, authkestra_engine::Missing>,
+    auth: Engine<Configured<Arc<dyn SessionStore>>, authkestra_engine::Missing>,
 }
 
 // ============================================================================
@@ -73,7 +73,7 @@ async fn main() {
 
     let session_store_arc: Arc<dyn SessionStore> = Arc::new(session_store);
 
-    let auth_engine = AuthEngine::builder()
+    let auth_engine = Engine::builder()
         .session_store(session_store_arc)
         .session_config(SessionConfig {
             secure: false,

--- a/crates/authkestra/examples/axum_data_layer_macros.rs
+++ b/crates/authkestra/examples/axum_data_layer_macros.rs
@@ -8,7 +8,7 @@
 //! to the internal unified `SqlKvStore`.
 
 use authkestra::flow::AkBase;
-use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AuthkestraState};
+use authkestra_axum::{AkAxumError, AkAxumExt, AuthSession, AuthkestraState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_macros::AuthkestraKvStore;

--- a/crates/authkestra/examples/axum_data_layer_macros.rs
+++ b/crates/authkestra/examples/axum_data_layer_macros.rs
@@ -8,7 +8,7 @@
 //! to the internal unified `SqlKvStore`.
 
 use authkestra::flow::Engine;
-use authkestra_axum::{Error, AxumExt, AuthSession, State};
+use authkestra_axum::{AxumError, AxumExt, AuthSession, AxumState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_macros::KvStore;
@@ -32,7 +32,7 @@ pub struct MySqliteSessionStore(authkestra_engine::store::sql::SqlKvStore<sqlx::
 // ============================================================================
 
 /// The State macro generates all the axum FromRef implementations.
-#[derive(Clone, State)]
+#[derive(Clone, AxumState)]
 struct AppState {
     // Automatically extracts SessionStore and SessionConfig
     #[authkestra(engine)]

--- a/crates/authkestra/examples/axum_oauth2_github.rs
+++ b/crates/authkestra/examples/axum_oauth2_github.rs
@@ -1,13 +1,13 @@
 //! # Axum GitHub OAuth2 Example
 //!
-//! This example demonstrates how to set up AkBase with Axum for GitHub OAuth2 login.
+//! This example demonstrates how to set up AuthEngine with Axum for GitHub OAuth2 login.
 //!
 //! To run this example, you'll need:
 //! - `AUTHKESTRA_GITHUB_CLIENT_ID`
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
-use authkestra::flow::{AkBase, OAuth2Flow};
-use authkestra_axum::{AkAxumError, AkAxumExt, AkState, AuthSession};
+use authkestra::flow::{AuthEngine, OAuth2Flow};
+use authkestra_axum::{AuthEngineAxumError, AuthEngineAxumExt, AuthEngineState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_providers::github::GithubProvider;
@@ -21,8 +21,8 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// AkBase state with support for session only.
-type AppState = AkState<Configured<Arc<dyn SessionStore>>>;
+/// AuthEngine state with support for session only.
+type AppState = AuthEngineState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {
@@ -57,7 +57,7 @@ async fn main() {
     let session_store: Arc<dyn SessionStore> =
         Arc::new(authkestra_engine::store::memory::MemoryStore::default());
 
-    let auth_engine = AkBase::builder()
+    let auth_engine = AuthEngine::builder()
         .provider(OAuth2Flow::new(github_provider))
         .session_store(session_store)
         .session_config(SessionConfig {
@@ -82,7 +82,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn get_user(session: Result<AuthSession, AkAxumError>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, AuthEngineAxumError>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_oauth2_github.rs
+++ b/crates/authkestra/examples/axum_oauth2_github.rs
@@ -7,7 +7,7 @@
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
 use authkestra::flow::{AkBase, OAuth2Flow};
-use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AuthkestraState};
+use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AkState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_providers::github::GithubProvider;
@@ -22,7 +22,7 @@ use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
 /// AkBase state with support for session only.
-type AppState = AuthkestraState<Configured<Arc<dyn SessionStore>>>;
+type AppState = AkState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {

--- a/crates/authkestra/examples/axum_oauth2_github.rs
+++ b/crates/authkestra/examples/axum_oauth2_github.rs
@@ -7,7 +7,7 @@
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
 use authkestra::flow::{Engine, OAuth2Flow};
-use authkestra_axum::{Error, AxumExt, State, AuthSession};
+use authkestra_axum::{AxumError, AxumExt, AxumState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_providers::github::GithubProvider;
@@ -22,7 +22,7 @@ use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
 /// Engine state with support for session only.
-type AppState = State<Configured<Arc<dyn SessionStore>>>;
+type AppState = AxumState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {
@@ -82,7 +82,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn get_user(session: Result<AuthSession, Error>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, AxumError>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_oauth2_github.rs
+++ b/crates/authkestra/examples/axum_oauth2_github.rs
@@ -1,13 +1,13 @@
 //! # Axum GitHub OAuth2 Example
 //!
-//! This example demonstrates how to set up AuthEngine with Axum for GitHub OAuth2 login.
+//! This example demonstrates how to set up AkBase with Axum for GitHub OAuth2 login.
 //!
 //! To run this example, you'll need:
 //! - `AUTHKESTRA_GITHUB_CLIENT_ID`
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
-use authkestra::flow::{AuthEngine, OAuth2Flow};
-use authkestra_axum::{AuthSession, AuthkestraAxumError, AuthkestraAxumExt, AuthkestraState};
+use authkestra::flow::{AkBase, OAuth2Flow};
+use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AuthkestraState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_providers::github::GithubProvider;
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// AuthEngine state with support for session only.
+/// AkBase state with support for session only.
 type AppState = AuthkestraState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
@@ -57,7 +57,7 @@ async fn main() {
     let session_store: Arc<dyn SessionStore> =
         Arc::new(authkestra_engine::store::memory::MemoryStore::default());
 
-    let auth_engine = AuthEngine::builder()
+    let auth_engine = AkBase::builder()
         .provider(OAuth2Flow::new(github_provider))
         .session_store(session_store)
         .session_config(SessionConfig {
@@ -82,7 +82,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn get_user(session: Result<AuthSession, AuthkestraAxumError>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, AkAxumError>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_oauth2_github.rs
+++ b/crates/authkestra/examples/axum_oauth2_github.rs
@@ -1,13 +1,13 @@
 //! # Axum GitHub OAuth2 Example
 //!
-//! This example demonstrates how to set up AuthEngine with Axum for GitHub OAuth2 login.
+//! This example demonstrates how to set up Engine with Axum for GitHub OAuth2 login.
 //!
 //! To run this example, you'll need:
 //! - `AUTHKESTRA_GITHUB_CLIENT_ID`
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
-use authkestra::flow::{AuthEngine, OAuth2Flow};
-use authkestra_axum::{AuthEngineAxumError, AuthEngineAxumExt, AuthEngineState, AuthSession};
+use authkestra::flow::{Engine, OAuth2Flow};
+use authkestra_axum::{Error, AxumExt, State, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_providers::github::GithubProvider;
@@ -21,8 +21,8 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// AuthEngine state with support for session only.
-type AppState = AuthEngineState<Configured<Arc<dyn SessionStore>>>;
+/// Engine state with support for session only.
+type AppState = State<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {
@@ -57,7 +57,7 @@ async fn main() {
     let session_store: Arc<dyn SessionStore> =
         Arc::new(authkestra_engine::store::memory::MemoryStore::default());
 
-    let auth_engine = AuthEngine::builder()
+    let auth_engine = Engine::builder()
         .provider(OAuth2Flow::new(github_provider))
         .session_store(session_store)
         .session_config(SessionConfig {
@@ -82,7 +82,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn get_user(session: Result<AuthSession, AuthEngineAxumError>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, Error>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_oauth2_github.rs
+++ b/crates/authkestra/examples/axum_oauth2_github.rs
@@ -7,7 +7,7 @@
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
 use authkestra::flow::{AkBase, OAuth2Flow};
-use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AkState};
+use authkestra_axum::{AkAxumError, AkAxumExt, AkState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_providers::github::GithubProvider;

--- a/crates/authkestra/examples/axum_oauth2_github.rs
+++ b/crates/authkestra/examples/axum_oauth2_github.rs
@@ -7,7 +7,7 @@
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
 use authkestra::flow::{Engine, OAuth2Flow};
-use authkestra_axum::{AxumError, AxumExt, AxumState, AuthSession};
+use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_providers::github::GithubProvider;

--- a/crates/authkestra/examples/axum_oauth_stateless.rs
+++ b/crates/authkestra/examples/axum_oauth_stateless.rs
@@ -1,14 +1,14 @@
 //! # Axum Stateless OAuth Example
 //!
-//! This example demonstrates how to set up AuthEngine for OAuth2 in stateless mode,
+//! This example demonstrates how to set up AkBase for OAuth2 in stateless mode,
 //! where the callback returns a JWT instead of creating a server-side session.
 //!
 //! To run this example, you'll need:
 //! - `AUTHKESTRA_GITHUB_CLIENT_ID`
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
-use authkestra::flow::{AuthEngine, OAuth2Flow};
-use authkestra_axum::{helpers, AuthToken, AuthkestraAxumError};
+use authkestra::flow::{AkBase, OAuth2Flow};
+use authkestra_axum::{helpers, AuthToken, AkAxumError};
 use authkestra_engine::{token::TokenManager, Configured, Missing};
 use authkestra_providers::github::GithubProvider;
 use axum::{
@@ -22,21 +22,21 @@ use serde_json::json;
 use std::sync::Arc;
 use tower_cookies::Cookies;
 
-/// AuthEngine state with support for tokens (stateless mode).
+/// AkBase state with support for tokens (stateless mode).
 #[derive(Clone)]
 struct AppState {
-    authkestra: AuthEngine<Missing, Configured<Arc<TokenManager>>>,
+    authkestra: AkBase<Missing, Configured<Arc<TokenManager>>>,
 }
 
 /// Required for the `AuthToken` extractor and internal helpers.
-impl FromRef<AppState> for Result<Arc<TokenManager>, AuthkestraAxumError> {
+impl FromRef<AppState> for Result<Arc<TokenManager>, AkAxumError> {
     fn from_ref(state: &AppState) -> Self {
         Ok(state.authkestra.token_manager.0.clone())
     }
 }
 
-/// Required for the `AuthEngine` to be used in generic handlers.
-impl FromRef<AppState> for AuthEngine<Missing, Configured<Arc<TokenManager>>> {
+/// Required for the `AkBase` to be used in generic handlers.
+impl FromRef<AppState> for AkBase<Missing, Configured<Arc<TokenManager>>> {
     fn from_ref(state: &AppState) -> Self {
         state.authkestra.clone()
     }
@@ -64,7 +64,7 @@ async fn main() {
     let github_provider = GithubProvider::new(client_id, client_secret, redirect_uri);
 
     // Initialize Authkestra in stateless mode (JWT only).
-    let auth_engine = AuthEngine::builder()
+    let auth_engine = AkBase::builder()
         .provider(OAuth2Flow::new(github_provider))
         .jwt_secret(b"your-256-bit-secret-key-at-least-32-bytes-long")
         .build();
@@ -90,7 +90,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-/// Custom login handler using AuthEngine helpers.
+/// Custom login handler using AkBase helpers.
 async fn login_handler(
     Path(provider): Path<String>,
     State(state): State<AppState>,
@@ -112,12 +112,12 @@ async fn callback_handler(
     State(state): State<AppState>,
     Query(params): Query<helpers::OAuthCallbackParams>,
     cookies: Cookies,
-) -> Result<impl IntoResponse, AuthkestraAxumError> {
-    let token_manager = <Result<Arc<TokenManager>, AuthkestraAxumError>>::from_ref(&state)?;
+) -> Result<impl IntoResponse, AkAxumError> {
+    let token_manager = <Result<Arc<TokenManager>, AkAxumError>>::from_ref(&state)?;
 
     let flow =
         state.authkestra.providers.get(&provider).ok_or_else(|| {
-            AuthkestraAxumError::Internal(format!("Provider {} not found", provider))
+            AkAxumError::Internal(format!("Provider {} not found", provider))
         })?;
 
     // We use the JWT-specific callback helper
@@ -132,15 +132,15 @@ async fn callback_handler(
     .await
     .map_err(|(status, msg)| {
         if status == StatusCode::UNAUTHORIZED {
-            AuthkestraAxumError::Unauthorized(msg)
+            AkAxumError::Unauthorized(msg)
         } else {
-            AuthkestraAxumError::Internal(msg)
+            AkAxumError::Internal(msg)
         }
     })
 }
 
 /// Protected endpoint using `AuthToken` extractor.
-async fn get_user(auth: Result<AuthToken, AuthkestraAxumError>) -> impl IntoResponse {
+async fn get_user(auth: Result<AuthToken, AkAxumError>) -> impl IntoResponse {
     match auth {
         Ok(AuthToken(claims)) => {
             let identity = claims.identity.as_ref().unwrap();

--- a/crates/authkestra/examples/axum_oauth_stateless.rs
+++ b/crates/authkestra/examples/axum_oauth_stateless.rs
@@ -8,7 +8,7 @@
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
 use authkestra::flow::{AkBase, OAuth2Flow};
-use authkestra_axum::{helpers, AuthToken, AkAxumError};
+use authkestra_axum::{helpers, AkAxumError, AuthToken};
 use authkestra_engine::{token::TokenManager, Configured, Missing};
 use authkestra_providers::github::GithubProvider;
 use axum::{
@@ -115,10 +115,11 @@ async fn callback_handler(
 ) -> Result<impl IntoResponse, AkAxumError> {
     let token_manager = <Result<Arc<TokenManager>, AkAxumError>>::from_ref(&state)?;
 
-    let flow =
-        state.authkestra.providers.get(&provider).ok_or_else(|| {
-            AkAxumError::Internal(format!("Provider {} not found", provider))
-        })?;
+    let flow = state
+        .authkestra
+        .providers
+        .get(&provider)
+        .ok_or_else(|| AkAxumError::Internal(format!("Provider {} not found", provider)))?;
 
     // We use the JWT-specific callback helper
     helpers::handle_oauth_callback_jwt_erased(

--- a/crates/authkestra/examples/axum_oauth_stateless.rs
+++ b/crates/authkestra/examples/axum_oauth_stateless.rs
@@ -1,14 +1,14 @@
 //! # Axum Stateless OAuth Example
 //!
-//! This example demonstrates how to set up AkBase for OAuth2 in stateless mode,
+//! This example demonstrates how to set up AuthEngine for OAuth2 in stateless mode,
 //! where the callback returns a JWT instead of creating a server-side session.
 //!
 //! To run this example, you'll need:
 //! - `AUTHKESTRA_GITHUB_CLIENT_ID`
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
-use authkestra::flow::{AkBase, OAuth2Flow};
-use authkestra_axum::{helpers, AkAxumError, AuthToken};
+use authkestra::flow::{AuthEngine, OAuth2Flow};
+use authkestra_axum::{helpers, AuthEngineAxumError, AuthToken};
 use authkestra_engine::{token::TokenManager, Configured, Missing};
 use authkestra_providers::github::GithubProvider;
 use axum::{
@@ -22,21 +22,21 @@ use serde_json::json;
 use std::sync::Arc;
 use tower_cookies::Cookies;
 
-/// AkBase state with support for tokens (stateless mode).
+/// AuthEngine state with support for tokens (stateless mode).
 #[derive(Clone)]
 struct AppState {
-    authkestra: AkBase<Missing, Configured<Arc<TokenManager>>>,
+    authkestra: AuthEngine<Missing, Configured<Arc<TokenManager>>>,
 }
 
 /// Required for the `AuthToken` extractor and internal helpers.
-impl FromRef<AppState> for Result<Arc<TokenManager>, AkAxumError> {
+impl FromRef<AppState> for Result<Arc<TokenManager>, AuthEngineAxumError> {
     fn from_ref(state: &AppState) -> Self {
         Ok(state.authkestra.token_manager.0.clone())
     }
 }
 
-/// Required for the `AkBase` to be used in generic handlers.
-impl FromRef<AppState> for AkBase<Missing, Configured<Arc<TokenManager>>> {
+/// Required for the `AuthEngine` to be used in generic handlers.
+impl FromRef<AppState> for AuthEngine<Missing, Configured<Arc<TokenManager>>> {
     fn from_ref(state: &AppState) -> Self {
         state.authkestra.clone()
     }
@@ -64,7 +64,7 @@ async fn main() {
     let github_provider = GithubProvider::new(client_id, client_secret, redirect_uri);
 
     // Initialize Authkestra in stateless mode (JWT only).
-    let auth_engine = AkBase::builder()
+    let auth_engine = AuthEngine::builder()
         .provider(OAuth2Flow::new(github_provider))
         .jwt_secret(b"your-256-bit-secret-key-at-least-32-bytes-long")
         .build();
@@ -90,7 +90,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-/// Custom login handler using AkBase helpers.
+/// Custom login handler using AuthEngine helpers.
 async fn login_handler(
     Path(provider): Path<String>,
     State(state): State<AppState>,
@@ -112,14 +112,14 @@ async fn callback_handler(
     State(state): State<AppState>,
     Query(params): Query<helpers::OAuthCallbackParams>,
     cookies: Cookies,
-) -> Result<impl IntoResponse, AkAxumError> {
-    let token_manager = <Result<Arc<TokenManager>, AkAxumError>>::from_ref(&state)?;
+) -> Result<impl IntoResponse, AuthEngineAxumError> {
+    let token_manager = <Result<Arc<TokenManager>, AuthEngineAxumError>>::from_ref(&state)?;
 
     let flow = state
         .authkestra
         .providers
         .get(&provider)
-        .ok_or_else(|| AkAxumError::Internal(format!("Provider {} not found", provider)))?;
+        .ok_or_else(|| AuthEngineAxumError::Internal(format!("Provider {} not found", provider)))?;
 
     // We use the JWT-specific callback helper
     helpers::handle_oauth_callback_jwt_erased(
@@ -133,15 +133,15 @@ async fn callback_handler(
     .await
     .map_err(|(status, msg)| {
         if status == StatusCode::UNAUTHORIZED {
-            AkAxumError::Unauthorized(msg)
+            AuthEngineAxumError::Unauthorized(msg)
         } else {
-            AkAxumError::Internal(msg)
+            AuthEngineAxumError::Internal(msg)
         }
     })
 }
 
 /// Protected endpoint using `AuthToken` extractor.
-async fn get_user(auth: Result<AuthToken, AkAxumError>) -> impl IntoResponse {
+async fn get_user(auth: Result<AuthToken, AuthEngineAxumError>) -> impl IntoResponse {
     match auth {
         Ok(AuthToken(claims)) => {
             let identity = claims.identity.as_ref().unwrap();

--- a/crates/authkestra/examples/axum_oauth_stateless.rs
+++ b/crates/authkestra/examples/axum_oauth_stateless.rs
@@ -8,7 +8,7 @@
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
 use authkestra::flow::{Engine, OAuth2Flow};
-use authkestra_axum::{helpers, Error, AuthToken};
+use authkestra_axum::{helpers, AxumError, AuthToken};
 use authkestra_engine::{token::TokenManager, Configured, Missing};
 use authkestra_providers::github::GithubProvider;
 use axum::{
@@ -29,7 +29,7 @@ struct AppState {
 }
 
 /// Required for the `AuthToken` extractor and internal helpers.
-impl FromRef<AppState> for Result<Arc<TokenManager>, Error> {
+impl FromRef<AppState> for Result<Arc<TokenManager>, AxumError> {
     fn from_ref(state: &AppState) -> Self {
         Ok(state.authkestra.token_manager.0.clone())
     }
@@ -112,14 +112,14 @@ async fn callback_handler(
     State(state): State<AppState>,
     Query(params): Query<helpers::OAuthCallbackParams>,
     cookies: Cookies,
-) -> Result<impl IntoResponse, Error> {
-    let token_manager = <Result<Arc<TokenManager>, Error>>::from_ref(&state)?;
+) -> Result<impl IntoResponse, AxumError> {
+    let token_manager = <Result<Arc<TokenManager>, AxumError>>::from_ref(&state)?;
 
     let flow = state
         .authkestra
         .providers
         .get(&provider)
-        .ok_or_else(|| Error::Internal(format!("Provider {} not found", provider)))?;
+        .ok_or_else(|| AxumError::Internal(format!("Provider {} not found", provider)))?;
 
     // We use the JWT-specific callback helper
     helpers::handle_oauth_callback_jwt_erased(
@@ -133,15 +133,15 @@ async fn callback_handler(
     .await
     .map_err(|(status, msg)| {
         if status == StatusCode::UNAUTHORIZED {
-            Error::Unauthorized(msg)
+            AxumError::Unauthorized(msg)
         } else {
-            Error::Internal(msg)
+            AxumError::Internal(msg)
         }
     })
 }
 
 /// Protected endpoint using `AuthToken` extractor.
-async fn get_user(auth: Result<AuthToken, Error>) -> impl IntoResponse {
+async fn get_user(auth: Result<AuthToken, AxumError>) -> impl IntoResponse {
     match auth {
         Ok(AuthToken(claims)) => {
             let identity = claims.identity.as_ref().unwrap();

--- a/crates/authkestra/examples/axum_oauth_stateless.rs
+++ b/crates/authkestra/examples/axum_oauth_stateless.rs
@@ -8,7 +8,7 @@
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
 use authkestra::flow::{Engine, OAuth2Flow};
-use authkestra_axum::{helpers, AxumError, AuthToken};
+use authkestra_axum::{helpers, AuthToken, AxumError};
 use authkestra_engine::{token::TokenManager, Configured, Missing};
 use authkestra_providers::github::GithubProvider;
 use axum::{

--- a/crates/authkestra/examples/axum_oauth_stateless.rs
+++ b/crates/authkestra/examples/axum_oauth_stateless.rs
@@ -1,14 +1,14 @@
 //! # Axum Stateless OAuth Example
 //!
-//! This example demonstrates how to set up AuthEngine for OAuth2 in stateless mode,
+//! This example demonstrates how to set up Engine for OAuth2 in stateless mode,
 //! where the callback returns a JWT instead of creating a server-side session.
 //!
 //! To run this example, you'll need:
 //! - `AUTHKESTRA_GITHUB_CLIENT_ID`
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
-use authkestra::flow::{AuthEngine, OAuth2Flow};
-use authkestra_axum::{helpers, AuthEngineAxumError, AuthToken};
+use authkestra::flow::{Engine, OAuth2Flow};
+use authkestra_axum::{helpers, Error, AuthToken};
 use authkestra_engine::{token::TokenManager, Configured, Missing};
 use authkestra_providers::github::GithubProvider;
 use axum::{
@@ -22,21 +22,21 @@ use serde_json::json;
 use std::sync::Arc;
 use tower_cookies::Cookies;
 
-/// AuthEngine state with support for tokens (stateless mode).
+/// Engine state with support for tokens (stateless mode).
 #[derive(Clone)]
 struct AppState {
-    authkestra: AuthEngine<Missing, Configured<Arc<TokenManager>>>,
+    authkestra: Engine<Missing, Configured<Arc<TokenManager>>>,
 }
 
 /// Required for the `AuthToken` extractor and internal helpers.
-impl FromRef<AppState> for Result<Arc<TokenManager>, AuthEngineAxumError> {
+impl FromRef<AppState> for Result<Arc<TokenManager>, Error> {
     fn from_ref(state: &AppState) -> Self {
         Ok(state.authkestra.token_manager.0.clone())
     }
 }
 
-/// Required for the `AuthEngine` to be used in generic handlers.
-impl FromRef<AppState> for AuthEngine<Missing, Configured<Arc<TokenManager>>> {
+/// Required for the `Engine` to be used in generic handlers.
+impl FromRef<AppState> for Engine<Missing, Configured<Arc<TokenManager>>> {
     fn from_ref(state: &AppState) -> Self {
         state.authkestra.clone()
     }
@@ -64,7 +64,7 @@ async fn main() {
     let github_provider = GithubProvider::new(client_id, client_secret, redirect_uri);
 
     // Initialize Authkestra in stateless mode (JWT only).
-    let auth_engine = AuthEngine::builder()
+    let auth_engine = Engine::builder()
         .provider(OAuth2Flow::new(github_provider))
         .jwt_secret(b"your-256-bit-secret-key-at-least-32-bytes-long")
         .build();
@@ -90,7 +90,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-/// Custom login handler using AuthEngine helpers.
+/// Custom login handler using Engine helpers.
 async fn login_handler(
     Path(provider): Path<String>,
     State(state): State<AppState>,
@@ -112,14 +112,14 @@ async fn callback_handler(
     State(state): State<AppState>,
     Query(params): Query<helpers::OAuthCallbackParams>,
     cookies: Cookies,
-) -> Result<impl IntoResponse, AuthEngineAxumError> {
-    let token_manager = <Result<Arc<TokenManager>, AuthEngineAxumError>>::from_ref(&state)?;
+) -> Result<impl IntoResponse, Error> {
+    let token_manager = <Result<Arc<TokenManager>, Error>>::from_ref(&state)?;
 
     let flow = state
         .authkestra
         .providers
         .get(&provider)
-        .ok_or_else(|| AuthEngineAxumError::Internal(format!("Provider {} not found", provider)))?;
+        .ok_or_else(|| Error::Internal(format!("Provider {} not found", provider)))?;
 
     // We use the JWT-specific callback helper
     helpers::handle_oauth_callback_jwt_erased(
@@ -133,15 +133,15 @@ async fn callback_handler(
     .await
     .map_err(|(status, msg)| {
         if status == StatusCode::UNAUTHORIZED {
-            AuthEngineAxumError::Unauthorized(msg)
+            Error::Unauthorized(msg)
         } else {
-            AuthEngineAxumError::Internal(msg)
+            Error::Internal(msg)
         }
     })
 }
 
 /// Protected endpoint using `AuthToken` extractor.
-async fn get_user(auth: Result<AuthToken, AuthEngineAxumError>) -> impl IntoResponse {
+async fn get_user(auth: Result<AuthToken, Error>) -> impl IntoResponse {
     match auth {
         Ok(AuthToken(claims)) => {
             let identity = claims.identity.as_ref().unwrap();

--- a/crates/authkestra/examples/axum_oidc_google.rs
+++ b/crates/authkestra/examples/axum_oidc_google.rs
@@ -1,13 +1,13 @@
 //! # Axum Google OIDC Example
 //!
-//! This example demonstrates how to set up AuthEngine with Axum for Google OIDC login.
+//! This example demonstrates how to set up Engine with Axum for Google OIDC login.
 //!
 //! To run this example, you'll need:
 //! - `AUTHKESTRA_GOOGLE_CLIENT_ID`
 //! - `AUTHKESTRA_GOOGLE_CLIENT_SECRET`
 
-use authkestra::flow::{AuthEngine, OAuth2Flow};
-use authkestra_axum::{AuthEngineAxumError, AuthEngineAxumExt, AuthEngineState, AuthSession};
+use authkestra::flow::{Engine, OAuth2Flow};
+use authkestra_axum::{Error, AxumExt, State, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_providers::google::GoogleProvider;
@@ -21,8 +21,8 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// AuthEngine state with support for session only.
-type AppState = AuthEngineState<Configured<Arc<dyn SessionStore>>>;
+/// Engine state with support for session only.
+type AppState = State<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {
@@ -42,7 +42,7 @@ async fn main() {
     let session_store: Arc<dyn SessionStore> =
         Arc::new(authkestra_engine::store::memory::MemoryStore::default());
 
-    let auth_engine = AuthEngine::builder()
+    let auth_engine = Engine::builder()
         .provider(OAuth2Flow::new(google_provider))
         .session_store(session_store)
         .session_config(SessionConfig {
@@ -67,7 +67,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn get_user(session: Result<AuthSession, AuthEngineAxumError>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, Error>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_oidc_google.rs
+++ b/crates/authkestra/examples/axum_oidc_google.rs
@@ -7,7 +7,7 @@
 //! - `AUTHKESTRA_GOOGLE_CLIENT_SECRET`
 
 use authkestra::flow::{Engine, OAuth2Flow};
-use authkestra_axum::{Error, AxumExt, State, AuthSession};
+use authkestra_axum::{AxumError, AxumExt, AxumState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_providers::google::GoogleProvider;
@@ -22,7 +22,7 @@ use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
 /// Engine state with support for session only.
-type AppState = State<Configured<Arc<dyn SessionStore>>>;
+type AppState = AxumState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {
@@ -67,7 +67,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn get_user(session: Result<AuthSession, Error>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, AxumError>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_oidc_google.rs
+++ b/crates/authkestra/examples/axum_oidc_google.rs
@@ -1,13 +1,13 @@
 //! # Axum Google OIDC Example
 //!
-//! This example demonstrates how to set up AuthEngine with Axum for Google OIDC login.
+//! This example demonstrates how to set up AkBase with Axum for Google OIDC login.
 //!
 //! To run this example, you'll need:
 //! - `AUTHKESTRA_GOOGLE_CLIENT_ID`
 //! - `AUTHKESTRA_GOOGLE_CLIENT_SECRET`
 
-use authkestra::flow::{AuthEngine, OAuth2Flow};
-use authkestra_axum::{AuthSession, AuthkestraAxumError, AuthkestraAxumExt, AuthkestraState};
+use authkestra::flow::{AkBase, OAuth2Flow};
+use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AuthkestraState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_providers::google::GoogleProvider;
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// AuthEngine state with support for session only.
+/// AkBase state with support for session only.
 type AppState = AuthkestraState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
@@ -42,7 +42,7 @@ async fn main() {
     let session_store: Arc<dyn SessionStore> =
         Arc::new(authkestra_engine::store::memory::MemoryStore::default());
 
-    let auth_engine = AuthEngine::builder()
+    let auth_engine = AkBase::builder()
         .provider(OAuth2Flow::new(google_provider))
         .session_store(session_store)
         .session_config(SessionConfig {
@@ -67,7 +67,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn get_user(session: Result<AuthSession, AuthkestraAxumError>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, AkAxumError>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_oidc_google.rs
+++ b/crates/authkestra/examples/axum_oidc_google.rs
@@ -7,7 +7,7 @@
 //! - `AUTHKESTRA_GOOGLE_CLIENT_SECRET`
 
 use authkestra::flow::{Engine, OAuth2Flow};
-use authkestra_axum::{AxumError, AxumExt, AxumState, AuthSession};
+use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_providers::google::GoogleProvider;

--- a/crates/authkestra/examples/axum_oidc_google.rs
+++ b/crates/authkestra/examples/axum_oidc_google.rs
@@ -7,7 +7,7 @@
 //! - `AUTHKESTRA_GOOGLE_CLIENT_SECRET`
 
 use authkestra::flow::{AkBase, OAuth2Flow};
-use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AkState};
+use authkestra_axum::{AkAxumError, AkAxumExt, AkState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_providers::google::GoogleProvider;

--- a/crates/authkestra/examples/axum_oidc_google.rs
+++ b/crates/authkestra/examples/axum_oidc_google.rs
@@ -1,13 +1,13 @@
 //! # Axum Google OIDC Example
 //!
-//! This example demonstrates how to set up AkBase with Axum for Google OIDC login.
+//! This example demonstrates how to set up AuthEngine with Axum for Google OIDC login.
 //!
 //! To run this example, you'll need:
 //! - `AUTHKESTRA_GOOGLE_CLIENT_ID`
 //! - `AUTHKESTRA_GOOGLE_CLIENT_SECRET`
 
-use authkestra::flow::{AkBase, OAuth2Flow};
-use authkestra_axum::{AkAxumError, AkAxumExt, AkState, AuthSession};
+use authkestra::flow::{AuthEngine, OAuth2Flow};
+use authkestra_axum::{AuthEngineAxumError, AuthEngineAxumExt, AuthEngineState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_providers::google::GoogleProvider;
@@ -21,8 +21,8 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// AkBase state with support for session only.
-type AppState = AkState<Configured<Arc<dyn SessionStore>>>;
+/// AuthEngine state with support for session only.
+type AppState = AuthEngineState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {
@@ -42,7 +42,7 @@ async fn main() {
     let session_store: Arc<dyn SessionStore> =
         Arc::new(authkestra_engine::store::memory::MemoryStore::default());
 
-    let auth_engine = AkBase::builder()
+    let auth_engine = AuthEngine::builder()
         .provider(OAuth2Flow::new(google_provider))
         .session_store(session_store)
         .session_config(SessionConfig {
@@ -67,7 +67,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn get_user(session: Result<AuthSession, AkAxumError>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, AuthEngineAxumError>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_oidc_google.rs
+++ b/crates/authkestra/examples/axum_oidc_google.rs
@@ -7,7 +7,7 @@
 //! - `AUTHKESTRA_GOOGLE_CLIENT_SECRET`
 
 use authkestra::flow::{AkBase, OAuth2Flow};
-use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AuthkestraState};
+use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AkState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{Configured, SessionConfig};
 use authkestra_providers::google::GoogleProvider;
@@ -22,7 +22,7 @@ use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
 /// AkBase state with support for session only.
-type AppState = AuthkestraState<Configured<Arc<dyn SessionStore>>>;
+type AppState = AkState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {

--- a/crates/authkestra/examples/axum_op_server.rs
+++ b/crates/authkestra/examples/axum_op_server.rs
@@ -3,18 +3,18 @@
 //! This example demonstrates setting up an OpenID Connect Provider using authkestra-op and Axum.
 use authkestra_engine::store::KvStore;
 
-use authkestra_axum::AuthEngineAxumOpExt;
-use authkestra_engine::{AuthEngine, Configured, TokenManager};
+use authkestra_axum::OpExt;
+use authkestra_engine::{Engine, Configured, TokenManager};
 use authkestra_op::{client::ClientRegistration, config::OpConfig};
 use axum::Router;
 use std::sync::Arc;
 
-use authkestra_axum::AuthkestraState;
+use authkestra_axum::State;
 
-#[derive(Clone, AuthkestraState)]
+#[derive(Clone, State)]
 struct AppState {
     #[authkestra(engine)]
-    authkestra: AuthEngine<
+    authkestra: Engine<
         Configured<Arc<dyn authkestra_engine::auth::SessionStore>>,
         Configured<Arc<TokenManager>>,
     >,
@@ -64,7 +64,7 @@ async fn main() {
         ..Default::default()
     };
 
-    let authkestra = authkestra_engine::AuthEngine::builder()
+    let authkestra = authkestra_engine::Engine::builder()
         .session_store(session_store)
         .session_config(session_config)
         .token_manager(token_manager)

--- a/crates/authkestra/examples/axum_op_server.rs
+++ b/crates/authkestra/examples/axum_op_server.rs
@@ -3,8 +3,8 @@
 //! This example demonstrates setting up an OpenID Connect Provider using authkestra-op and Axum.
 use authkestra_engine::store::KvStore;
 
-use authkestra_axum::AuthEngineAxumOpExt;
-use authkestra_engine::{AuthEngine, Configured, TokenManager};
+use authkestra_axum::AkAxumOpExt;
+use authkestra_engine::{AkBase, Configured, TokenManager};
 use authkestra_op::{client::ClientRegistration, config::OpConfig};
 use axum::Router;
 use std::sync::Arc;
@@ -14,7 +14,7 @@ use authkestra_axum::AuthkestraState;
 #[derive(Clone, AuthkestraState)]
 struct AppState {
     #[authkestra(engine)]
-    authkestra: AuthEngine<
+    authkestra: AkBase<
         Configured<Arc<dyn authkestra_engine::auth::SessionStore>>,
         Configured<Arc<TokenManager>>,
     >,
@@ -64,7 +64,7 @@ async fn main() {
         ..Default::default()
     };
 
-    let authkestra = authkestra_engine::AuthEngine::builder()
+    let authkestra = authkestra_engine::AkBase::builder()
         .session_store(session_store)
         .session_config(session_config)
         .token_manager(token_manager)

--- a/crates/authkestra/examples/axum_op_server.rs
+++ b/crates/authkestra/examples/axum_op_server.rs
@@ -3,8 +3,8 @@
 //! This example demonstrates setting up an OpenID Connect Provider using authkestra-op and Axum.
 use authkestra_engine::store::KvStore;
 
-use authkestra_axum::AkAxumOpExt;
-use authkestra_engine::{AkBase, Configured, TokenManager};
+use authkestra_axum::AuthEngineAxumOpExt;
+use authkestra_engine::{AuthEngine, Configured, TokenManager};
 use authkestra_op::{client::ClientRegistration, config::OpConfig};
 use axum::Router;
 use std::sync::Arc;
@@ -14,7 +14,7 @@ use authkestra_axum::AuthkestraState;
 #[derive(Clone, AuthkestraState)]
 struct AppState {
     #[authkestra(engine)]
-    authkestra: AkBase<
+    authkestra: AuthEngine<
         Configured<Arc<dyn authkestra_engine::auth::SessionStore>>,
         Configured<Arc<TokenManager>>,
     >,
@@ -64,7 +64,7 @@ async fn main() {
         ..Default::default()
     };
 
-    let authkestra = authkestra_engine::AkBase::builder()
+    let authkestra = authkestra_engine::AuthEngine::builder()
         .session_store(session_store)
         .session_config(session_config)
         .token_manager(token_manager)

--- a/crates/authkestra/examples/axum_op_server.rs
+++ b/crates/authkestra/examples/axum_op_server.rs
@@ -9,9 +9,9 @@ use authkestra_op::{client::ClientRegistration, config::OpConfig};
 use axum::Router;
 use std::sync::Arc;
 
-use authkestra_axum::State;
+use authkestra_axum::AxumState;
 
-#[derive(Clone, State)]
+#[derive(Clone, AxumState)]
 struct AppState {
     #[authkestra(engine)]
     authkestra: Engine<

--- a/crates/authkestra/examples/axum_op_server.rs
+++ b/crates/authkestra/examples/axum_op_server.rs
@@ -4,7 +4,7 @@
 use authkestra_engine::store::KvStore;
 
 use authkestra_axum::OpExt;
-use authkestra_engine::{Engine, Configured, TokenManager};
+use authkestra_engine::{Configured, Engine, TokenManager};
 use authkestra_op::{client::ClientRegistration, config::OpConfig};
 use axum::Router;
 use std::sync::Arc;

--- a/crates/authkestra/examples/axum_resource_server_strategy.rs
+++ b/crates/authkestra/examples/axum_resource_server_strategy.rs
@@ -1,6 +1,6 @@
 //! # Axum Resource Server Strategy Example
 //!
-//! This example demonstrates how to use the Resource Server strategy with `AuthEngineGuard`
+//! This example demonstrates how to use the Resource Server strategy with `Guard`
 //! and the `Auth` extractor to protect an API.
 
 use authkestra_axum::Auth;
@@ -23,7 +23,7 @@ struct UserIdentity {
     scope: Option<String>,
 }
 
-/// AppState using Authkestra's `AuthEngineGuard` (ResourceEnforcer).
+/// AppState using Authkestra's `Guard` (ResourceEnforcer).
 #[derive(Clone)]
 struct AppState {
     resource_enforcer: Arc<ResourceEnforcer<UserIdentity>>,

--- a/crates/authkestra/examples/axum_resource_server_strategy.rs
+++ b/crates/authkestra/examples/axum_resource_server_strategy.rs
@@ -1,6 +1,6 @@
 //! # Axum Resource Server Strategy Example
 //!
-//! This example demonstrates how to use the Resource Server strategy with `AuthEngineGuard`
+//! This example demonstrates how to use the Resource Server strategy with `AkResourceGuard`
 //! and the `Auth` extractor to protect an API.
 
 use authkestra_axum::Auth;
@@ -23,7 +23,7 @@ struct UserIdentity {
     scope: Option<String>,
 }
 
-/// AppState using Authkestra's `AuthEngineGuard` (ResourceEnforcer).
+/// AppState using Authkestra's `AkResourceGuard` (ResourceEnforcer).
 #[derive(Clone)]
 struct AppState {
     resource_enforcer: Arc<ResourceEnforcer<UserIdentity>>,

--- a/crates/authkestra/examples/axum_resource_server_strategy.rs
+++ b/crates/authkestra/examples/axum_resource_server_strategy.rs
@@ -1,6 +1,6 @@
 //! # Axum Resource Server Strategy Example
 //!
-//! This example demonstrates how to use the Resource Server strategy with `AkResourceGuard`
+//! This example demonstrates how to use the Resource Server strategy with `AuthEngineGuard`
 //! and the `Auth` extractor to protect an API.
 
 use authkestra_axum::Auth;
@@ -23,7 +23,7 @@ struct UserIdentity {
     scope: Option<String>,
 }
 
-/// AppState using Authkestra's `AkResourceGuard` (ResourceEnforcer).
+/// AppState using Authkestra's `AuthEngineGuard` (ResourceEnforcer).
 #[derive(Clone)]
 struct AppState {
     resource_enforcer: Arc<ResourceEnforcer<UserIdentity>>,

--- a/crates/authkestra/examples/axum_session_redis.rs
+++ b/crates/authkestra/examples/axum_session_redis.rs
@@ -6,8 +6,8 @@
 //! - A running Redis instance
 //! - `REDIS_URL` environment variable (e.g., `redis://127.0.0.1/`)
 
-use authkestra::flow::AuthEngine;
-use authkestra_axum::{AuthEngineAxumError, AuthEngineAxumExt, AuthEngineState, AuthSession};
+use authkestra::flow::Engine;
+use authkestra_axum::{Error, AxumExt, State, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::store::redis::RedisStore;
 use authkestra_engine::{Configured, SessionConfig};
@@ -21,8 +21,8 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// AuthEngine state with support for session only.
-type AppState = AuthEngineState<Configured<Arc<dyn SessionStore>>>;
+/// Engine state with support for session only.
+type AppState = State<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {
@@ -37,7 +37,7 @@ async fn main() {
             .expect("Failed to connect to Redis"),
     );
 
-    let auth_engine = AuthEngine::builder()
+    let auth_engine = Engine::builder()
         .session_store(session_store)
         .session_config(SessionConfig {
             secure: false,
@@ -61,7 +61,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn get_user(session: Result<AuthSession, AuthEngineAxumError>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, Error>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_session_redis.rs
+++ b/crates/authkestra/examples/axum_session_redis.rs
@@ -6,8 +6,8 @@
 //! - A running Redis instance
 //! - `REDIS_URL` environment variable (e.g., `redis://127.0.0.1/`)
 
-use authkestra::flow::AkBase;
-use authkestra_axum::{AkAxumError, AkAxumExt, AkState, AuthSession};
+use authkestra::flow::AuthEngine;
+use authkestra_axum::{AuthEngineAxumError, AuthEngineAxumExt, AuthEngineState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::store::redis::RedisStore;
 use authkestra_engine::{Configured, SessionConfig};
@@ -21,8 +21,8 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// AkBase state with support for session only.
-type AppState = AkState<Configured<Arc<dyn SessionStore>>>;
+/// AuthEngine state with support for session only.
+type AppState = AuthEngineState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {
@@ -37,7 +37,7 @@ async fn main() {
             .expect("Failed to connect to Redis"),
     );
 
-    let auth_engine = AkBase::builder()
+    let auth_engine = AuthEngine::builder()
         .session_store(session_store)
         .session_config(SessionConfig {
             secure: false,
@@ -61,7 +61,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn get_user(session: Result<AuthSession, AkAxumError>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, AuthEngineAxumError>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_session_redis.rs
+++ b/crates/authkestra/examples/axum_session_redis.rs
@@ -7,7 +7,7 @@
 //! - `REDIS_URL` environment variable (e.g., `redis://127.0.0.1/`)
 
 use authkestra::flow::Engine;
-use authkestra_axum::{Error, AxumExt, State, AuthSession};
+use authkestra_axum::{AxumError, AxumExt, AxumState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::store::redis::RedisStore;
 use authkestra_engine::{Configured, SessionConfig};
@@ -22,7 +22,7 @@ use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
 /// Engine state with support for session only.
-type AppState = State<Configured<Arc<dyn SessionStore>>>;
+type AppState = AxumState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {
@@ -61,7 +61,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn get_user(session: Result<AuthSession, Error>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, AxumError>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_session_redis.rs
+++ b/crates/authkestra/examples/axum_session_redis.rs
@@ -7,7 +7,7 @@
 //! - `REDIS_URL` environment variable (e.g., `redis://127.0.0.1/`)
 
 use authkestra::flow::AkBase;
-use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AuthkestraState};
+use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AkState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::store::redis::RedisStore;
 use authkestra_engine::{Configured, SessionConfig};
@@ -22,7 +22,7 @@ use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
 /// AkBase state with support for session only.
-type AppState = AuthkestraState<Configured<Arc<dyn SessionStore>>>;
+type AppState = AkState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {

--- a/crates/authkestra/examples/axum_session_redis.rs
+++ b/crates/authkestra/examples/axum_session_redis.rs
@@ -7,7 +7,7 @@
 //! - `REDIS_URL` environment variable (e.g., `redis://127.0.0.1/`)
 
 use authkestra::flow::AkBase;
-use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AkState};
+use authkestra_axum::{AkAxumError, AkAxumExt, AkState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::store::redis::RedisStore;
 use authkestra_engine::{Configured, SessionConfig};

--- a/crates/authkestra/examples/axum_session_redis.rs
+++ b/crates/authkestra/examples/axum_session_redis.rs
@@ -6,8 +6,8 @@
 //! - A running Redis instance
 //! - `REDIS_URL` environment variable (e.g., `redis://127.0.0.1/`)
 
-use authkestra::flow::AuthEngine;
-use authkestra_axum::{AuthSession, AuthkestraAxumError, AuthkestraAxumExt, AuthkestraState};
+use authkestra::flow::AkBase;
+use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AuthkestraState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::store::redis::RedisStore;
 use authkestra_engine::{Configured, SessionConfig};
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// AuthEngine state with support for session only.
+/// AkBase state with support for session only.
 type AppState = AuthkestraState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
@@ -37,7 +37,7 @@ async fn main() {
             .expect("Failed to connect to Redis"),
     );
 
-    let auth_engine = AuthEngine::builder()
+    let auth_engine = AkBase::builder()
         .session_store(session_store)
         .session_config(SessionConfig {
             secure: false,
@@ -61,7 +61,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn get_user(session: Result<AuthSession, AuthkestraAxumError>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, AkAxumError>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_session_redis.rs
+++ b/crates/authkestra/examples/axum_session_redis.rs
@@ -7,7 +7,7 @@
 //! - `REDIS_URL` environment variable (e.g., `redis://127.0.0.1/`)
 
 use authkestra::flow::Engine;
-use authkestra_axum::{AxumError, AxumExt, AxumState, AuthSession};
+use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::store::redis::RedisStore;
 use authkestra_engine::{Configured, SessionConfig};

--- a/crates/authkestra/examples/axum_sql_store.rs
+++ b/crates/authkestra/examples/axum_sql_store.rs
@@ -4,7 +4,7 @@
 //! It also demonstrates how to manage the database table lifecycle by calling `.migrate().await`.
 
 use authkestra::flow::AkBase;
-use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AkState};
+use authkestra_axum::{AkAxumError, AkAxumExt, AkState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::store::sql::SqlKvStore;
 use authkestra_engine::{Configured, SessionConfig};

--- a/crates/authkestra/examples/axum_sql_store.rs
+++ b/crates/authkestra/examples/axum_sql_store.rs
@@ -4,7 +4,7 @@
 //! It also demonstrates how to manage the database table lifecycle by calling `.migrate().await`.
 
 use authkestra::flow::AkBase;
-use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AuthkestraState};
+use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AkState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::store::sql::SqlKvStore;
 use authkestra_engine::{Configured, SessionConfig};
@@ -20,7 +20,7 @@ use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
 /// AkBase state with support for session only.
-type AppState = AuthkestraState<Configured<Arc<dyn SessionStore>>>;
+type AppState = AkState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {

--- a/crates/authkestra/examples/axum_sql_store.rs
+++ b/crates/authkestra/examples/axum_sql_store.rs
@@ -4,7 +4,7 @@
 //! It also demonstrates how to manage the database table lifecycle by calling `.migrate().await`.
 
 use authkestra::flow::Engine;
-use authkestra_axum::{AxumError, AxumExt, AxumState, AuthSession};
+use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::store::sql::SqlKvStore;
 use authkestra_engine::{Configured, SessionConfig};

--- a/crates/authkestra/examples/axum_sql_store.rs
+++ b/crates/authkestra/examples/axum_sql_store.rs
@@ -3,8 +3,8 @@
 //! This example demonstrates how to use `SqlKvStore` (with SQLite) as a session store with Axum.
 //! It also demonstrates how to manage the database table lifecycle by calling `.migrate().await`.
 
-use authkestra::flow::AuthEngine;
-use authkestra_axum::{AuthEngineAxumError, AuthEngineAxumExt, AuthEngineState, AuthSession};
+use authkestra::flow::Engine;
+use authkestra_axum::{Error, AxumExt, State, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::store::sql::SqlKvStore;
 use authkestra_engine::{Configured, SessionConfig};
@@ -19,8 +19,8 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// AuthEngine state with support for session only.
-type AppState = AuthEngineState<Configured<Arc<dyn SessionStore>>>;
+/// Engine state with support for session only.
+type AppState = State<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {
@@ -44,10 +44,10 @@ async fn main() {
         .await
         .expect("Failed to run database migrations");
 
-    // 4. Wrap the store in an Arc and provide it to the AuthEngine.
+    // 4. Wrap the store in an Arc and provide it to the Engine.
     let session_store: Arc<dyn SessionStore> = Arc::new(sql_store);
 
-    let auth_engine = AuthEngine::builder()
+    let auth_engine = Engine::builder()
         .session_store(session_store)
         .session_config(SessionConfig {
             secure: false, // For local development
@@ -71,7 +71,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn get_user(session: Result<AuthSession, AuthEngineAxumError>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, Error>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_sql_store.rs
+++ b/crates/authkestra/examples/axum_sql_store.rs
@@ -3,8 +3,8 @@
 //! This example demonstrates how to use `SqlKvStore` (with SQLite) as a session store with Axum.
 //! It also demonstrates how to manage the database table lifecycle by calling `.migrate().await`.
 
-use authkestra::flow::AkBase;
-use authkestra_axum::{AkAxumError, AkAxumExt, AkState, AuthSession};
+use authkestra::flow::AuthEngine;
+use authkestra_axum::{AuthEngineAxumError, AuthEngineAxumExt, AuthEngineState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::store::sql::SqlKvStore;
 use authkestra_engine::{Configured, SessionConfig};
@@ -19,8 +19,8 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// AkBase state with support for session only.
-type AppState = AkState<Configured<Arc<dyn SessionStore>>>;
+/// AuthEngine state with support for session only.
+type AppState = AuthEngineState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {
@@ -44,10 +44,10 @@ async fn main() {
         .await
         .expect("Failed to run database migrations");
 
-    // 4. Wrap the store in an Arc and provide it to the AkBase.
+    // 4. Wrap the store in an Arc and provide it to the AuthEngine.
     let session_store: Arc<dyn SessionStore> = Arc::new(sql_store);
 
-    let auth_engine = AkBase::builder()
+    let auth_engine = AuthEngine::builder()
         .session_store(session_store)
         .session_config(SessionConfig {
             secure: false, // For local development
@@ -71,7 +71,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn get_user(session: Result<AuthSession, AkAxumError>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, AuthEngineAxumError>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_sql_store.rs
+++ b/crates/authkestra/examples/axum_sql_store.rs
@@ -3,8 +3,8 @@
 //! This example demonstrates how to use `SqlKvStore` (with SQLite) as a session store with Axum.
 //! It also demonstrates how to manage the database table lifecycle by calling `.migrate().await`.
 
-use authkestra::flow::AuthEngine;
-use authkestra_axum::{AuthSession, AuthkestraAxumError, AuthkestraAxumExt, AuthkestraState};
+use authkestra::flow::AkBase;
+use authkestra_axum::{AuthSession, AkAxumError, AkAxumExt, AuthkestraState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::store::sql::SqlKvStore;
 use authkestra_engine::{Configured, SessionConfig};
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// AuthEngine state with support for session only.
+/// AkBase state with support for session only.
 type AppState = AuthkestraState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
@@ -44,10 +44,10 @@ async fn main() {
         .await
         .expect("Failed to run database migrations");
 
-    // 4. Wrap the store in an Arc and provide it to the AuthEngine.
+    // 4. Wrap the store in an Arc and provide it to the AkBase.
     let session_store: Arc<dyn SessionStore> = Arc::new(sql_store);
 
-    let auth_engine = AuthEngine::builder()
+    let auth_engine = AkBase::builder()
         .session_store(session_store)
         .session_config(SessionConfig {
             secure: false, // For local development
@@ -71,7 +71,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn get_user(session: Result<AuthSession, AuthkestraAxumError>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, AkAxumError>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/examples/axum_sql_store.rs
+++ b/crates/authkestra/examples/axum_sql_store.rs
@@ -4,7 +4,7 @@
 //! It also demonstrates how to manage the database table lifecycle by calling `.migrate().await`.
 
 use authkestra::flow::Engine;
-use authkestra_axum::{Error, AxumExt, State, AuthSession};
+use authkestra_axum::{AxumError, AxumExt, AxumState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::store::sql::SqlKvStore;
 use authkestra_engine::{Configured, SessionConfig};
@@ -20,7 +20,7 @@ use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
 /// Engine state with support for session only.
-type AppState = State<Configured<Arc<dyn SessionStore>>>;
+type AppState = AxumState<Configured<Arc<dyn SessionStore>>>;
 
 #[tokio::main]
 async fn main() {
@@ -71,7 +71,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn get_user(session: Result<AuthSession, Error>) -> impl IntoResponse {
+async fn get_user(session: Result<AuthSession, AxumError>) -> impl IntoResponse {
     match session {
         Ok(AuthSession(session)) => Json(json!({
             "id": session.identity.external_id,

--- a/crates/authkestra/tests/typestate_tests.rs
+++ b/crates/authkestra/tests/typestate_tests.rs
@@ -1,4 +1,4 @@
-use authkestra::flow::Authkestra;
+use authkestra::flow::AkBase;
 use authkestra_engine::state::Identity;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -6,7 +6,7 @@ use std::sync::Arc;
 #[tokio::test]
 async fn test_typestate_session_flow() {
     // Start with Missing, Missing
-    let builder = Authkestra::builder();
+    let builder = AkBase::builder();
 
     // Configure session store -> transitions to Configured, Missing
     let auth = builder
@@ -34,7 +34,7 @@ async fn test_typestate_session_flow() {
 #[test]
 fn test_typestate_token_flow() {
     // Start with Missing, Missing
-    let builder = Authkestra::builder();
+    let builder = AkBase::builder();
 
     // Configure token manager -> transitions to Missing, Configured
     let auth = builder.jwt_secret(b"secret").build();
@@ -57,7 +57,7 @@ fn test_typestate_token_flow() {
 
 #[tokio::test]
 async fn test_typestate_full_flow() {
-    let auth = Authkestra::builder()
+    let auth = AkBase::builder()
         .session_store(Arc::new(
             authkestra_engine::store::memory::MemoryStore::default(),
         ))
@@ -76,3 +76,4 @@ async fn test_typestate_full_flow() {
     assert!(auth.create_session(identity.clone()).await.is_ok());
     assert!(auth.issue_token(identity, 3600).is_ok());
 }
+

--- a/crates/authkestra/tests/typestate_tests.rs
+++ b/crates/authkestra/tests/typestate_tests.rs
@@ -1,4 +1,4 @@
-use authkestra::flow::AuthEngine;
+use authkestra::flow::Engine;
 use authkestra_engine::state::Identity;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -6,7 +6,7 @@ use std::sync::Arc;
 #[tokio::test]
 async fn test_typestate_session_flow() {
     // Start with Missing, Missing
-    let builder = AuthEngine::builder();
+    let builder = Engine::builder();
 
     // Configure session store -> transitions to Configured, Missing
     let auth = builder
@@ -34,7 +34,7 @@ async fn test_typestate_session_flow() {
 #[test]
 fn test_typestate_token_flow() {
     // Start with Missing, Missing
-    let builder = AuthEngine::builder();
+    let builder = Engine::builder();
 
     // Configure token manager -> transitions to Missing, Configured
     let auth = builder.jwt_secret(b"secret").build();
@@ -57,7 +57,7 @@ fn test_typestate_token_flow() {
 
 #[tokio::test]
 async fn test_typestate_full_flow() {
-    let auth = AuthEngine::builder()
+    let auth = Engine::builder()
         .session_store(Arc::new(
             authkestra_engine::store::memory::MemoryStore::default(),
         ))

--- a/crates/authkestra/tests/typestate_tests.rs
+++ b/crates/authkestra/tests/typestate_tests.rs
@@ -76,4 +76,3 @@ async fn test_typestate_full_flow() {
     assert!(auth.create_session(identity.clone()).await.is_ok());
     assert!(auth.issue_token(identity, 3600).is_ok());
 }
-

--- a/crates/authkestra/tests/typestate_tests.rs
+++ b/crates/authkestra/tests/typestate_tests.rs
@@ -1,4 +1,4 @@
-use authkestra::flow::AkBase;
+use authkestra::flow::AuthEngine;
 use authkestra_engine::state::Identity;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -6,7 +6,7 @@ use std::sync::Arc;
 #[tokio::test]
 async fn test_typestate_session_flow() {
     // Start with Missing, Missing
-    let builder = AkBase::builder();
+    let builder = AuthEngine::builder();
 
     // Configure session store -> transitions to Configured, Missing
     let auth = builder
@@ -34,7 +34,7 @@ async fn test_typestate_session_flow() {
 #[test]
 fn test_typestate_token_flow() {
     // Start with Missing, Missing
-    let builder = AkBase::builder();
+    let builder = AuthEngine::builder();
 
     // Configure token manager -> transitions to Missing, Configured
     let auth = builder.jwt_secret(b"secret").build();
@@ -57,7 +57,7 @@ fn test_typestate_token_flow() {
 
 #[tokio::test]
 async fn test_typestate_full_flow() {
-    let auth = AkBase::builder()
+    let auth = AuthEngine::builder()
         .session_store(Arc::new(
             authkestra_engine::store::memory::MemoryStore::default(),
         ))

--- a/docs/book/ch02-core-engine-and-identity.md
+++ b/docs/book/ch02-core-engine-and-identity.md
@@ -1,6 +1,6 @@
 # Chapter 2: Core Engine and Identity
 
-The `AuthEngine` is the heart of Authkestra. It orchestrates the various components (session stores, auth methods) and produces a unified, verifiable `Identity`.
+The `AkBase` is the heart of Authkestra. It orchestrates the various components (session stores, auth methods) and produces a unified, verifiable `Identity`.
 
 ## Identity and Verifiable Claims
 
@@ -38,13 +38,13 @@ pub struct Claims {
 }
 ```
 
-## The AuthEngine (Orchestrator)
+## The AkBase (Orchestrator)
 
-The `AuthEngine` uses the **Typestate Builder Pattern** to ensure that critical components (like a `SessionStore` or `TokenService`) are configured at compile-time before the engine can be used.
+The `AkBase` uses the **Typestate Builder Pattern** to ensure that critical components (like a `SessionStore` or `TokenService`) are configured at compile-time before the engine can be used.
 
 ### Quantum Readiness
 
-The `AuthEngine` is designed to be **PQC-ready**. This means the `TokenService` and `Authenticator` traits are defined to handle larger signature and key sizes associated with Module-Lattice-Based algorithms like **ML-DSA** (FIPS 204).
+The `AkBase` is designed to be **PQC-ready**. This means the `TokenService` and `Authenticator` traits are defined to handle larger signature and key sizes associated with Module-Lattice-Based algorithms like **ML-DSA** (FIPS 204).
 
 ## Architectural Decisions
 

--- a/docs/book/ch02-core-engine-and-identity.md
+++ b/docs/book/ch02-core-engine-and-identity.md
@@ -1,6 +1,6 @@
 # Chapter 2: Core Engine and Identity
 
-The `AkBase` is the heart of Authkestra. It orchestrates the various components (session stores, auth methods) and produces a unified, verifiable `Identity`.
+The `AuthEngine` is the heart of Authkestra. It orchestrates the various components (session stores, auth methods) and produces a unified, verifiable `Identity`.
 
 ## Identity and Verifiable Claims
 
@@ -38,13 +38,13 @@ pub struct Claims {
 }
 ```
 
-## The AkBase (Orchestrator)
+## The AuthEngine (Orchestrator)
 
-The `AkBase` uses the **Typestate Builder Pattern** to ensure that critical components (like a `SessionStore` or `TokenService`) are configured at compile-time before the engine can be used.
+The `AuthEngine` uses the **Typestate Builder Pattern** to ensure that critical components (like a `SessionStore` or `TokenService`) are configured at compile-time before the engine can be used.
 
 ### Quantum Readiness
 
-The `AkBase` is designed to be **PQC-ready**. This means the `TokenService` and `Authenticator` traits are defined to handle larger signature and key sizes associated with Module-Lattice-Based algorithms like **ML-DSA** (FIPS 204).
+The `AuthEngine` is designed to be **PQC-ready**. This means the `TokenService` and `Authenticator` traits are defined to handle larger signature and key sizes associated with Module-Lattice-Based algorithms like **ML-DSA** (FIPS 204).
 
 ## Architectural Decisions
 

--- a/docs/book/ch02-core-engine-and-identity.md
+++ b/docs/book/ch02-core-engine-and-identity.md
@@ -1,6 +1,6 @@
 # Chapter 2: Core Engine and Identity
 
-The `AuthEngine` is the heart of Authkestra. It orchestrates the various components (session stores, auth methods) and produces a unified, verifiable `Identity`.
+The `Engine` is the heart of Authkestra. It orchestrates the various components (session stores, auth methods) and produces a unified, verifiable `Identity`.
 
 ## Identity and Verifiable Claims
 
@@ -38,13 +38,13 @@ pub struct Claims {
 }
 ```
 
-## The AuthEngine (Orchestrator)
+## The Engine (Orchestrator)
 
-The `AuthEngine` uses the **Typestate Builder Pattern** to ensure that critical components (like a `SessionStore` or `TokenService`) are configured at compile-time before the engine can be used.
+The `Engine` uses the **Typestate Builder Pattern** to ensure that critical components (like a `SessionStore` or `TokenService`) are configured at compile-time before the engine can be used.
 
 ### Quantum Readiness
 
-The `AuthEngine` is designed to be **PQC-ready**. This means the `TokenService` and `Authenticator` traits are defined to handle larger signature and key sizes associated with Module-Lattice-Based algorithms like **ML-DSA** (FIPS 204).
+The `Engine` is designed to be **PQC-ready**. This means the `TokenService` and `Authenticator` traits are defined to handle larger signature and key sizes associated with Module-Lattice-Based algorithms like **ML-DSA** (FIPS 204).
 
 ## Architectural Decisions
 

--- a/docs/book/ch08-getting-started-tutorial.md
+++ b/docs/book/ch08-getting-started-tutorial.md
@@ -1,6 +1,6 @@
 # Chapter 8: Getting Started Tutorial
 
-Welcome to the Authkestra getting started guide! This chapter provides a highly practical "Hello World" tutorial that walks you through setting up `AuthEngine` in a basic web application. We'll use the popular `axum` framework for this example, but the concepts apply similarly to `actix-web`.
+Welcome to the Authkestra getting started guide! This chapter provides a highly practical "Hello World" tutorial that walks you through setting up `Engine` in a basic web application. We'll use the popular `axum` framework for this example, but the concepts apply similarly to `actix-web`.
 
 ## Prerequisites
 
@@ -29,13 +29,13 @@ authkestra-core = { version = "0.1", features = ["axum"] }
 # authkestra-providers-github = "0.1"
 ```
 
-## Step 2: Initialize AuthEngine
+## Step 2: Initialize Engine
 
-The core of Authkestra is the `AuthEngine`. Let's initialize it in our `main.rs`. For this tutorial, we will set up a basic in-memory configuration.
+The core of Authkestra is the `Engine`. Let's initialize it in our `main.rs`. For this tutorial, we will set up a basic in-memory configuration.
 
 ```rust
 use axum::{routing::get, Router};
-use authkestra_core::engine::{AuthEngine, EngineConfig};
+use authkestra_core::engine::{Engine, EngineConfig};
 use authkestra_core::providers::LocalProvider;
 use std::sync::Arc;
 
@@ -46,7 +46,7 @@ async fn main() {
         .with_secret_key("super_secret_development_key_do_not_use_in_prod");
 
     // 2. Instantiate the engine and add providers
-    let mut engine = AuthEngine::new(config);
+    let mut engine = Engine::new(config);
 
     // Add a local email/password provider for demonstration
     engine.add_provider(LocalProvider::new());

--- a/docs/book/ch08-getting-started-tutorial.md
+++ b/docs/book/ch08-getting-started-tutorial.md
@@ -1,6 +1,6 @@
 # Chapter 8: Getting Started Tutorial
 
-Welcome to the Authkestra getting started guide! This chapter provides a highly practical "Hello World" tutorial that walks you through setting up `AkBase` in a basic web application. We'll use the popular `axum` framework for this example, but the concepts apply similarly to `actix-web`.
+Welcome to the Authkestra getting started guide! This chapter provides a highly practical "Hello World" tutorial that walks you through setting up `AuthEngine` in a basic web application. We'll use the popular `axum` framework for this example, but the concepts apply similarly to `actix-web`.
 
 ## Prerequisites
 
@@ -29,13 +29,13 @@ authkestra-core = { version = "0.1", features = ["axum"] }
 # authkestra-providers-github = "0.1"
 ```
 
-## Step 2: Initialize AkBase
+## Step 2: Initialize AuthEngine
 
-The core of Authkestra is the `AkBase`. Let's initialize it in our `main.rs`. For this tutorial, we will set up a basic in-memory configuration.
+The core of Authkestra is the `AuthEngine`. Let's initialize it in our `main.rs`. For this tutorial, we will set up a basic in-memory configuration.
 
 ```rust
 use axum::{routing::get, Router};
-use authkestra_core::engine::{AkBase, EngineConfig};
+use authkestra_core::engine::{AuthEngine, EngineConfig};
 use authkestra_core::providers::LocalProvider;
 use std::sync::Arc;
 
@@ -46,7 +46,7 @@ async fn main() {
         .with_secret_key("super_secret_development_key_do_not_use_in_prod");
 
     // 2. Instantiate the engine and add providers
-    let mut engine = AkBase::new(config);
+    let mut engine = AuthEngine::new(config);
 
     // Add a local email/password provider for demonstration
     engine.add_provider(LocalProvider::new());

--- a/docs/book/ch08-getting-started-tutorial.md
+++ b/docs/book/ch08-getting-started-tutorial.md
@@ -1,6 +1,6 @@
 # Chapter 8: Getting Started Tutorial
 
-Welcome to the Authkestra getting started guide! This chapter provides a highly practical "Hello World" tutorial that walks you through setting up `AuthEngine` in a basic web application. We'll use the popular `axum` framework for this example, but the concepts apply similarly to `actix-web`.
+Welcome to the Authkestra getting started guide! This chapter provides a highly practical "Hello World" tutorial that walks you through setting up `AkBase` in a basic web application. We'll use the popular `axum` framework for this example, but the concepts apply similarly to `actix-web`.
 
 ## Prerequisites
 
@@ -29,13 +29,13 @@ authkestra-core = { version = "0.1", features = ["axum"] }
 # authkestra-providers-github = "0.1"
 ```
 
-## Step 2: Initialize AuthEngine
+## Step 2: Initialize AkBase
 
-The core of Authkestra is the `AuthEngine`. Let's initialize it in our `main.rs`. For this tutorial, we will set up a basic in-memory configuration.
+The core of Authkestra is the `AkBase`. Let's initialize it in our `main.rs`. For this tutorial, we will set up a basic in-memory configuration.
 
 ```rust
 use axum::{routing::get, Router};
-use authkestra_core::engine::{AuthEngine, EngineConfig};
+use authkestra_core::engine::{AkBase, EngineConfig};
 use authkestra_core::providers::LocalProvider;
 use std::sync::Arc;
 
@@ -46,7 +46,7 @@ async fn main() {
         .with_secret_key("super_secret_development_key_do_not_use_in_prod");
 
     // 2. Instantiate the engine and add providers
-    let mut engine = AuthEngine::new(config);
+    let mut engine = AkBase::new(config);
 
     // Add a local email/password provider for demonstration
     engine.add_provider(LocalProvider::new());

--- a/docs/rfc-001-architecture-migration.md
+++ b/docs/rfc-001-architecture-migration.md
@@ -9,7 +9,7 @@ This document proposes a comprehensive migration plan to transition Authkestra f
 Authkestra currently consists of numerous specialized crates (`authkestra-core`, `authkestra-flow`, `authkestra-token`, `authkestra-session`, `authkestra-guard`, etc.). While this high level of modularity demonstrates the breadth of the project, it suffers from several architectural issues:
 
 - **Blurry Boundaries:** Crates mix protocol concerns, abstractions, state handling, and execution logic.
-- **Missing Core Engine:** There is no central orchestrator (`AkBase`) to tie flows, providers, sessions, and tokens together.
+- **Missing Core Engine:** There is no central orchestrator (`AuthEngine`) to tie flows, providers, sessions, and tokens together.
 - **Naming Inconsistencies:** Crates like `authkestra-guard` handle JWT logic rather than just enforcement.
 - **Developer Friction:** A steep learning curve prevents users from achieving a simple "golden path" integration in a few lines of code.
 
@@ -24,7 +24,7 @@ The new architecture will be split into three distinct zones:
 A framework-agnostic runtime that acts as the brain of the system.
 
 - **Crate:** `authkestra-engine` (Merging `core`, `flow`, `token`, and parts of `guard`)
-- **Responsibilities:** Identity modeling, trait definitions (`Authenticator`, `Flow`, `Provider`, `SessionStore`), protocol helpers (PKCE, OIDC discovery), and the central `AkBase` orchestrator.
+- **Responsibilities:** Identity modeling, trait definitions (`Authenticator`, `Flow`, `Provider`, `SessionStore`), protocol helpers (PKCE, OIDC discovery), and the central `AuthEngine` orchestrator.
 
 ### 3.2. Layer 2: Extensions (Plugins)
 
@@ -113,12 +113,12 @@ pub trait TokenService {
 }
 ```
 
-### 4.6. AkBase (The Orchestrator)
+### 4.6. AuthEngine (The Orchestrator)
 
 The central runtime that ties everything together.
 
 ```rust
-pub struct AkBase {
+pub struct AuthEngine {
     providers: Vec<Box<dyn Provider>>,
     methods: Vec<Box<dyn AuthMethod>>,
     flows: Vec<Box<dyn Flow>>,
@@ -126,9 +126,9 @@ pub struct AkBase {
     token_service: Box<dyn TokenService>,
 }
 
-impl AkBase {
-    pub fn builder() -> AkEngineBuilder {
-        AkEngineBuilder::new()
+impl AuthEngine {
+    pub fn builder() -> AuthEngineBuilder {
+        AuthEngineBuilder::new()
     }
 }
 ```
@@ -136,7 +136,7 @@ impl AkBase {
 **Golden Path Example:**
 
 ```rust
-let engine = AkBase::builder()
+let engine = AuthEngine::builder()
     .with_provider(GoogleProvider::new(...))
     .with_method(Credentials::new())
     .with_session_store(MemoryStore::new())
@@ -155,11 +155,11 @@ let engine = AkBase::builder()
 1. **Create `authkestra-engine`:** Initialize the new crate.
 2. **Merge Crates:** Move code from `authkestra-core`, `authkestra-flow`, and `authkestra-token` into `authkestra-engine/src/{auth, flow, token, protocol}`. Do not alter business logic yet.
 3. **Define Core Traits:** Implement the `AuthMethod`, `Flow`, `Provider`, `SessionStore`, and `TokenService` traits in `authkestra-engine`.
-4. **Implement `AkBase` Builder:** Create the `AkBase` struct and its builder API.
+4. **Implement `AuthEngine` Builder:** Create the `AuthEngine` struct and its builder API.
 5. **Refactor OAuth Flow:** Update the existing OAuth implementation to implement the `Flow` trait and use the `Provider` trait.
 6. **Refactor Session Crate:** Split `authkestra-session` into an interface-only crate (`authkestra-session`) and implementation crates (`authkestra-session-memory`, etc.).
 7. **Rename Guard:** Rename `authkestra-guard` to `authkestra-resource` and focus it strictly on validation and enforcement (middleware/extractors).
-8. **Create Golden Example:** Update `authkestra-examples` to demonstrate the new `AkBase::builder()` API using Axum/Actix.
+8. **Create Golden Example:** Update `authkestra-examples` to demonstrate the new `AuthEngine::builder()` API using Axum/Actix.
 
 ### Phase 2: Authentication Expansion
 
@@ -205,7 +205,7 @@ let engine = AkBase::builder()
 
 ## 6. Migration Rules & Constraints
 
-1. **No Breaking User-Space APIs in Phase 1 (Where Possible):** During the initial merge, preserve existing structs where feasible. The breaking changes occur when transitioning to the `AkBase::builder()` pattern.
+1. **No Breaking User-Space APIs in Phase 1 (Where Possible):** During the initial merge, preserve existing structs where feasible. The breaking changes occur when transitioning to the `AuthEngine::builder()` pattern.
 2. **Every Feature is a Plugin:** Do not hardcode WebAuthn, TOTP, or specific DB logic into the engine. They must implement the defined traits.
 3. **One Identity Lifecycle:** All flows MUST resolve to the unified `Identity` struct.
 4. **Dogfooding:** The Admin Dashboard MUST be authenticated using Authkestra itself.

--- a/docs/rfc-001-architecture-migration.md
+++ b/docs/rfc-001-architecture-migration.md
@@ -9,7 +9,7 @@ This document proposes a comprehensive migration plan to transition Authkestra f
 Authkestra currently consists of numerous specialized crates (`authkestra-core`, `authkestra-flow`, `authkestra-token`, `authkestra-session`, `authkestra-guard`, etc.). While this high level of modularity demonstrates the breadth of the project, it suffers from several architectural issues:
 
 - **Blurry Boundaries:** Crates mix protocol concerns, abstractions, state handling, and execution logic.
-- **Missing Core Engine:** There is no central orchestrator (`AuthEngine`) to tie flows, providers, sessions, and tokens together.
+- **Missing Core Engine:** There is no central orchestrator (`Engine`) to tie flows, providers, sessions, and tokens together.
 - **Naming Inconsistencies:** Crates like `authkestra-guard` handle JWT logic rather than just enforcement.
 - **Developer Friction:** A steep learning curve prevents users from achieving a simple "golden path" integration in a few lines of code.
 
@@ -24,7 +24,7 @@ The new architecture will be split into three distinct zones:
 A framework-agnostic runtime that acts as the brain of the system.
 
 - **Crate:** `authkestra-engine` (Merging `core`, `flow`, `token`, and parts of `guard`)
-- **Responsibilities:** Identity modeling, trait definitions (`Authenticator`, `Flow`, `Provider`, `SessionStore`), protocol helpers (PKCE, OIDC discovery), and the central `AuthEngine` orchestrator.
+- **Responsibilities:** Identity modeling, trait definitions (`Authenticator`, `Flow`, `Provider`, `SessionStore`), protocol helpers (PKCE, OIDC discovery), and the central `Engine` orchestrator.
 
 ### 3.2. Layer 2: Extensions (Plugins)
 
@@ -113,12 +113,12 @@ pub trait TokenService {
 }
 ```
 
-### 4.6. AuthEngine (The Orchestrator)
+### 4.6. Engine (The Orchestrator)
 
 The central runtime that ties everything together.
 
 ```rust
-pub struct AuthEngine {
+pub struct Engine {
     providers: Vec<Box<dyn Provider>>,
     methods: Vec<Box<dyn AuthMethod>>,
     flows: Vec<Box<dyn Flow>>,
@@ -126,9 +126,9 @@ pub struct AuthEngine {
     token_service: Box<dyn TokenService>,
 }
 
-impl AuthEngine {
-    pub fn builder() -> AuthEngineBuilder {
-        AuthEngineBuilder::new()
+impl Engine {
+    pub fn builder() -> EngineBuilder {
+        EngineBuilder::new()
     }
 }
 ```
@@ -136,7 +136,7 @@ impl AuthEngine {
 **Golden Path Example:**
 
 ```rust
-let engine = AuthEngine::builder()
+let engine = Engine::builder()
     .with_provider(GoogleProvider::new(...))
     .with_method(Credentials::new())
     .with_session_store(MemoryStore::new())
@@ -155,11 +155,11 @@ let engine = AuthEngine::builder()
 1. **Create `authkestra-engine`:** Initialize the new crate.
 2. **Merge Crates:** Move code from `authkestra-core`, `authkestra-flow`, and `authkestra-token` into `authkestra-engine/src/{auth, flow, token, protocol}`. Do not alter business logic yet.
 3. **Define Core Traits:** Implement the `AuthMethod`, `Flow`, `Provider`, `SessionStore`, and `TokenService` traits in `authkestra-engine`.
-4. **Implement `AuthEngine` Builder:** Create the `AuthEngine` struct and its builder API.
+4. **Implement `Engine` Builder:** Create the `Engine` struct and its builder API.
 5. **Refactor OAuth Flow:** Update the existing OAuth implementation to implement the `Flow` trait and use the `Provider` trait.
 6. **Refactor Session Crate:** Split `authkestra-session` into an interface-only crate (`authkestra-session`) and implementation crates (`authkestra-session-memory`, etc.).
 7. **Rename Guard:** Rename `authkestra-guard` to `authkestra-resource` and focus it strictly on validation and enforcement (middleware/extractors).
-8. **Create Golden Example:** Update `authkestra-examples` to demonstrate the new `AuthEngine::builder()` API using Axum/Actix.
+8. **Create Golden Example:** Update `authkestra-examples` to demonstrate the new `Engine::builder()` API using Axum/Actix.
 
 ### Phase 2: Authentication Expansion
 
@@ -205,7 +205,7 @@ let engine = AuthEngine::builder()
 
 ## 6. Migration Rules & Constraints
 
-1. **No Breaking User-Space APIs in Phase 1 (Where Possible):** During the initial merge, preserve existing structs where feasible. The breaking changes occur when transitioning to the `AuthEngine::builder()` pattern.
+1. **No Breaking User-Space APIs in Phase 1 (Where Possible):** During the initial merge, preserve existing structs where feasible. The breaking changes occur when transitioning to the `Engine::builder()` pattern.
 2. **Every Feature is a Plugin:** Do not hardcode WebAuthn, TOTP, or specific DB logic into the engine. They must implement the defined traits.
 3. **One Identity Lifecycle:** All flows MUST resolve to the unified `Identity` struct.
 4. **Dogfooding:** The Admin Dashboard MUST be authenticated using Authkestra itself.

--- a/docs/rfc-001-architecture-migration.md
+++ b/docs/rfc-001-architecture-migration.md
@@ -9,7 +9,7 @@ This document proposes a comprehensive migration plan to transition Authkestra f
 Authkestra currently consists of numerous specialized crates (`authkestra-core`, `authkestra-flow`, `authkestra-token`, `authkestra-session`, `authkestra-guard`, etc.). While this high level of modularity demonstrates the breadth of the project, it suffers from several architectural issues:
 
 - **Blurry Boundaries:** Crates mix protocol concerns, abstractions, state handling, and execution logic.
-- **Missing Core Engine:** There is no central orchestrator (`AuthEngine`) to tie flows, providers, sessions, and tokens together.
+- **Missing Core Engine:** There is no central orchestrator (`AkBase`) to tie flows, providers, sessions, and tokens together.
 - **Naming Inconsistencies:** Crates like `authkestra-guard` handle JWT logic rather than just enforcement.
 - **Developer Friction:** A steep learning curve prevents users from achieving a simple "golden path" integration in a few lines of code.
 
@@ -24,7 +24,7 @@ The new architecture will be split into three distinct zones:
 A framework-agnostic runtime that acts as the brain of the system.
 
 - **Crate:** `authkestra-engine` (Merging `core`, `flow`, `token`, and parts of `guard`)
-- **Responsibilities:** Identity modeling, trait definitions (`Authenticator`, `Flow`, `Provider`, `SessionStore`), protocol helpers (PKCE, OIDC discovery), and the central `AuthEngine` orchestrator.
+- **Responsibilities:** Identity modeling, trait definitions (`Authenticator`, `Flow`, `Provider`, `SessionStore`), protocol helpers (PKCE, OIDC discovery), and the central `AkBase` orchestrator.
 
 ### 3.2. Layer 2: Extensions (Plugins)
 
@@ -113,12 +113,12 @@ pub trait TokenService {
 }
 ```
 
-### 4.6. AuthEngine (The Orchestrator)
+### 4.6. AkBase (The Orchestrator)
 
 The central runtime that ties everything together.
 
 ```rust
-pub struct AuthEngine {
+pub struct AkBase {
     providers: Vec<Box<dyn Provider>>,
     methods: Vec<Box<dyn AuthMethod>>,
     flows: Vec<Box<dyn Flow>>,
@@ -126,9 +126,9 @@ pub struct AuthEngine {
     token_service: Box<dyn TokenService>,
 }
 
-impl AuthEngine {
-    pub fn builder() -> AuthEngineBuilder {
-        AuthEngineBuilder::new()
+impl AkBase {
+    pub fn builder() -> AkEngineBuilder {
+        AkEngineBuilder::new()
     }
 }
 ```
@@ -136,7 +136,7 @@ impl AuthEngine {
 **Golden Path Example:**
 
 ```rust
-let engine = AuthEngine::builder()
+let engine = AkBase::builder()
     .with_provider(GoogleProvider::new(...))
     .with_method(Credentials::new())
     .with_session_store(MemoryStore::new())
@@ -155,11 +155,11 @@ let engine = AuthEngine::builder()
 1. **Create `authkestra-engine`:** Initialize the new crate.
 2. **Merge Crates:** Move code from `authkestra-core`, `authkestra-flow`, and `authkestra-token` into `authkestra-engine/src/{auth, flow, token, protocol}`. Do not alter business logic yet.
 3. **Define Core Traits:** Implement the `AuthMethod`, `Flow`, `Provider`, `SessionStore`, and `TokenService` traits in `authkestra-engine`.
-4. **Implement `AuthEngine` Builder:** Create the `AuthEngine` struct and its builder API.
+4. **Implement `AkBase` Builder:** Create the `AkBase` struct and its builder API.
 5. **Refactor OAuth Flow:** Update the existing OAuth implementation to implement the `Flow` trait and use the `Provider` trait.
 6. **Refactor Session Crate:** Split `authkestra-session` into an interface-only crate (`authkestra-session`) and implementation crates (`authkestra-session-memory`, etc.).
 7. **Rename Guard:** Rename `authkestra-guard` to `authkestra-resource` and focus it strictly on validation and enforcement (middleware/extractors).
-8. **Create Golden Example:** Update `authkestra-examples` to demonstrate the new `AuthEngine::builder()` API using Axum/Actix.
+8. **Create Golden Example:** Update `authkestra-examples` to demonstrate the new `AkBase::builder()` API using Axum/Actix.
 
 ### Phase 2: Authentication Expansion
 
@@ -205,7 +205,7 @@ let engine = AuthEngine::builder()
 
 ## 6. Migration Rules & Constraints
 
-1. **No Breaking User-Space APIs in Phase 1 (Where Possible):** During the initial merge, preserve existing structs where feasible. The breaking changes occur when transitioning to the `AuthEngine::builder()` pattern.
+1. **No Breaking User-Space APIs in Phase 1 (Where Possible):** During the initial merge, preserve existing structs where feasible. The breaking changes occur when transitioning to the `AkBase::builder()` pattern.
 2. **Every Feature is a Plugin:** Do not hardcode WebAuthn, TOTP, or specific DB logic into the engine. They must implement the defined traits.
 3. **One Identity Lifecycle:** All flows MUST resolve to the unified `Identity` struct.
 4. **Dogfooding:** The Admin Dashboard MUST be authenticated using Authkestra itself.

--- a/docs/rfc-002-next-gen-identity.md
+++ b/docs/rfc-002-next-gen-identity.md
@@ -14,7 +14,7 @@ The digital identity landscape is shifting towards:
 
 ### 3.1. GNAP & OAuth 2.1 Implementation
 - **OAuth 2.1**: Mandate PKCE, deprecate Implicit/Password grants, enforce DPoP/MTLS for sender-constraint.
-- **GNAP (RFC 9635)**: Implement the `AkBase` to handle unified JSON requests for multiple tokens, bypassing the rigid "redirect-only" model. Support dynamic client instance keys.
+- **GNAP (RFC 9635)**: Implement the `AuthEngine` to handle unified JSON requests for multiple tokens, bypassing the rigid "redirect-only" model. Support dynamic client instance keys.
 
 ### 3.2. Verifiable Credentials & Privacy
 - **Data Model**: Adopt W3C Verifiable Credentials Data Model v2.0.
@@ -39,6 +39,6 @@ The digital identity landscape is shifting towards:
 - **authkestra-ssf**: New crate for Shared Signals Framework.
 
 ## 5. Timeline
-- **Immediate**: Update `AkBase` traits to be "Future-Proof" (RFC-001 completion).
+- **Immediate**: Update `AuthEngine` traits to be "Future-Proof" (RFC-001 completion).
 - **Mid-Term**: Implement PQC WebAuthn and SD-JWT.
 - **Long-Term**: Full GNAP and CAEP event bus integration.

--- a/docs/rfc-002-next-gen-identity.md
+++ b/docs/rfc-002-next-gen-identity.md
@@ -14,7 +14,7 @@ The digital identity landscape is shifting towards:
 
 ### 3.1. GNAP & OAuth 2.1 Implementation
 - **OAuth 2.1**: Mandate PKCE, deprecate Implicit/Password grants, enforce DPoP/MTLS for sender-constraint.
-- **GNAP (RFC 9635)**: Implement the `AuthEngine` to handle unified JSON requests for multiple tokens, bypassing the rigid "redirect-only" model. Support dynamic client instance keys.
+- **GNAP (RFC 9635)**: Implement the `Engine` to handle unified JSON requests for multiple tokens, bypassing the rigid "redirect-only" model. Support dynamic client instance keys.
 
 ### 3.2. Verifiable Credentials & Privacy
 - **Data Model**: Adopt W3C Verifiable Credentials Data Model v2.0.
@@ -39,6 +39,6 @@ The digital identity landscape is shifting towards:
 - **authkestra-ssf**: New crate for Shared Signals Framework.
 
 ## 5. Timeline
-- **Immediate**: Update `AuthEngine` traits to be "Future-Proof" (RFC-001 completion).
+- **Immediate**: Update `Engine` traits to be "Future-Proof" (RFC-001 completion).
 - **Mid-Term**: Implement PQC WebAuthn and SD-JWT.
 - **Long-Term**: Full GNAP and CAEP event bus integration.

--- a/docs/rfc-002-next-gen-identity.md
+++ b/docs/rfc-002-next-gen-identity.md
@@ -14,7 +14,7 @@ The digital identity landscape is shifting towards:
 
 ### 3.1. GNAP & OAuth 2.1 Implementation
 - **OAuth 2.1**: Mandate PKCE, deprecate Implicit/Password grants, enforce DPoP/MTLS for sender-constraint.
-- **GNAP (RFC 9635)**: Implement the `AuthEngine` to handle unified JSON requests for multiple tokens, bypassing the rigid "redirect-only" model. Support dynamic client instance keys.
+- **GNAP (RFC 9635)**: Implement the `AkBase` to handle unified JSON requests for multiple tokens, bypassing the rigid "redirect-only" model. Support dynamic client instance keys.
 
 ### 3.2. Verifiable Credentials & Privacy
 - **Data Model**: Adopt W3C Verifiable Credentials Data Model v2.0.
@@ -39,6 +39,6 @@ The digital identity landscape is shifting towards:
 - **authkestra-ssf**: New crate for Shared Signals Framework.
 
 ## 5. Timeline
-- **Immediate**: Update `AuthEngine` traits to be "Future-Proof" (RFC-001 completion).
+- **Immediate**: Update `AkBase` traits to be "Future-Proof" (RFC-001 completion).
 - **Mid-Term**: Implement PQC WebAuthn and SD-JWT.
 - **Long-Term**: Full GNAP and CAEP event bus integration.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,7 +46,7 @@ This roadmap outlines the evolution of Authkestra into a next-generation identit
 
 ### Phase 1: Engine Consolidation & GNAP Prep
 - Merge `core`, `flow`, `token` into `authkestra-engine`.
-- Implement `AuthEngine` builder with Typestate pattern.
+- Implement `AkBase` builder with Typestate pattern.
 - Update `Flow` trait for GNAP compatibility.
 
 ### Phase 2: Quantum-Safe & Privacy-Preserving Auth

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,7 +46,7 @@ This roadmap outlines the evolution of Authkestra into a next-generation identit
 
 ### Phase 1: Engine Consolidation & GNAP Prep
 - Merge `core`, `flow`, `token` into `authkestra-engine`.
-- Implement `AkBase` builder with Typestate pattern.
+- Implement `AuthEngine` builder with Typestate pattern.
 - Update `Flow` trait for GNAP compatibility.
 
 ### Phase 2: Quantum-Safe & Privacy-Preserving Auth

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,7 +46,7 @@ This roadmap outlines the evolution of Authkestra into a next-generation identit
 
 ### Phase 1: Engine Consolidation & GNAP Prep
 - Merge `core`, `flow`, `token` into `authkestra-engine`.
-- Implement `AuthEngine` builder with Typestate pattern.
+- Implement `Engine` builder with Typestate pattern.
 - Update `Flow` trait for GNAP compatibility.
 
 ### Phase 2: Quantum-Safe & Privacy-Preserving Auth

--- a/plans/ticket-12-plan.md
+++ b/plans/ticket-12-plan.md
@@ -1,7 +1,7 @@
-# Plan for Issue #12: Central Orchestrator (AuthEngine)
+# Plan for Issue #12: Central Orchestrator (Engine)
 
 ## 1. Goal
-Create `AuthEngine`, the central orchestrator that ties everything together, using the Typestate Builder Pattern.
+Create `Engine`, the central orchestrator that ties everything together, using the Typestate Builder Pattern.
 
 ## 2. Typestate Pattern Design
 
@@ -14,26 +14,26 @@ impl SessionStoreState for NoSessionStore {}
 pub struct WithSessionStore<S: SessionStore>(pub S);
 impl<S: SessionStore> SessionStoreState for WithSessionStore<S> {}
 
-// AuthEngine struct
-pub struct AuthEngine<SessionState: SessionStoreState> {
+// Engine struct
+pub struct Engine<SessionState: SessionStoreState> {
     session_store: SessionState,
     // other fields like config, providers...
 }
 
-// AuthEngineBuilder struct
-pub struct AuthEngineBuilder<SessionState: SessionStoreState> {
+// EngineBuilder struct
+pub struct EngineBuilder<SessionState: SessionStoreState> {
     session_store: SessionState,
 }
 ```
 
 ## 3. Implementation Steps
 
-1. Create `authkestra-engine/src/engine.rs` with `AuthEngine`, `AuthEngineBuilder`, and typestate definitions.
-2. Implement `AuthEngine::builder()` returning an `AuthEngineBuilder<NoSessionStore>`.
-3. Implement `.session_store(store)` on `AuthEngineBuilder<NoSessionStore>` which returns `AuthEngineBuilder<WithSessionStore<S>>`.
-4. Implement `.build()` on `AuthEngineBuilder` to return `AuthEngine`.
-5. Implement `create_session()` on `AuthEngine<WithSessionStore<S>>`.
+1. Create `authkestra-engine/src/engine.rs` with `Engine`, `EngineBuilder`, and typestate definitions.
+2. Implement `Engine::builder()` returning an `EngineBuilder<NoSessionStore>`.
+3. Implement `.session_store(store)` on `EngineBuilder<NoSessionStore>` which returns `EngineBuilder<WithSessionStore<S>>`.
+4. Implement `.build()` on `EngineBuilder` to return `Engine`.
+5. Implement `create_session()` on `Engine<WithSessionStore<S>>`.
 6. Expose these types in `authkestra-engine/src/lib.rs`.
-7. Update `authkestra-examples` to initialize `AuthEngine` using the new builder.
+7. Update `authkestra-examples` to initialize `Engine` using the new builder.
 8. Add typestate tests in `authkestra-engine/src/tests.rs` or a new file to verify methods aren't available when the typestate is lacking.
 9. Update `docs/` and `README.md` to reflect the new primary entry point.

--- a/plans/ticket-16-refinement.md
+++ b/plans/ticket-16-refinement.md
@@ -12,8 +12,8 @@ This plan addresses the user feedback regarding the refactored examples in `auth
 ## Action Items
 
 ### 1. Update `axum_basic_setup.rs` for Testability
-- **Context:** The current basic setup example initializes the `AuthEngine` but does not register any `AuthMethod`, leaving developers with no endpoints to actually test a login flow.
-- **Action:** Add a mock authentication flow or use the `ClientCredentialsFlow` (or similar simple flow) to the `AuthEngine` builder.
+- **Context:** The current basic setup example initializes the `Engine` but does not register any `AuthMethod`, leaving developers with no endpoints to actually test a login flow.
+- **Action:** Add a mock authentication flow or use the `ClientCredentialsFlow` (or similar simple flow) to the `Engine` builder.
 - **Expected Outcome:** Users should be able to run the example, trigger a login via a specific endpoint (e.g., `/auth/mock/login`), and successfully see their session in the `/api/user` endpoint.
 
 ### 2. Simplify `axum_resource_server.rs` Boilerplate
@@ -27,7 +27,7 @@ This plan addresses the user feedback regarding the refactored examples in `auth
 - **Context:** Developers frequently build stateless backends using JWTs in cookies, bypassing server-side memory or Redis session stores.
 - **Action:** Create a new example file `authkestra-examples/examples/axum_stateless_session.rs`.
 - **Implementation Details:**
-  - Configure `AuthEngine` with a stateless session manager (e.g., a JWT cookie store instead of `authkestra_session_memory::MemoryStore`).
+  - Configure `Engine` with a stateless session manager (e.g., a JWT cookie store instead of `authkestra_session_memory::MemoryStore`).
   - Demonstrate a flow (like OAuth2 or OIDC) that issues these stateless session tokens.
   - Provide an endpoint to read and validate the stateless session.
 
@@ -35,7 +35,7 @@ This plan addresses the user feedback regarding the refactored examples in `auth
 - **Context:** We need to explicitly demonstrate the "Resource Server strategy" using `authkestra-resource` to protect APIs.
 - **Action:** Create a new example file `authkestra-examples/examples/axum_resource_server_strategy.rs`.
 - **Implementation Details:**
-  - Show how to register the resource server strategy into the main `AuthEngine` if applicable, or how to use the specific `authkestra-resource` extractors and middlewares.
+  - Show how to register the resource server strategy into the main `Engine` if applicable, or how to use the specific `authkestra-resource` extractors and middlewares.
   - Provide clear dummy data/endpoints to test token validation scopes and claims.
 
 ## Execution


### PR DESCRIPTION
This PR introduces the final global renaming of `AuthEngine` to `AkBase` and re-aligns all traits and macros to the `Ak` prefix prefix. It also strips out all legacy backward compatibility macros (like `#[auth_engine]` and `AuthkestraFromRef`) in favor of the new API. Examples have been updated and tests pass cleanly.