### PR TITLE
chore(website): update base url for github pages

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -4,7 +4,8 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://authkestra.com',
+	site: 'https://marcjazz.github.io',
+	base: '/authkestra',
 
 	integrations: [
 		starlight({


### PR DESCRIPTION
Sets the Astro base URL to `/authkestra` to correctly serve CSS/JS assets on GitHub pages.