### PR TITLE
docs(website): document required cargo features

### DIFF
--- a/website/src/content/docs/advanced/op-server.md
+++ b/website/src/content/docs/advanced/op-server.md
@@ -9,6 +9,18 @@ Beyond consuming identities, Authkestra allows you to *become* the identity prov
 
 An OpenID Provider (OP) is an OAuth 2.0 Authorization Server capable of authenticating End-Users and providing claims to a Relying Party (RP). We strictly implement [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html).
 
+## Prerequisites
+
+Because OP Servers are an advanced use case, the OP logic is not included in the default `authkestra` facade crate. You must include the `authkestra-op` crate directly and explicitly enable the `op` feature on your chosen web framework adapter.
+
+```toml
+[dependencies]
+authkestra-op = "0.2.1"
+authkestra-axum = { version = "0.2.1", features = ["op"] }
+# Or if using Actix:
+# authkestra-actix = { version = "0.2.1", features = ["op"] }
+```
+
 ## The OpStore Interface
 
 To run an OP Server, you need to persist four specific types of records: Clients, Auth Codes, Refresh Tokens, and Device Codes. 

--- a/website/src/content/docs/advanced/op-server.md
+++ b/website/src/content/docs/advanced/op-server.md
@@ -47,6 +47,27 @@ Authkestra's OP server is fully featured and natively supports the following OAu
 4. **Device Code** (`GrantType::DeviceCode`): The OAuth 2.0 Device Authorization Grant (RFC 8628). Used for input-constrained devices like Smart TVs or CLI tools where the user authenticates on a secondary device (e.g., their smartphone).
 5. **Token Exchange** (`GrantType::TokenExchange`): The OAuth 2.0 Token Exchange grant (RFC 8693). Allows a resource server to impersonate or delegate permissions by exchanging an incoming access token for a new token targeting a downstream service.
 
