### PR TITLE
ci: fix crate publishing topological sort

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,11 +48,35 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 2
       matrix:
         crate:
           - authkestra-resource
           - authkestra-providers
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish crate
+        run: bash .github/scripts/publish-crate.sh "${{ matrix.crate }}"
+
+  publish-advanced:
+    name: Publish advanced / ${{ matrix.crate }}
+    runs-on: ubuntu-latest
+    needs: publish-core
+    environment: ${{ github.event.inputs.deploy_environment || 'pre-prod' }}
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        crate:
           - authkestra-oidc
           - authkestra-op
 
@@ -69,7 +93,7 @@ jobs:
   publish-frameworks:
     name: Publish frameworks / ${{ matrix.crate }}
     runs-on: ubuntu-latest
-    needs: publish-core
+    needs: publish-advanced
     environment: ${{ github.event.inputs.deploy_environment || 'pre-prod' }}
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -4,8 +4,7 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://marcjazz.github.io',
-	base: '/authkestra',
+	site: 'https://authkestra.com',
 
 	integrations: [
 		starlight({


### PR DESCRIPTION
Separates the `publish-core` job into `publish-core` and `publish-advanced` to prevent parallel jobs from failing when `authkestra-op` tries to package before `authkestra-resource` propagates to the crates.io index.