### PR TITLE
docs(website): document custom claims

### DIFF
--- a/website/src/content/docs/advanced/op-server.md
+++ b/website/src/content/docs/advanced/op-server.md
@@ -113,6 +113,32 @@ let config = OpConfig {
 };
 ```
 
+## Custom Claims
+
+When building a full Identity Provider, you often need to attach domain-specific data to your tokens (e.g., `role`, `project_id`, or `billing_tier`). This aligns with custom claim mappers found in enterprise systems like Keycloak or Auth0.
+
+Authkestra's core `TokenManager` natively supports injecting custom claims via the `*_with_extra` suite of methods. You simply provide a `HashMap<String, serde_json::Value>` containing your extra claims when minting tokens:
+
+```rust
+use std::collections::HashMap;
+use serde_json::json;
+
+let mut extra_claims = HashMap::new();
+extra_claims.insert("org_id".to_string(), json!("org-123"));
+extra_claims.insert("role".to_string(), json!("admin"));
+
+// Issue an ID Token with standard claims AND your custom claims appended
+let id_token = token_manager.issue_id_token_with_extra(
+    identity,
+    "client-1",
+    Some("nonce123".to_string()),
+    3600,
+    extra_claims
+)?;
+```
+
+*(Note: When calling `issue_id_token_with_extra`, an explicit `nonce` argument will always take precedence over a `"nonce"` key provided in the `extra_claims` map).*
+
 ## Wiring the OP Endpoints
 
 Once your stores and config are built, you wire the server routes using `op_axum_router()` (or `op_actix_router()`).

--- a/website/src/content/docs/advanced/resource-server.md
+++ b/website/src/content/docs/advanced/resource-server.md
@@ -45,6 +45,21 @@ let validation_config = ValidationConfig::builder()
 let jwt_strategy = JwtStrategy::<UserIdentity>::new(validation_config);
 ```
 
+### Advanced JWT Validation
+
+The `ValidationConfig::builder()` supports several advanced validation rules to enforce strict security policies:
+
+- **Multi-Audience Support**: If your API serves multiple distinct clients, you can configure it to accept tokens minted for any of those audiences by chaining `.audiences(["client_a", "client_b"])`. (You can still use `.audience("single_client")` for backward compatibility).
+- **Strict Key IDs (`kid`)**: By default, if a JWT is missing the `kid` (Key ID) header, Authkestra will gracefully fall back to the first available key in the JWKS. To strictly reject malformed tokens that lack a `kid`, chain `.require_kid(true)`.
+
+```rust
+let advanced_config = ValidationConfig::builder()
+    .jwks_url("https://example.com/jwks")
+    .audiences(["admin_portal", "mobile_app"])
+    .require_kid(true) // Reject tokens without a 'kid' header
+    .build();
+```
+
 ### 2. Flexible Strategy Chaining
 
 A core feature of Authkestra is **Flexible Chaining**. What if you want to support *multiple* types of authentication on the same endpoint? For instance, accepting an OIDC JWT *or* a custom API key? 


### PR DESCRIPTION
Adds documentation for the new `_with_extra` custom claims methods on `TokenManager`. This outlines how developers can inject domain-specific claims (like `role` or `org_id`) into issued ID and Access tokens.