### PR TITLE
ci(docs): upgrade node version to 22 for astro build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install pnpm
         uses: pnpm/action-setup@v3

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - '.'
+
 allowBuilds:
   esbuild: true
   sharp: true


### PR DESCRIPTION
Astro requires Node >= 22.12.0 for building. This PR updates the setup-node action to use Node 22.