### PR TITLE
chore: release 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authkestra"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "actix-files",
  "actix-web",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-actix"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "actix-utils",
  "actix-web",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-axum"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "authkestra-engine",
  "authkestra-macros",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-engine"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-macros"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-oidc"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "authkestra-engine",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-op"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "argon2",
  "async-trait",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-providers"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "authkestra-engine",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-resource"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "authkestra-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,16 +22,16 @@ categories = ["authentication"]
 readme = "README.md"
 
 [workspace.dependencies]
-authkestra-engine = { version = "0.2.1", path = "crates/authkestra-engine" }
-authkestra-providers = { version = "0.2.1", path = "crates/authkestra-providers" }
-authkestra-axum = { version = "0.2.1", path = "crates/authkestra-axum" }
-authkestra-macros = { version = "0.2.1", path = "crates/authkestra-macros" }
-authkestra-oidc = { version = "0.2.1", path = "crates/authkestra-oidc" }
-authkestra-actix = { version = "0.2.1", path = "crates/authkestra-actix" }
-authkestra-resource = { version = "0.2.1", path = "crates/authkestra-resource" }
-authkestra = { version = "0.2.1", path = "crates/authkestra" }
+authkestra-engine = { version = "0.2.2", path = "crates/authkestra-engine" }
+authkestra-providers = { version = "0.2.2", path = "crates/authkestra-providers" }
+authkestra-axum = { version = "0.2.2", path = "crates/authkestra-axum" }
+authkestra-macros = { version = "0.2.2", path = "crates/authkestra-macros" }
+authkestra-oidc = { version = "0.2.2", path = "crates/authkestra-oidc" }
+authkestra-actix = { version = "0.2.2", path = "crates/authkestra-actix" }
+authkestra-resource = { version = "0.2.2", path = "crates/authkestra-resource" }
+authkestra = { version = "0.2.2", path = "crates/authkestra" }
 
-authkestra-op = { version = "0.2.1", path = "crates/authkestra-op" }
+authkestra-op = { version = "0.2.2", path = "crates/authkestra-op" }
 rand = "0.9.2"
 url = "2.5"
 sha2 = "0.10"

--- a/crates/authkestra-actix/Cargo.toml
+++ b/crates/authkestra-actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-actix"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 description = "Actix-web integration for the authkestra authentication framework"
 repository.workspace = true

--- a/crates/authkestra-axum/Cargo.toml
+++ b/crates/authkestra-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-axum"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 description = "Axum integration for the authkestra authentication framework"
 repository.workspace = true

--- a/crates/authkestra-engine/Cargo.toml
+++ b/crates/authkestra-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-engine"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 description = "Unified authentication engine for the authkestra framework"
 repository.workspace = true

--- a/crates/authkestra-macros/Cargo.toml
+++ b/crates/authkestra-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-macros"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors = ["Authkestra Contributors"]
 license.workspace = true

--- a/crates/authkestra-oidc/Cargo.toml
+++ b/crates/authkestra-oidc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-oidc"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 description = "OIDC support for the authkestra framework"
 repository.workspace = true

--- a/crates/authkestra-op/Cargo.toml
+++ b/crates/authkestra-op/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-op"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 description = "OpenID Provider (OP) support for the authkestra framework — issue tokens and run the authorization code grant, rather than only consuming an external IdP"
 repository.workspace = true

--- a/crates/authkestra-providers/Cargo.toml
+++ b/crates/authkestra-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-providers"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 description = "Consolidated OAuth providers for the authkestra framework"
 repository.workspace = true

--- a/crates/authkestra-resource/Cargo.toml
+++ b/crates/authkestra-resource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-resource"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 description = "Resource server enforcement and validation for the authkestra framework"
 repository.workspace = true

--- a/crates/authkestra/Cargo.toml
+++ b/crates/authkestra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 description = "A modular authentication framework for Rust"
 repository.workspace = true

--- a/website/src/content/docs/advanced/op-server.md
+++ b/website/src/content/docs/advanced/op-server.md
@@ -15,10 +15,10 @@ Because OP Servers are an advanced use case, the OP logic is not included in the
 
 ```toml
 [dependencies]
-authkestra-op = "0.2.1"
-authkestra-axum = { version = "0.2.1", features = ["op"] }
+authkestra-op = "0.2.2"
+authkestra-axum = { version = "0.2.2", features = ["op"] }
 # Or if using Actix:
-# authkestra-actix = { version = "0.2.1", features = ["op"] }
+# authkestra-actix = { version = "0.2.2", features = ["op"] }
 ```
 
 ## The OpStore Interface