+## Supported Algorithms & Scopes
+
+It is important to distinguish between what the Authkestra framework *can* do and what you, the developer, *choose* to enable via your OP configuration.
+
+### Signing Algorithms
+
+Authkestra uses the underlying `jsonwebtoken` crate, which provides robust support for modern cryptographic signing algorithms (including `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `EdDSA`, etc.). 
+
+However, when configuring your OP server, **you must choose an asymmetric algorithm** (like `RS256`). Authkestra intentionally rejects symmetric algorithms (like `HS256`) for OpenID Providers. This is a strict security requirement: Resource Servers and Relying Parties must be able to verify your tokens using public keys exposed at your `/jwks` endpoint without ever knowing your private signing secret.
+
+### Scopes
+
+Authkestra is entirely **scope-agnostic**. The framework does not hardcode what scopes mean. 
+
+If you want to be OpenID Connect compliant, you simply add `"openid"`, `"profile"`, and `"email"` to your configuration. But you are completely free to invent custom scopes for your own APIs (e.g., `"billing:read"`, `"admin:write"`, `"devices:provision"`).
+
+The relationship works like this:
+1. **Global Capability**: You define all possible scopes your server understands in `OpConfig.scopes_supported`.
+2. **Client Restriction**: When creating a `ClientRegistration` in your database, you give that client a subset of those scopes.
+3. **User Delegation**: When a user logs in, the `/authorize` flow ensures the requested scopes do not exceed what the client is permitted to ask for.
+
 ## Documenting `OpConfig`
 
 The behavior of your OpenID Provider is entirely driven by `OpConfig`. When building the state, you must configure this struct to declare what your server supports.

--- a/website/src/content/docs/advanced/resource-server.md
+++ b/website/src/content/docs/advanced/resource-server.md
@@ -11,6 +11,18 @@ According to [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-1.
 
 To securely validate an external JWT, the Resource Server must verify the cryptographic signature using the external provider's public keys (JWKS, defined in [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517)).
 
+## Prerequisites
+
+Like the OP Server, the Resource Server is an advanced component and is not included by default. You must explicitly include the `authkestra-resource` crate and enable the `resource` feature on your chosen web adapter.
+
+```toml
+[dependencies]
+authkestra-resource = "0.2.1"
+authkestra-axum = { version = "0.2.1", features = ["resource"] }
+# Or if using Actix:
+# authkestra-actix = { version = "0.2.1", features = ["resource"] }
+```
+
 ## Building with Authkestra Guard
 
 Authkestra provides the `authkestra-resource` crate, which features a `Guard` and a `JwtStrategy` that automatically caches and refreshes external JWKS.

--- a/website/src/content/docs/guides/framework-integration.mdx
+++ b/website/src/content/docs/guides/framework-integration.mdx
@@ -6,6 +6,29 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 Authkestra provides first-class support for both the `axum` and `actix-web` web frameworks through lightweight adapter crates (`authkestra-axum` and `authkestra-actix`).
 
+## Prerequisites
+
+Ensure you have enabled the correct web framework feature on the `authkestra` crate in your `Cargo.toml`. Also, since session management is stateful, make sure the `session` feature is enabled.
+
+<Tabs>
+  <TabItem label="Axum" icon="seti:rust">
+
+```toml
+[dependencies]
+authkestra = { version = "0.2.1", features = ["axum", "session"] }
+```
+
+  </TabItem>
+  <TabItem label="Actix-web" icon="seti:rust">
+
+```toml
+[dependencies]
+authkestra = { version = "0.2.1", features = ["actix", "session"] }
+```
+
+  </TabItem>
+</Tabs>
+
 ## The `AuthSession` Extractor
 
 The primary way to interact with an authenticated user in a handler is via the `AuthSession` extractor. It automatically validates the session and injects the user's identity.

--- a/website/src/content/docs/guides/quickstart.mdx
+++ b/website/src/content/docs/guides/quickstart.mdx
@@ -16,7 +16,7 @@ Add the `authkestra` facade crate to your `Cargo.toml`. The facade re-exports al
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.0", features = ["axum", "github"] }
+authkestra = { version = "0.2.1", features = ["axum", "github"] }
 ```
 
   </TabItem>
@@ -24,7 +24,7 @@ authkestra = { version = "0.2.0", features = ["axum", "github"] }
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.0", features = ["actix", "github"] }
+authkestra = { version = "0.2.1", features = ["actix", "github"] }
 ```
 
   </TabItem>

--- a/website/src/content/docs/providers/oauth2.md
+++ b/website/src/content/docs/providers/oauth2.md
@@ -11,6 +11,15 @@ By default, OAuth2 logins often result in a server-side session being created. H
 
 Authkestra strictly implements the [OAuth 2.0 Authorization Framework (RFC 6749)](https://datatracker.ietf.org/doc/html/rfc6749) and [PKCE (RFC 7636)](https://datatracker.ietf.org/doc/html/rfc7636). We didn't invent these protocols; we just provide a memory-safe, idiomatic Rust engine to execute them.
 
+## Prerequisites
+
+If you are using multiple OAuth providers (e.g., GitHub and Google), you must enable their respective feature flags:
+
+```toml
+[dependencies]
+authkestra = { version = "0.2.1", features = ["github", "google"] }
+```
+
 ## Stateless Engine Configuration
 
 Notice how we completely omit `.session_store()` and use `.jwt_secret()` instead. You can also chain multiple providers back-to-back:

--- a/website/src/content/docs/providers/oidc.md
+++ b/website/src/content/docs/providers/oidc.md
@@ -5,6 +5,15 @@ description: Using the generic OpenID Connect client with Authkestra.
 
 Authkestra provides a generic OpenID Connect (OIDC) client that can automatically discover endpoints and keys from any OIDC-compliant provider.
 
+## Prerequisites
+
+To use the OIDC client, you must enable the `oidc` feature on the `authkestra` crate.
+
+```toml
+[dependencies]
+authkestra = { version = "0.2.1", features = ["oidc"] }
+```
+
 ## Configuring the OIDC Provider
 
 You can instantiate the `OidcProvider` directly by pointing it to the issuer URL. The client will automatically fetch the `/.well-known/openid-configuration` to determine the authorization and token endpoints.

--- a/website/src/content/docs/storage/overview.md
+++ b/website/src/content/docs/storage/overview.md
@@ -22,5 +22,15 @@ Because this is a trait, you can implement it using `sqlx`, `diesel`, `redis`, o
 
 ## Included Stores
 
-Authkestra comes with a few implementations out of the box for convenience:
-- `authkestra_engine::store::memory::MemoryStore` (Great for testing and local dev)
+Authkestra comes with a few generic implementations out of the box for convenience. To use them, you must enable the corresponding feature flags in your `Cargo.toml`:
+
+```toml
+[dependencies]
+# Example: Using Redis and SQLite stores
+authkestra = { version = "0.2.1", features = ["redis", "sql-sqlite"] }
+```
+
+The available built-in stores and their feature flags are:
+- **Memory Store**: `authkestra_engine::store::memory::MemoryStore` (Great for testing and local dev; enabled by the `memory` feature).
+- **Redis Store**: `authkestra_engine::store::redis::RedisStore` (Production-ready distributed cache; enabled by the `redis` feature).
+- **SQL Store**: `authkestra_engine::store::sql::SqlStore` (Relational persistence; enabled by `sql-postgres`, `sql-mysql`, or `sql-sqlite` features).


### PR DESCRIPTION
Addresses the issue where advanced components and specific integrations (OP Server, Resource Server, OIDC, OAuth2 providers, Storage backends, and framework integrations) did not explicitly show the required `Cargo.toml` changes and feature flags in the documentation. Adds "Prerequisites" sections to all relevant documentation pages to guide developers on which crates and features to enable.