### PR TITLE
feat(op): allow JwksResponse to hold multiple keys

### DIFF
--- a/crates/authkestra-op/src/handlers/jwks.rs
+++ b/crates/authkestra-op/src/handlers/jwks.rs
@@ -10,12 +10,21 @@ pub struct JwksResponse {
 }
 
 impl JwksResponse {
-    /// Creates a new JWKS response from an optional JWK.
-    /// If the token manager does not have a public key (e.g., symmetric only),
-    /// the keys array will be empty.
-    pub fn new(jwk: Option<Jwk>) -> Self {
+    /// Creates a new JWKS response from any iterable of JWKs.
+    ///
+    /// This accepts anything implementing `IntoIterator<Item = Jwk>`, so a
+    /// single `Option<Jwk>` (e.g. from `TokenManager::public_jwk`) still
+    /// works unchanged, while callers managing their own key history (e.g.
+    /// host apps rotating keys and wanting to keep the previous "stale" key
+    /// published alongside the new "active" one) can pass in a `Vec<Jwk>` or
+    /// any other collection of keys.
+    ///
+    /// If no keys are provided (e.g. the token manager does not have a
+    /// public key, such as symmetric-only setups), the keys array will be
+    /// empty.
+    pub fn new(keys: impl IntoIterator<Item = Jwk>) -> Self {
         Self {
-            keys: jwk.into_iter().collect(),
+            keys: keys.into_iter().collect(),
         }
     }
 }
@@ -43,5 +52,27 @@ mod tests {
         let response = JwksResponse::new(Some(jwk.clone()));
         assert_eq!(response.keys.len(), 1);
         assert_eq!(response.keys[0].kid.as_deref(), Some("123"));
+    }
+
+    #[test]
+    fn test_jwks_response_with_multiple_keys() {
+        let jwk1 = Jwk {
+            kty: "RSA".into(),
+            alg: Some("RS256".into()),
+            kid: Some("key-1".into()),
+            n: Some("n1".into()),
+            e: Some("AQAB".into()),
+        };
+        let jwk2 = Jwk {
+            kty: "RSA".into(),
+            alg: Some("RS256".into()),
+            kid: Some("key-2".into()),
+            n: Some("n2".into()),
+            e: Some("AQAB".into()),
+        };
+        let response = JwksResponse::new(vec![jwk1, jwk2]);
+        assert_eq!(response.keys.len(), 2);
+        assert_eq!(response.keys[0].kid.as_deref(), Some("key-1"));
+        assert_eq!(response.keys[1].kid.as_deref(), Some("key-2"));
     }
 }


### PR DESCRIPTION
## Summary

`JwksResponse::new` currently takes `Option<Jwk>`, which caps the `/jwks.json` response at a single key. This blocks host applications that manage their own key rotation externally: a very common pattern is to keep the previous "stale" key's public JWK published alongside the new "active" one, so tokens signed before a rotation keep verifying until they naturally expire. This is the standard JWKS rotation pattern (RFC 7517), and it's how Auth0, Google, and Keycloak all publish multiple keys during a rotation window. Today, a host app doing this has no way to get more than one key into the response this crate serves.

## Before / after

```rust
// before
pub fn new(jwk: Option<Jwk>) -> Self {
    Self { keys: jwk.into_iter().collect() }
}

// after
pub fn new(keys: impl IntoIterator<Item = Jwk>) -> Self {
    Self { keys: keys.into_iter().collect() }
}
```

## Zero breaking changes

`Option<Jwk>` implements `IntoIterator<Item = Jwk>` in `std`, so every existing call site keeps compiling and behaving identically, with no changes required:

- `JwksResponse::new(None)` and `JwksResponse::new(Some(jwk))` in the crate's own tests — **left completely untouched** in this PR, as proof of backward compatibility.
- `crates/authkestra-axum/src/op.rs` and `crates/authkestra-actix/src/op.rs`, which both call `JwksResponse::new(token_manager.public_jwk())` where `public_jwk()` returns `Option<Jwk>` — untouched, compiles as-is.

Host apps that maintain their own key history can now pass a `Vec<Jwk>` (or any other `IntoIterator<Item = Jwk>`) instead.

This PR does **not** change `TokenManager` or add multi-key storage to the engine — that's out of scope. The change is purely about not capping `JwksResponse` at one key, since the crate already expects host apps to own their own storage/state (see the `KvStore`/`ClientStore` patterns).

## Scope

Single file: `crates/authkestra-op/src/handlers/jwks.rs`. No other files were touched.

## Verification

- `cargo test -p authkestra-op` — 44 passed, 0 failed, including both original tests (`test_jwks_response_empty`, `test_jwks_response_with_key`) unmodified, plus the new `test_jwks_response_with_multiple_keys`.
- `cargo build --workspace` — clean.
- `cargo test --workspace` — one unrelated failure: `authkestra::tests::examples_e2e::test_all_oauth_examples_sequentially`. This test sequentially boots several of the crate's OAuth example binaries as real HTTP servers on a fixed port (3000) and is sensitive to port availability/timing in a sandboxed CI-less environment; it does not exercise `JwksResponse` or the OP JWKS handler at all. I confirmed the diff for this PR touches only `jwks.rs` (`git diff --stat upstream/main`), so this is an environment characteristic of the sandbox, not a regression from this change. Some workspace tests (Redis/SQL-backed integration tests noted in `CONTRIBUTING.md`) may also be skipped/unavailable without the project's `docker-compose` dependencies running in this sandbox.
- `cargo clippy --workspace -- -D warnings` (the exact command documented in `CONTRIBUTING.md`) — clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — one pre-existing, unrelated failure in `crates/authkestra/examples/actix/basic_setup.rs` (`unused imports: Configured and Missing`), confirmed present identically on a fresh, unmodified clone of `upstream/main`. Not touched or introduced by this PR.
- `cargo fmt` — no-op, already formatted.

## AI Usage Declaration

Portions of this change (implementation, tests, and this PR description) were drafted with AI assistance (Claude). All changes were reviewed line-by-line by a human before submission: the diff is a single, minimal, backward-compatible signature change plus one new test, and every command listed above under Verification was actually run against this branch (not fabricated) to confirm the behavior described.

## Risk Assessment

Low risk. The change is additive/widening at the type level (`Option<Jwk>` -> `impl IntoIterator<Item = Jwk>`), which is a strict superset of the previous API surface. No runtime behavior changes for existing callers since `Option<Jwk>::into_iter()` behaves identically before and after.
