### PR TITLE
chore(website): fix pnpm workspace config

### DIFF
--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - '.'
+
 allowBuilds:
   esbuild: true
   sharp: true


### PR DESCRIPTION
This fixes the GitHub Actions build error caused by pnpm v9 strictly requiring a packages array when a pnpm-workspace.yaml is present.