### PR TITLE
chore(website): revert to authkestra.com and upgrade github actions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: 22
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 9
 
@@ -44,7 +44,7 @@ jobs:
         run: pnpm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./website/dist
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -4,7 +4,8 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://authkestra.com',
+	site: 'https://marcjazz.github.io',
+	base: '/authkestra',
 
 	integrations: [
 		starlight({

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -4,8 +4,7 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://marcjazz.github.io',
-	base: '/authkestra',
+	site: 'https://authkestra.com',
 
 	integrations: [
 		starlight({


### PR DESCRIPTION
Reverts Astro config to point back to `authkestra.com` and upgrades CI action dependencies (`pnpm/action-setup` to v4 and `actions/upload-pages-artifact` to v4) to quiet Node 20 deprecation warnings.