--- a/website/src/content/docs/advanced/resource-server.md
+++ b/website/src/content/docs/advanced/resource-server.md
@@ -17,10 +17,10 @@ Like the OP Server, the Resource Server is an advanced component and is not incl
 
 ```toml
 [dependencies]
-authkestra-resource = "0.2.1"
-authkestra-axum = { version = "0.2.1", features = ["resource"] }
+authkestra-resource = "0.2.2"
+authkestra-axum = { version = "0.2.2", features = ["resource"] }
 # Or if using Actix:
-# authkestra-actix = { version = "0.2.1", features = ["resource"] }
+# authkestra-actix = { version = "0.2.2", features = ["resource"] }
 ```
 
 ## Building with Authkestra Guard

--- a/website/src/content/docs/guides/framework-integration.mdx
+++ b/website/src/content/docs/guides/framework-integration.mdx
@@ -15,7 +15,7 @@ Ensure you have enabled the correct web framework feature on the `authkestra` cr
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.1", features = ["axum", "session"] }
+authkestra = { version = "0.2.2", features = ["axum", "session"] }
 ```
 
   </TabItem>
@@ -23,7 +23,7 @@ authkestra = { version = "0.2.1", features = ["axum", "session"] }
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.1", features = ["actix", "session"] }
+authkestra = { version = "0.2.2", features = ["actix", "session"] }
 ```
 
   </TabItem>

--- a/website/src/content/docs/guides/quickstart.mdx
+++ b/website/src/content/docs/guides/quickstart.mdx
@@ -16,7 +16,7 @@ Add the `authkestra` facade crate to your `Cargo.toml`. The facade re-exports al
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.1", features = ["axum", "github"] }
+authkestra = { version = "0.2.2", features = ["axum", "github"] }
 ```
 
   </TabItem>
@@ -24,7 +24,7 @@ authkestra = { version = "0.2.1", features = ["axum", "github"] }
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.1", features = ["actix", "github"] }
+authkestra = { version = "0.2.2", features = ["actix", "github"] }
 ```
 
   </TabItem>

--- a/website/src/content/docs/providers/client-credentials.md
+++ b/website/src/content/docs/providers/client-credentials.md
@@ -11,7 +11,7 @@ The Client Credentials flow is built natively into the `authkestra-engine`. If y
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.1" }
+authkestra = { version = "0.2.2" }
 ```
 
 ## Using `ClientCredentialsFlow`

--- a/website/src/content/docs/providers/device-flow.md
+++ b/website/src/content/docs/providers/device-flow.md
@@ -13,7 +13,7 @@ The Device Flow logic is built natively into the `authkestra-engine`. Ensure you
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.1" }
+authkestra = { version = "0.2.2" }
 ```
 
 ## Using `DeviceFlow`

--- a/website/src/content/docs/providers/oauth2.md
+++ b/website/src/content/docs/providers/oauth2.md
@@ -17,7 +17,7 @@ If you are using multiple OAuth providers (e.g., GitHub and Google), you must en
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.1", features = ["github", "google"] }
+authkestra = { version = "0.2.2", features = ["github", "google"] }
 ```
 
 ## Stateless Engine Configuration

--- a/website/src/content/docs/providers/oidc.md
+++ b/website/src/content/docs/providers/oidc.md
@@ -11,7 +11,7 @@ To use the OIDC client, you must enable the `oidc` feature on the `authkestra` c
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.1", features = ["oidc"] }
+authkestra = { version = "0.2.2", features = ["oidc"] }
 ```
 
 ## Configuring the OIDC Provider

--- a/website/src/content/docs/storage/overview.md
+++ b/website/src/content/docs/storage/overview.md
@@ -27,7 +27,7 @@ Authkestra comes with a few generic implementations out of the box for convenien
 ```toml
 [dependencies]
 # Example: Using Redis and SQLite stores
-authkestra = { version = "0.2.1", features = ["redis", "sql-sqlite"] }
+authkestra = { version = "0.2.2", features = ["redis", "sql-sqlite"] }
 ```
 
 The available built-in stores and their feature flags are:


### PR DESCRIPTION
Bumps version to `0.2.2` across the workspace and updates documentation code snippets accordingly. This release includes the new multi-audience support, strict kid enforcement, and custom claims on tokens.