### PR TITLE
chore: bump workspace to 0.2.1 and include readmes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,11 +48,35 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 2
       matrix:
         crate:
           - authkestra-resource
           - authkestra-providers
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish crate
+        run: bash .github/scripts/publish-crate.sh "${{ matrix.crate }}"
+
+  publish-advanced:
+    name: Publish advanced / ${{ matrix.crate }}
+    runs-on: ubuntu-latest
+    needs: publish-core
+    environment: ${{ github.event.inputs.deploy_environment || 'pre-prod' }}
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        crate:
           - authkestra-oidc
           - authkestra-op
 
@@ -69,7 +93,7 @@ jobs:
   publish-frameworks:
     name: Publish frameworks / ${{ matrix.crate }}
     runs-on: ubuntu-latest
-    needs: publish-core
+    needs: publish-advanced
     environment: ${{ github.event.inputs.deploy_environment || 'pre-prod' }}
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authkestra"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actix-files",
  "actix-web",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-actix"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actix-utils",
  "actix-web",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-axum"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "authkestra-engine",
  "authkestra-macros",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-engine"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-oidc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "authkestra-engine",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-op"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "argon2",
  "async-trait",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-providers"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "authkestra-engine",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-resource"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "authkestra-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,18 +19,19 @@ repository = "https://github.com/marcjazz/authkestra"
 license = "MIT OR Apache-2.0"
 keywords = ["auth", "authentication", "oauth2", "oidc"]
 categories = ["authentication"]
+readme = "README.md"
 
 [workspace.dependencies]
-authkestra-engine = { version = "0.2.0", path = "crates/authkestra-engine" }
-authkestra-providers = { version = "0.2.0", path = "crates/authkestra-providers" }
-authkestra-axum = { version = "0.2.0", path = "crates/authkestra-axum" }
-authkestra-macros = { version = "0.2.0", path = "crates/authkestra-macros" }
-authkestra-oidc = { version = "0.2.0", path = "crates/authkestra-oidc" }
-authkestra-actix = { version = "0.2.0", path = "crates/authkestra-actix" }
-authkestra-resource = { version = "0.2.0", path = "crates/authkestra-resource" }
-authkestra = { version = "0.2.0", path = "crates/authkestra" }
+authkestra-engine = { version = "0.2.1", path = "crates/authkestra-engine" }
+authkestra-providers = { version = "0.2.1", path = "crates/authkestra-providers" }
+authkestra-axum = { version = "0.2.1", path = "crates/authkestra-axum" }
+authkestra-macros = { version = "0.2.1", path = "crates/authkestra-macros" }
+authkestra-oidc = { version = "0.2.1", path = "crates/authkestra-oidc" }
+authkestra-actix = { version = "0.2.1", path = "crates/authkestra-actix" }
+authkestra-resource = { version = "0.2.1", path = "crates/authkestra-resource" }
+authkestra = { version = "0.2.1", path = "crates/authkestra" }
 
-authkestra-op = { version = "0.2.0", path = "crates/authkestra-op" }
+authkestra-op = { version = "0.2.1", path = "crates/authkestra-op" }
 rand = "0.9.2"
 url = "2.5"
 sha2 = "0.10"

--- a/crates/authkestra-actix/Cargo.toml
+++ b/crates/authkestra-actix/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "authkestra-actix"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "Actix-web integration for the authkestra authentication framework"
 repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
+readme = "README.md"
 
 [dependencies]
 authkestra-engine = { workspace = true }

--- a/crates/authkestra-axum/Cargo.toml
+++ b/crates/authkestra-axum/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "authkestra-axum"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "Axum integration for the authkestra authentication framework"
 repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
+readme = "README.md"
 
 [dependencies]
 authkestra-engine = { workspace = true, optional = true }

--- a/crates/authkestra-engine/Cargo.toml
+++ b/crates/authkestra-engine/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "authkestra-engine"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "Unified authentication engine for the authkestra framework"
 repository.workspace = true
 license.workspace = true
+readme.workspace = true
 
 [dependencies]
 # From authkestra-core

--- a/crates/authkestra-macros/Cargo.toml
+++ b/crates/authkestra-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-macros"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors = ["Authkestra Contributors"]
 license.workspace = true
@@ -8,6 +8,7 @@ description = "Procedural macros for authkestra framework integrations"
 repository.workspace = true
 keywords.workspace = true
 categories.workspace = true
+readme = "README.md"
 
 [lib]
 proc-macro = true

--- a/crates/authkestra-oidc/Cargo.toml
+++ b/crates/authkestra-oidc/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "authkestra-oidc"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "OIDC support for the authkestra framework"
 repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
+readme = "README.md"
 
 [dependencies]
 authkestra-engine = { workspace = true, features = ["token"] }

--- a/crates/authkestra-op/Cargo.toml
+++ b/crates/authkestra-op/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "authkestra-op"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "OpenID Provider (OP) support for the authkestra framework — issue tokens and run the authorization code grant, rather than only consuming an external IdP"
 repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
+readme.workspace = true
 
 [dependencies]
 authkestra-engine = { workspace = true, features = ["token", "memory"] }

--- a/crates/authkestra-providers/Cargo.toml
+++ b/crates/authkestra-providers/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "authkestra-providers"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "Consolidated OAuth providers for the authkestra framework"
 repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
+readme.workspace = true
 
 [features]
 default = []

--- a/crates/authkestra-resource/Cargo.toml
+++ b/crates/authkestra-resource/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "authkestra-resource"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "Resource server enforcement and validation for the authkestra framework"
 repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
+readme = "README.md"
 
 [dependencies]
 authkestra-engine = { workspace = true }

--- a/crates/authkestra/Cargo.toml
+++ b/crates/authkestra/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "authkestra"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "A modular authentication framework for Rust"
 repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
+readme.workspace = true
 
 [dependencies]
 authkestra-engine = { workspace = true }

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -4,8 +4,7 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://marcjazz.github.io',
-	base: '/authkestra',
+	site: 'https://authkestra.com',
 
 	integrations: [
 		starlight({


### PR DESCRIPTION
Bumps all crates to `0.2.1` so we can successfully republish them to crates.io. Also adds `readme = "README.md"` explicitly to all `Cargo.toml` files to ensure cargo packages the markdown documentation for the crates.io registry.