### PR TITLE
chore: release 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-engine"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-oidc"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "authkestra-engine",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-op"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "argon2",
  "async-trait",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-resource"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "authkestra-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,16 +22,16 @@ categories = ["authentication"]
 readme = "README.md"
 
 [workspace.dependencies]
-authkestra-engine = { version = "0.2.1", path = "crates/authkestra-engine" }
+authkestra-engine = { version = "0.2.2", path = "crates/authkestra-engine" }
 authkestra-providers = { version = "0.2.1", path = "crates/authkestra-providers" }
 authkestra-axum = { version = "0.2.1", path = "crates/authkestra-axum" }
 authkestra-macros = { version = "0.2.1", path = "crates/authkestra-macros" }
-authkestra-oidc = { version = "0.2.1", path = "crates/authkestra-oidc" }
+authkestra-oidc = { version = "0.2.2", path = "crates/authkestra-oidc" }
 authkestra-actix = { version = "0.2.1", path = "crates/authkestra-actix" }
-authkestra-resource = { version = "0.2.1", path = "crates/authkestra-resource" }
+authkestra-resource = { version = "0.2.2", path = "crates/authkestra-resource" }
 authkestra = { version = "0.2.1", path = "crates/authkestra" }
 
-authkestra-op = { version = "0.2.1", path = "crates/authkestra-op" }
+authkestra-op = { version = "0.2.2", path = "crates/authkestra-op" }
 rand = "0.9.2"
 url = "2.5"
 sha2 = "0.10"

--- a/crates/authkestra-engine/Cargo.toml
+++ b/crates/authkestra-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-engine"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 description = "Unified authentication engine for the authkestra framework"
 repository.workspace = true

--- a/crates/authkestra-oidc/Cargo.toml
+++ b/crates/authkestra-oidc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-oidc"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 description = "OIDC support for the authkestra framework"
 repository.workspace = true

--- a/crates/authkestra-op/Cargo.toml
+++ b/crates/authkestra-op/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-op"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 description = "OpenID Provider (OP) support for the authkestra framework — issue tokens and run the authorization code grant, rather than only consuming an external IdP"
 repository.workspace = true

--- a/crates/authkestra-resource/Cargo.toml
+++ b/crates/authkestra-resource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authkestra-resource"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 description = "Resource server enforcement and validation for the authkestra framework"
 repository.workspace = true

--- a/website/src/content/docs/advanced/op-server.md
+++ b/website/src/content/docs/advanced/op-server.md
@@ -15,7 +15,7 @@ Because OP Servers are an advanced use case, the OP logic is not included in the
 
 ```toml
 [dependencies]
-authkestra-op = "0.2.1"
+authkestra-op = "0.2.2"
 authkestra-axum = { version = "0.2.1", features = ["op"] }
 # Or if using Actix:
 # authkestra-actix = { version = "0.2.1", features = ["op"] }

--- a/website/src/content/docs/advanced/resource-server.md
+++ b/website/src/content/docs/advanced/resource-server.md
@@ -17,7 +17,7 @@ Like the OP Server, the Resource Server is an advanced component and is not incl
 
 ```toml
 [dependencies]
-authkestra-resource = "0.2.1"
+authkestra-resource = "0.2.2"
 authkestra-axum = { version = "0.2.1", features = ["resource"] }
 # Or if using Actix:
 # authkestra-actix = { version = "0.2.1", features = ["resource"] }


### PR DESCRIPTION
Selectively bumps version to `0.2.2` ONLY for the crates affected by recent API changes (`authkestra-engine`, `authkestra-oidc`, `authkestra-op`, and `authkestra-resource`). Also updates the workspace dependencies and documentation code snippets to match.