### PR TITLE
feat(engine): allow custom claims on issued tokens

### DIFF
--- a/crates/authkestra-engine/src/token/mod.rs
+++ b/crates/authkestra-engine/src/token/mod.rs
@@ -116,6 +116,28 @@ impl TokenManager {
         scope: Option<String>,
         aud: Option<String>,
     ) -> Result<String, AuthError> {
+        self.issue_user_token_with_extra(identity, expires_in_secs, scope, aud, HashMap::new())
+    }
+
+    /// Issues a token for a user identity, stamping the given `extra` claims
+    /// onto the token in addition to the standard/core claims.
+    ///
+    /// This lets a host application (e.g. a resource server built on top of
+    /// this engine) attach domain-specific claims — such as `api_key_id`,
+    /// `project_id`, or `roles` — so downstream consumers (an API gateway or
+    /// authorization proxy) can read them directly off the token without a
+    /// database round-trip. Keys in `extra` take precedence over any
+    /// same-named field set elsewhere in `extra` by this method; they cannot
+    /// override the top-level standard claims (`sub`, `aud`, `exp`, etc.)
+    /// since those are not part of the flattened map.
+    pub fn issue_user_token_with_extra(
+        &self,
+        identity: Identity,
+        expires_in_secs: u64,
+        scope: Option<String>,
+        aud: Option<String>,
+        extra: HashMap<String, serde_json::Value>,
+    ) -> Result<String, AuthError> {
         let now = chrono::Utc::now().timestamp() as usize;
         let expiration = now + expires_in_secs as usize;
 
@@ -129,7 +151,7 @@ impl TokenManager {
             jti: Some(uuid::Uuid::new_v4().to_string()),
             scope,
             identity: Some(identity),
-            extra: HashMap::new(),
+            extra,
         };
 
         let mut header = Header::new(self.alg);
@@ -148,6 +170,27 @@ impl TokenManager {
         nonce: Option<String>,
         expires_in_secs: u64,
     ) -> Result<String, AuthError> {
+        self.issue_id_token_with_extra(identity, client_id, nonce, expires_in_secs, HashMap::new())
+    }
+
+    /// Issues an OIDC-conformant ID token, stamping the given `extra` claims
+    /// onto the token in addition to the standard/core claims.
+    ///
+    /// `nonce` is a reserved claim key: `extra` is merged into the token
+    /// first, then the explicit `nonce` parameter is applied on top. So if
+    /// `nonce` is `Some(_)`, it always wins over any `"nonce"` entry passed
+    /// in `extra`. If `nonce` is `None`, an `extra["nonce"]` value (if any)
+    /// is left as-is. This preserves OIDC `nonce` semantics — it reflects
+    /// what the client sent in the authorization request — and keeps it from
+    /// being accidentally clobbered by unrelated custom claims.
+    pub fn issue_id_token_with_extra(
+        &self,
+        identity: Identity,
+        client_id: &str,
+        nonce: Option<String>,
+        expires_in_secs: u64,
+        extra: HashMap<String, serde_json::Value>,
+    ) -> Result<String, AuthError> {
         let now = chrono::Utc::now().timestamp() as usize;
         let expiration = now + expires_in_secs as usize;
 
@@ -161,7 +204,7 @@ impl TokenManager {
             jti: Some(uuid::Uuid::new_v4().to_string()),
             scope: None,
             identity: Some(identity),
-            extra: HashMap::new(),
+            extra,
         };
 
         if let Some(n) = nonce {
@@ -186,6 +229,20 @@ impl TokenManager {
         scope: Option<String>,
         aud: Option<String>,
     ) -> Result<String, AuthError> {
+        self.issue_client_token_with_extra(client_id, expires_in_secs, scope, aud, HashMap::new())
+    }
+
+    /// Issues a machine-to-machine (M2M) token for a client, stamping the
+    /// given `extra` claims onto the token in addition to the standard/core
+    /// claims. See [`Self::issue_user_token_with_extra`] for the rationale.
+    pub fn issue_client_token_with_extra(
+        &self,
+        client_id: &str,
+        expires_in_secs: u64,
+        scope: Option<String>,
+        aud: Option<String>,
+        extra: HashMap<String, serde_json::Value>,
+    ) -> Result<String, AuthError> {
         let now = chrono::Utc::now().timestamp() as usize;
         let expiration = now + expires_in_secs as usize;
 
@@ -199,7 +256,7 @@ impl TokenManager {
             jti: Some(uuid::Uuid::new_v4().to_string()),
             scope,
             identity: None,
-            extra: HashMap::new(),
+            extra,
         };
 
         let mut header = Header::new(self.alg);
@@ -407,6 +464,157 @@ a0QMqKUcs8+YTy5R5K6qtw==
             .validate_token(&token, Some("client-2"))
             .unwrap_err();
         assert!(err.to_string().contains("InvalidAudience"));
+    }
+
+    #[test]
+    fn test_issue_user_token_with_extra_round_trips_custom_claims() {
+        let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
+        let identity = Identity {
+            provider_id: "mock".to_string(),
+            external_id: "user123".to_string(),
+            email: None,
+            username: None,
+            attributes: HashMap::new(),
+        };
+
+        let mut extra = HashMap::new();
+        extra.insert("api_key_id".to_string(), serde_json::json!("key-abc"));
+        extra.insert("project_id".to_string(), serde_json::json!("proj-42"));
+
+        let token = manager
+            .issue_user_token_with_extra(identity, 3600, None, None, extra)
+            .unwrap();
+        let claims = manager.validate_token(&token, None).unwrap();
+
+        assert_eq!(
+            claims.extra.get("api_key_id"),
+            Some(&serde_json::json!("key-abc"))
+        );
+        assert_eq!(
+            claims.extra.get("project_id"),
+            Some(&serde_json::json!("proj-42"))
+        );
+    }
+
+    #[test]
+    fn test_issue_user_token_wrapper_still_has_empty_extra() {
+        let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
+        let identity = Identity {
+            provider_id: "mock".to_string(),
+            external_id: "user123".to_string(),
+            email: None,
+            username: None,
+            attributes: HashMap::new(),
+        };
+
+        let token = manager
+            .issue_user_token(identity, 3600, None, None)
+            .unwrap();
+        let claims = manager.validate_token(&token, None).unwrap();
+
+        assert!(claims.extra.is_empty());
+    }
+
+    #[test]
+    fn test_issue_client_token_with_extra_round_trips_custom_claims() {
+        let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
+
+        let mut extra = HashMap::new();
+        extra.insert("roles".to_string(), serde_json::json!(["admin", "billing"]));
+
+        let token = manager
+            .issue_client_token_with_extra("client-1", 3600, None, None, extra)
+            .unwrap();
+        let claims = manager.validate_token(&token, None).unwrap();
+
+        assert_eq!(
+            claims.extra.get("roles"),
+            Some(&serde_json::json!(["admin", "billing"]))
+        );
+    }
+
+    #[test]
+    fn test_issue_client_token_wrapper_still_has_empty_extra() {
+        let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
+
+        let token = manager
+            .issue_client_token("client-1", 3600, None, None)
+            .unwrap();
+        let claims = manager.validate_token(&token, None).unwrap();
+
+        assert!(claims.extra.is_empty());
+    }
+
+    #[test]
+    fn test_issue_id_token_with_extra_round_trips_custom_claims() {
+        let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
+        let identity = Identity {
+            provider_id: "mock".to_string(),
+            external_id: "user123".to_string(),
+            email: None,
+            username: None,
+            attributes: HashMap::new(),
+        };
+
+        let mut extra = HashMap::new();
+        extra.insert("org_id".to_string(), serde_json::json!("org-7"));
+
+        let token = manager
+            .issue_id_token_with_extra(
+                identity,
+                "client-1",
+                Some("nonce123".to_string()),
+                3600,
+                extra,
+            )
+            .unwrap();
+        let claims = manager.validate_token(&token, None).unwrap();
+
+        assert_eq!(
+            claims.extra.get("org_id"),
+            Some(&serde_json::json!("org-7"))
+        );
+        assert_eq!(
+            claims.extra.get("nonce"),
+            Some(&serde_json::json!("nonce123"))
+        );
+    }
+
+    #[test]
+    fn test_issue_id_token_with_extra_explicit_nonce_wins_over_extra_nonce() {
+        // Documents the precedence chosen in `issue_id_token_with_extra`:
+        // the explicit `nonce` parameter always overrides a `"nonce"` entry
+        // supplied via `extra`.
+        let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
+        let identity = Identity {
+            provider_id: "mock".to_string(),
+            external_id: "user123".to_string(),
+            email: None,
+            username: None,
+            attributes: HashMap::new(),
+        };
+
+        let mut extra = HashMap::new();
+        extra.insert(
+            "nonce".to_string(),
+            serde_json::json!("attacker-supplied-nonce"),
+        );
+
+        let token = manager
+            .issue_id_token_with_extra(
+                identity,
+                "client-1",
+                Some("real-nonce".to_string()),
+                3600,
+                extra,
+            )
+            .unwrap();
+        let claims = manager.validate_token(&token, None).unwrap();
+
+        assert_eq!(
+            claims.extra.get("nonce"),
+            Some(&serde_json::json!("real-nonce"))
+        );
     }
 }
 pub mod jwk;


### PR DESCRIPTION
## What's missing today

`TokenManager` (`crates/authkestra-engine/src/token/mod.rs`) exposes three token-issuance methods — `issue_user_token`, `issue_id_token`, and `issue_client_token` — that all build a `Claims` struct with `#[serde(flatten)] pub extra: HashMap<String, serde_json::Value>`. Every call site hardcodes `extra: HashMap::new()`; `issue_id_token` is the sole exception, inserting a single `nonce` entry when a nonce is supplied.

There is currently no way for a host application built on `authkestra-op`/`authkestra-engine` to stamp its own domain-specific claims onto an issued token — e.g. a resource-server-scoped claim like `api_key_id`, `project_id`, or `roles` that a downstream consumer (an API gateway or authorization proxy) needs to read directly off the token without a database round-trip.

This is motivated by real integration work: building a resource server on top of Authkestra that needs to carry a few of its own identifiers/roles in the access token for a downstream gateway to enforce policy on, without round-tripping to a database on every request.

Custom claim mapping is also a standard OAuth2/OIDC authorization-server feature — Auth0, Keycloak, and Okta all support it — and this project's own docs (`docs/rfc-003-oidc-provider.md`) describe a goal of "standalone server deployment (similar to Keycloak)," which implies the same capability eventually.

## The change

Additive only, scoped to `authkestra-engine`. No changes to `authkestra-op` or any other crate; every existing call site keeps compiling unmodified.

- Added `issue_user_token_with_extra`, `issue_id_token_with_extra`, and `issue_client_token_with_extra`, each accepting an `extra: HashMap<String, serde_json::Value>` parameter that becomes `Claims.extra` for the issued token.
- The existing `issue_user_token`, `issue_id_token`, and `issue_client_token` are now thin wrappers that delegate to the `_with_extra` variants with `HashMap::new()`. Logic (timestamps, `jti`, `nbf`, `header.kid`, etc.) is unchanged — it lives entirely in the `_with_extra` variants now.
- `issue_id_token_with_extra` merges the caller-supplied `extra` map into the claims first, then applies the explicit `nonce` parameter on top. This means the `nonce` parameter always wins over a `"nonce"` key smuggled in via `extra`, preserving OIDC `nonce` semantics (it reflects what the client sent in the authorization request) instead of letting an unrelated custom claim clobber it. This precedence is documented on the method and covered by a dedicated test.

## Tests

All added to the existing `#[cfg(test)] mod tests` block in `token/mod.rs`:

- `test_issue_user_token_with_extra_round_trips_custom_claims`
- `test_issue_user_token_wrapper_still_has_empty_extra`
- `test_issue_client_token_with_extra_round_trips_custom_claims`
- `test_issue_client_token_wrapper_still_has_empty_extra`
- `test_issue_id_token_with_extra_round_trips_custom_claims`
- `test_issue_id_token_with_extra_explicit_nonce_wins_over_extra_nonce` (the reserved-key collision case)

All pre-existing tests (`test_claims_serialization`, `test_token_manager_issuance`, `test_token_manager_asymmetric_issuance`, `test_issue_id_token`, `test_token_manager_audience_validation`) are unmodified and pass.

## Verification

```
cargo build --workspace                                        # clean
cargo test -p authkestra-engine                                 # 16 passed, 0 failed
cargo test --workspace --exclude authkestra --all-features      # all passed
cargo clippy --workspace --exclude authkestra --all-targets --all-features -- -D warnings   # clean
cargo fmt --all
```

Notes on scope of verification:
- `cargo test --workspace` (including the `authkestra` crate's `examples_e2e` test) is flaky in this sandbox independent of this change: `test_all_oauth_examples_sequentially` spawns the example binaries sequentially against a hardcoded `localhost:3000` and occasionally hits `AddrInUse`/stale-server 404s from insufficient shutdown time between examples. Reproduced the same failure mode on unmodified `upstream/main` before making any change, so it's pre-existing test infra flakiness, not something introduced here.
- `cargo clippy --workspace` (including the `authkestra` crate) fails independent of this change on `crates/authkestra/examples/actix/basic_setup.rs` (`unused imports: Configured and Missing`), tracing back to commit 80b475b (unrelated to this PR, no files in `authkestra` touched here).
- Tests requiring external services (Redis/SQL/Postgres/MySQL via testcontainers) were run with `--all-features` and passed locally with Docker available; no tests were skipped for that reason.

## AI Usage Declaration

This change was developed with AI assistance (Claude). AI was used to read the existing `TokenManager` implementation, design and write the additive `_with_extra` methods and their tests, and draft this PR description. All code was reviewed, built, tested, and linted locally before opening this PR; the reasoning above (the nonce-precedence decision, the additive/wrapper design) reflects a human-reviewed judgment call, not an unreviewed AI suggestion.
