### PR TITLE
feat(resource): support multi-value audience and opt-in strict kid enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,11 +565,14 @@ dependencies = [
  "base64",
  "http 1.4.0",
  "jsonwebtoken",
+ "rand 0.8.6",
  "reqwest",
+ "rsa",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/authkestra-oidc/src/error.rs
+++ b/crates/authkestra-oidc/src/error.rs
@@ -63,6 +63,9 @@ impl From<authkestra_resource::jwt::ValidationError> for OidcError {
             authkestra_resource::jwt::ValidationError::KeyNotFound => {
                 OidcError::ValidationError("Key not found".to_string())
             }
+            authkestra_resource::jwt::ValidationError::MissingKid => {
+                OidcError::ValidationError("Token is missing a required 'kid' header".to_string())
+            }
             authkestra_resource::jwt::ValidationError::Paseto(e) => OidcError::ValidationError(e),
             authkestra_resource::jwt::ValidationError::Validation(e) => {
                 OidcError::ValidationError(e)

--- a/crates/authkestra-resource/Cargo.toml
+++ b/crates/authkestra-resource/Cargo.toml
@@ -20,3 +20,8 @@ tokio = { version = "1.0", features = ["full"] }
 thiserror = "2.0.18"
 http = "1"
 base64 = "0.22.1"
+
+[dev-dependencies]
+wiremock = "0.6"
+rsa = "0.9.6"
+rand = "0.8"

--- a/crates/authkestra-resource/src/jwt.rs
+++ b/crates/authkestra-resource/src/jwt.rs
@@ -24,6 +24,10 @@ pub enum ValidationError {
     InvalidToken(String),
     #[error("Key not found in JWKS")]
     KeyNotFound,
+    #[error(
+        "Token is missing a 'kid' header, which is required by this JWKS cache's strict validation policy"
+    )]
+    MissingKid,
     #[error("PASETO error: {0}")]
     Paseto(String),
     #[error("Discovery error: {0}")]
@@ -58,6 +62,7 @@ pub struct JwksCache {
     jwks_uri: String,
     jwks: RwLock<Option<(Jwks, Instant)>>,
     ttl: Duration,
+    require_kid: bool,
 }
 
 impl JwksCache {
@@ -66,7 +71,19 @@ impl JwksCache {
             jwks_uri,
             jwks: RwLock::new(None),
             ttl: refresh_interval,
+            require_kid: false,
         }
+    }
+
+    /// When set to `true`, tokens presented without a `kid` header will be rejected
+    /// with [`ValidationError::MissingKid`] instead of silently falling back to the
+    /// first key in the JWKS. This guards against key-confusion when the JWKS holds
+    /// more than one key (e.g. during rotation).
+    ///
+    /// Defaults to `false` to preserve today's permissive fallback behavior.
+    pub fn require_kid(mut self, value: bool) -> Self {
+        self.require_kid = value;
+        self
     }
 
     pub async fn get_jwks(&self) -> Result<Jwks, ValidationError> {
@@ -83,6 +100,10 @@ impl JwksCache {
     }
 
     pub async fn get_key(&self, kid: Option<&str>) -> Result<Option<Jwk>, ValidationError> {
+        if kid.is_none() && self.require_kid {
+            return Err(ValidationError::MissingKid);
+        }
+
         let jwks = self.get_jwks().await?;
         if let Some(key) = jwks.find_key(kid) {
             return Ok(Some(key.clone()));
@@ -107,8 +128,9 @@ pub struct ValidationConfig {
     pub jwks_url: String,
     pub refresh_interval: Duration,
     pub issuer: Option<String>,
-    pub audience: Option<String>,
+    pub audience: Vec<String>,
     pub algorithms: Vec<Algorithm>,
+    pub require_kid: bool,
 }
 
 impl ValidationConfig {
@@ -124,8 +146,9 @@ pub struct ValidationConfigBuilder {
     jwks_url: Option<String>,
     refresh_interval: Option<Duration>,
     issuer: Option<String>,
-    audience: Option<String>,
+    audience: Vec<String>,
     algorithms: Vec<Algorithm>,
+    require_kid: bool,
 }
 
 impl ValidationConfigBuilder {
@@ -147,15 +170,33 @@ impl ValidationConfigBuilder {
         self
     }
 
-    /// Set the expected audience.
+    /// Add an expected audience. May be called multiple times to accept tokens scoped to
+    /// any one of several audiences. Kept for backward compatibility with single-audience
+    /// configuration; prefer [`ValidationConfigBuilder::audiences`] when adding more than one.
     pub fn audience(mut self, audience: impl Into<String>) -> Self {
-        self.audience = Some(audience.into());
+        self.audience.push(audience.into());
+        self
+    }
+
+    /// Add multiple expected audiences at once. A token is accepted if its `aud` claim
+    /// matches ANY of the configured audiences (e.g. a token valid for both a web app and
+    /// a mobile client, or a gateway service that accepts several downstream audiences).
+    pub fn audiences(mut self, audiences: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.audience.extend(audiences.into_iter().map(Into::into));
         self
     }
 
     /// Set the allowed algorithms.
     pub fn algorithms(mut self, algorithms: Vec<Algorithm>) -> Self {
         self.algorithms = algorithms;
+        self
+    }
+
+    /// When `true`, reject tokens that omit a `kid` header instead of silently falling back
+    /// to the first key in the JWKS. Off by default for backward compatibility. See
+    /// [`JwksCache::require_kid`].
+    pub fn require_kid(mut self, value: bool) -> Self {
+        self.require_kid = value;
         self
     }
 
@@ -175,6 +216,7 @@ impl ValidationConfigBuilder {
             } else {
                 self.algorithms
             },
+            require_kid: self.require_kid,
         }
     }
 }
@@ -189,7 +231,8 @@ pub struct JwtStrategy<I> {
 impl<I> JwtStrategy<I> {
     /// Create a new `JwtStrategy` with the given `ValidationConfig`.
     pub fn new(config: ValidationConfig) -> Self {
-        let cache = JwksCache::new(config.jwks_url, config.refresh_interval);
+        let cache = JwksCache::new(config.jwks_url, config.refresh_interval)
+            .require_kid(config.require_kid);
         let mut validation = Validation::new(config.algorithms[0]);
         validation.algorithms = config.algorithms;
 
@@ -197,8 +240,8 @@ impl<I> JwtStrategy<I> {
             validation.set_issuer(&[iss]);
         }
 
-        if let Some(aud) = config.audience {
-            validation.set_audience(&[aud]);
+        if !config.audience.is_empty() {
+            validation.set_audience(&config.audience);
         }
 
         Self {

--- a/crates/authkestra-resource/tests/jwt_test.rs
+++ b/crates/authkestra-resource/tests/jwt_test.rs
@@ -1,0 +1,302 @@
+//! Integration tests for `authkestra_resource::jwt`, covering:
+//! - multi-value audience support on `ValidationConfig` / `ValidationConfigBuilder`
+//! - backward compatibility of the single-value `.audience(...)` builder method
+//! - opt-in strict `kid` enforcement on `JwksCache`
+//!
+//! JWKS is served via a local `wiremock` server and tokens are signed with
+//! freshly generated RSA keys so the full offline-validation path (JWKS fetch,
+//! key lookup, signature + claim validation) is exercised end to end.
+
+use authkestra_engine::strategy::AuthenticationStrategy;
+use authkestra_engine::token::jwk::Jwk;
+use authkestra_resource::jwt::{
+    validate_jwt_generic, JwksCache, JwtStrategy, ValidationConfig, ValidationError,
+};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use http::{header::AUTHORIZATION, Request};
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header, Validation};
+use rsa::pkcs8::{EncodePrivateKey, LineEnding};
+use rsa::traits::PublicKeyParts;
+use rsa::RsaPrivateKey;
+use serde::{Deserialize, Serialize};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TestClaims {
+    sub: String,
+    exp: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    aud: Option<String>,
+}
+
+#[derive(Serialize)]
+struct JwksBody {
+    keys: Vec<Jwk>,
+}
+
+struct TestKey {
+    encoding_key: EncodingKey,
+    jwk: Jwk,
+}
+
+/// Generates a fresh RSA key pair and wraps it as both a signing key and the
+/// public `Jwk` representation that would be published on a JWKS endpoint.
+fn generate_rsa_key(kid: Option<&str>) -> TestKey {
+    let mut rng = rand::thread_rng();
+    let private_key = RsaPrivateKey::new(&mut rng, 2048).expect("failed to generate RSA key");
+    let pem = private_key
+        .to_pkcs8_pem(LineEnding::LF)
+        .expect("failed to encode PKCS8 PEM");
+    let encoding_key =
+        EncodingKey::from_rsa_pem(pem.as_bytes()).expect("failed to build encoding key");
+
+    let n = URL_SAFE_NO_PAD.encode(private_key.n().to_bytes_be());
+    let e = URL_SAFE_NO_PAD.encode(private_key.e().to_bytes_be());
+
+    let jwk = Jwk {
+        kid: kid.map(|s| s.to_string()),
+        kty: "RSA".to_string(),
+        alg: Some("RS256".to_string()),
+        n: Some(n),
+        e: Some(e),
+    };
+
+    TestKey { encoding_key, jwk }
+}
+
+fn sign_token(key: &EncodingKey, kid: Option<&str>, claims: &TestClaims) -> String {
+    let mut header = Header::new(Algorithm::RS256);
+    header.kid = kid.map(|s| s.to_string());
+    encode(&header, claims, key).expect("failed to sign token")
+}
+
+fn future_exp() -> usize {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as usize
+        + 3600
+}
+
+async fn start_jwks_server(keys: Vec<Jwk>) -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/.well-known/jwks.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&JwksBody { keys }))
+        .mount(&server)
+        .await;
+    server
+}
+
+fn jwks_url(server: &MockServer) -> String {
+    format!("{}/.well-known/jwks.json", server.uri())
+}
+
+#[tokio::test]
+async fn multi_audience_accepts_token_matching_any_configured_audience() {
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+
+    let config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .audiences(["a", "b", "c"])
+        .build();
+    assert_eq!(
+        config.audience,
+        vec!["a".to_string(), "b".to_string(), "c".to_string()]
+    );
+
+    let cache = JwksCache::new(config.jwks_url.clone(), config.refresh_interval);
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.set_audience(&config.audience);
+
+    let claims = TestClaims {
+        sub: "user-1".to_string(),
+        exp: future_exp(),
+        aud: Some("b".to_string()),
+    };
+    let token = sign_token(&key.encoding_key, Some("kid-1"), &claims);
+
+    let result: TestClaims = validate_jwt_generic(&token, &cache, &validation)
+        .await
+        .expect("token whose aud is in the configured audience set should validate");
+    assert_eq!(result.sub, "user-1");
+}
+
+#[tokio::test]
+async fn multi_audience_rejects_token_not_matching_any_configured_audience() {
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+
+    let config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .audiences(["a", "c"])
+        .build();
+
+    let cache = JwksCache::new(config.jwks_url.clone(), config.refresh_interval);
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.set_audience(&config.audience);
+
+    let claims = TestClaims {
+        sub: "user-1".to_string(),
+        exp: future_exp(),
+        aud: Some("b".to_string()),
+    };
+    let token = sign_token(&key.encoding_key, Some("kid-1"), &claims);
+
+    let err = validate_jwt_generic::<TestClaims>(&token, &cache, &validation)
+        .await
+        .expect_err("token whose aud is absent from the configured set must be rejected");
+    assert!(matches!(err, ValidationError::Jwt(_)));
+}
+
+#[test]
+fn single_audience_builder_call_is_backward_compatible() {
+    let config = ValidationConfig::builder()
+        .jwks_url("https://example.invalid/jwks.json")
+        .audience("x")
+        .build();
+
+    assert_eq!(config.audience, vec!["x".to_string()]);
+}
+
+#[tokio::test]
+async fn single_audience_builder_validates_like_before() {
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+
+    let config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .audience("x")
+        .build();
+
+    let cache = JwksCache::new(config.jwks_url.clone(), config.refresh_interval);
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.set_audience(&config.audience);
+
+    let matching = TestClaims {
+        sub: "user-1".to_string(),
+        exp: future_exp(),
+        aud: Some("x".to_string()),
+    };
+    let token = sign_token(&key.encoding_key, Some("kid-1"), &matching);
+    validate_jwt_generic::<TestClaims>(&token, &cache, &validation)
+        .await
+        .expect("token with matching single audience should validate");
+
+    let mismatched = TestClaims {
+        sub: "user-1".to_string(),
+        exp: future_exp(),
+        aud: Some("y".to_string()),
+    };
+    let token = sign_token(&key.encoding_key, Some("kid-1"), &mismatched);
+    let err = validate_jwt_generic::<TestClaims>(&token, &cache, &validation)
+        .await
+        .expect_err("token with mismatched single audience must be rejected");
+    assert!(matches!(err, ValidationError::Jwt(_)));
+}
+
+#[tokio::test]
+async fn missing_kid_falls_back_to_first_key_by_default() {
+    let key1 = generate_rsa_key(Some("k1"));
+    let key2 = generate_rsa_key(Some("k2"));
+    let server = start_jwks_server(vec![key1.jwk.clone(), key2.jwk.clone()]).await;
+
+    let cache = JwksCache::new(jwks_url(&server), Duration::from_secs(3600));
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.validate_aud = false;
+
+    let claims = TestClaims {
+        sub: "user-1".to_string(),
+        exp: future_exp(),
+        aud: None,
+    };
+    // Signed by the FIRST key in the JWKS, with no `kid` header on the token.
+    let token = sign_token(&key1.encoding_key, None, &claims);
+
+    let result: TestClaims = validate_jwt_generic(&token, &cache, &validation)
+        .await
+        .expect("kid-less token should fall back to the first JWKS key by default");
+    assert_eq!(result.sub, "user-1");
+}
+
+#[tokio::test]
+async fn missing_kid_is_rejected_when_require_kid_is_enabled() {
+    let key1 = generate_rsa_key(Some("k1"));
+    let key2 = generate_rsa_key(Some("k2"));
+    let server = start_jwks_server(vec![key1.jwk.clone(), key2.jwk.clone()]).await;
+
+    let cache = JwksCache::new(jwks_url(&server), Duration::from_secs(3600)).require_kid(true);
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.validate_aud = false;
+
+    let claims = TestClaims {
+        sub: "user-1".to_string(),
+        exp: future_exp(),
+        aud: None,
+    };
+    let token = sign_token(&key1.encoding_key, None, &claims);
+
+    let err = validate_jwt_generic::<TestClaims>(&token, &cache, &validation)
+        .await
+        .expect_err("kid-less token must be rejected when require_kid is enabled");
+    assert!(matches!(err, ValidationError::MissingKid));
+}
+
+#[tokio::test]
+async fn require_kid_still_allows_tokens_that_present_a_kid() {
+    let key1 = generate_rsa_key(Some("k1"));
+    let key2 = generate_rsa_key(Some("k2"));
+    let server = start_jwks_server(vec![key1.jwk.clone(), key2.jwk.clone()]).await;
+
+    let cache = JwksCache::new(jwks_url(&server), Duration::from_secs(3600)).require_kid(true);
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.validate_aud = false;
+
+    let claims = TestClaims {
+        sub: "user-2".to_string(),
+        exp: future_exp(),
+        aud: None,
+    };
+    // Signed by the SECOND key and explicitly identifies it via `kid`.
+    let token = sign_token(&key2.encoding_key, Some("k2"), &claims);
+
+    let result: TestClaims = validate_jwt_generic(&token, &cache, &validation)
+        .await
+        .expect("token presenting a kid should validate normally under require_kid");
+    assert_eq!(result.sub, "user-2");
+}
+
+#[tokio::test]
+async fn strategy_surfaces_strict_kid_rejection_as_an_error_not_a_silent_none() {
+    let key1 = generate_rsa_key(Some("k1"));
+    let server = start_jwks_server(vec![key1.jwk.clone()]).await;
+
+    let validation_config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .require_kid(true)
+        .build();
+
+    let strategy: JwtStrategy<TestClaims> = JwtStrategy::new(validation_config);
+
+    let claims = TestClaims {
+        sub: "user-1".to_string(),
+        exp: future_exp(),
+        aud: None,
+    };
+    let token = sign_token(&key1.encoding_key, None, &claims);
+
+    let request = Request::builder()
+        .header(AUTHORIZATION, format!("Bearer {token}"))
+        .body(())
+        .unwrap();
+    let (parts, _) = request.into_parts();
+
+    let result = strategy.authenticate(&parts).await;
+    assert!(
+        result.is_err(),
+        "a strict-kid rejection must surface as Err(AuthError), not be swallowed as Ok(None)"
+    );
+}


### PR DESCRIPTION
## Summary

Two small, independent, additive fixes to offline JWT validation in `crates/authkestra-resource/src/jwt.rs`:

### 1. Multi-value audience

`ValidationConfig.audience` was `Option<String>`, so a resource server could only ever accept a single `aud` value. `jsonwebtoken::Validation::set_audience` already accepts a slice of multiple acceptable audiences (token is valid if `aud` matches ANY of them) -- the config surface just didn't expose that. This is a real limitation for e.g. a gateway service, or a token that's valid for both a web app and a mobile client.

- `ValidationConfig.audience` is now `Vec<String>`.
- `ValidationConfigBuilder::audience(impl Into<String>)` is preserved and now pushes onto the vec, so existing single-audience callers keep compiling and behaving identically.
- New `ValidationConfigBuilder::audiences(impl IntoIterator<Item = impl Into<String>>)` accepts several audiences at once.
- `JwtStrategy::new` now calls `validation.set_audience(&config.audience)` whenever the vec is non-empty.

### 2. Opt-in strict `kid` enforcement

`Jwks::find_key` silently falls back to `self.keys.first()` when a presented token has no `kid` header. If a JWKS ever holds more than one key (e.g. during key rotation), a kid-less token can validate against the wrong key -- a classic key-confusion footgun.

- `JwksCache` gains a `require_kid: bool` field (default `false`) and a fluent `require_kid(bool)` setter.
- When `true`, `JwksCache::get_key(None)` now returns the new `ValidationError::MissingKid` instead of falling back to the first key.
- `ValidationConfig` / `ValidationConfigBuilder` gained a matching `require_kid` field/method, threaded into `JwksCache::new(...).require_kid(config.require_kid)` inside `JwtStrategy::new`.
- `JwtStrategy::authenticate`'s existing match arm (`Err(InvalidToken(_)) | Err(Jwt(_)) => Ok(None)`) does **not** match `MissingKid`, so a strict-mode rejection correctly falls through to `Err(AuthError::Token(...))` -- it surfaces as an explicit auth error rather than being silently swallowed as "no credentials". Covered by a dedicated test.

**Both changes default to today's exact behavior and are purely opt-in / additive. No existing call site needs to change.**

## Fix required elsewhere

Adding the `MissingKid` variant made `authkestra-oidc`'s `From<ValidationError> for OidcError` non-exhaustive. Added a `MissingKid => OidcError::ValidationError(...)` arm (`crates/authkestra-oidc/src/error.rs`), mirroring how `KeyNotFound` is already handled there.

## Testing

Added `crates/authkestra-resource/tests/jwt_test.rs` (new `wiremock` + `rsa` dev-dependencies), exercising the full offline-validation path against a mock JWKS endpoint with freshly generated RSA keys:

- `multi_audience_accepts_token_matching_any_configured_audience` / `multi_audience_rejects_token_not_matching_any_configured_audience` -- built with `.audiences(["a","b","c"])`, a token with `aud: "b"` validates; built with `.audiences(["a","c"])`, it's rejected.
- `single_audience_builder_call_is_backward_compatible` / `single_audience_builder_validates_like_before` -- proves `.audience("x")` still works exactly as before, both at the config level and functionally.
- `missing_kid_falls_back_to_first_key_by_default` -- JWKS with 2 keys, kid-less token still validates against the first key when `require_kid` is left at its default.
- `missing_kid_is_rejected_when_require_kid_is_enabled` -- same setup, `require_kid(true)` now rejects with `ValidationError::MissingKid`.
- `require_kid_still_allows_tokens_that_present_a_kid` -- strict mode doesn't affect tokens that do present a `kid`.
- `strategy_surfaces_strict_kid_rejection_as_an_error_not_a_silent_none` -- exercises `JwtStrategy::authenticate` end-to-end and asserts the strict-kid rejection surfaces as `Err`, not `Ok(None)`.

### Commands run

- `cargo test -p authkestra-resource` -- 8/8 new tests pass, existing (0) unit tests pass.
- `cargo build --workspace` -- clean after fixing the `authkestra-oidc` non-exhaustive match.
- `cargo build -p authkestra --examples --features full` -- all examples build, including `axum_resource_server`, `axum_resource_server_strategy`, and `actix_resource_server_strategy` (checked for direct field access on `ValidationConfig.audience`; none exists, only builder calls, so no example changes were needed beyond what already compiled).
- `cargo test --workspace --exclude authkestra --exclude authkestra-providers` -- all pass (authkestra-engine, authkestra-op, authkestra-oidc, authkestra-resource, authkestra-macros, authkestra-axum, authkestra-actix).
- `cargo clippy -p authkestra-resource -p authkestra-oidc --all-targets --all-features -- -D warnings` -- clean.
- `cargo fmt --check` -- clean.

### Pre-existing sandbox-environment failures (not caused by this change, verified against the unmodified base commit via `git stash`)

- `cargo test -p authkestra --test examples_e2e` fails with `AddrInUse` / a wiremock-redirect mismatch when run in this sandbox -- reproduces identically on the pre-change baseline (real server binds a fixed port that isn't free / isn't reachable the way the test expects here).
- `cargo test -p authkestra-providers` fails to compile its `tests/*_oauth.rs` files with plain `cargo test --workspace` because those tests need `--features github,google,discord`, which `--workspace` doesn't pass by default -- also pre-existing and unrelated to this change.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` fails on an unrelated, pre-existing unused-import warning in `crates/authkestra/examples/actix/basic_setup.rs` (`Configured`/`Missing` imports), confirmed present on the unmodified base commit as well.

## AI Usage Declaration

This PR was authored with AI assistance (Claude). The implementation, tests, and this description were AI-generated and then verified by running the build/test/lint commands listed above, including diffing behavior against the unmodified base commit to confirm the two known-failing tests/lints are pre-existing and not regressions introduced by this change.