### PR TITLE
build: optimize crate sizes by excluding unnecessary directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authkestra"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "actix-files",
  "actix-web",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-actix"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "actix-utils",
  "actix-web",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-axum"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "authkestra-engine",
  "authkestra-macros",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-engine"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-macros"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-oidc"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "authkestra-engine",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-op"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "argon2",
  "async-trait",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-providers"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "authkestra-engine",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-resource"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "authkestra-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,20 @@ license = "MIT OR Apache-2.0"
 keywords = ["auth", "authentication", "oauth2", "oidc"]
 categories = ["authentication"]
 readme = "README.md"
+exclude = [
+    "/Cargo.lock",
+    "tests/**/*",
+    "examples/**/*",
+    ".github/**/*",
+    "docs/**/*",
+    "website/**/*",
+    "benches/**/*",
+    ".gitignore",
+    ".agents/**/*",
+    "plans/**/*",
+    "AGENTS.md",
+    "docker-compose.yml"
+]
 
 [workspace.dependencies]
 authkestra-engine = { version = "0.2.2", path = "crates/authkestra-engine" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,16 +36,16 @@ exclude = [
 ]
 
 [workspace.dependencies]
-authkestra-engine = { version = "0.2.2", path = "crates/authkestra-engine" }
-authkestra-providers = { version = "0.2.2", path = "crates/authkestra-providers" }
-authkestra-axum = { version = "0.2.2", path = "crates/authkestra-axum" }
-authkestra-macros = { version = "0.2.2", path = "crates/authkestra-macros" }
-authkestra-oidc = { version = "0.2.2", path = "crates/authkestra-oidc" }
-authkestra-actix = { version = "0.2.2", path = "crates/authkestra-actix" }
-authkestra-resource = { version = "0.2.2", path = "crates/authkestra-resource" }
-authkestra = { version = "0.2.2", path = "crates/authkestra" }
+authkestra-engine = { version = "0.2.3", path = "crates/authkestra-engine" }
+authkestra-providers = { version = "0.2.3", path = "crates/authkestra-providers" }
+authkestra-axum = { version = "0.2.3", path = "crates/authkestra-axum" }
+authkestra-macros = { version = "0.2.3", path = "crates/authkestra-macros" }
+authkestra-oidc = { version = "0.2.3", path = "crates/authkestra-oidc" }
+authkestra-actix = { version = "0.2.3", path = "crates/authkestra-actix" }
+authkestra-resource = { version = "0.2.3", path = "crates/authkestra-resource" }
+authkestra = { version = "0.2.3", path = "crates/authkestra" }
 
-authkestra-op = { version = "0.2.2", path = "crates/authkestra-op" }
+authkestra-op = { version = "0.2.3", path = "crates/authkestra-op" }
 rand = "0.9.2"
 url = "2.5"
 sha2 = "0.10"

--- a/crates/authkestra-actix/Cargo.toml
+++ b/crates/authkestra-actix/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 exclude.workspace = true
 name = "authkestra-actix"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 description = "Actix-web integration for the authkestra authentication framework"
 repository.workspace = true

--- a/crates/authkestra-actix/Cargo.toml
+++ b/crates/authkestra-actix/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude.workspace = true
 name = "authkestra-actix"
 version = "0.2.2"
 edition.workspace = true

--- a/crates/authkestra-axum/Cargo.toml
+++ b/crates/authkestra-axum/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude.workspace = true
 name = "authkestra-axum"
 version = "0.2.2"
 edition.workspace = true

--- a/crates/authkestra-axum/Cargo.toml
+++ b/crates/authkestra-axum/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 exclude.workspace = true
 name = "authkestra-axum"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 description = "Axum integration for the authkestra authentication framework"
 repository.workspace = true

--- a/crates/authkestra-engine/Cargo.toml
+++ b/crates/authkestra-engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 exclude.workspace = true
 name = "authkestra-engine"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 description = "Unified authentication engine for the authkestra framework"
 repository.workspace = true

--- a/crates/authkestra-engine/Cargo.toml
+++ b/crates/authkestra-engine/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude.workspace = true
 name = "authkestra-engine"
 version = "0.2.2"
 edition.workspace = true

--- a/crates/authkestra-macros/Cargo.toml
+++ b/crates/authkestra-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 exclude.workspace = true
 name = "authkestra-macros"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors = ["Authkestra Contributors"]
 license.workspace = true

--- a/crates/authkestra-macros/Cargo.toml
+++ b/crates/authkestra-macros/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude.workspace = true
 name = "authkestra-macros"
 version = "0.2.2"
 edition.workspace = true

--- a/crates/authkestra-oidc/Cargo.toml
+++ b/crates/authkestra-oidc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 exclude.workspace = true
 name = "authkestra-oidc"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 description = "OIDC support for the authkestra framework"
 repository.workspace = true

--- a/crates/authkestra-oidc/Cargo.toml
+++ b/crates/authkestra-oidc/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude.workspace = true
 name = "authkestra-oidc"
 version = "0.2.2"
 edition.workspace = true

--- a/crates/authkestra-op/Cargo.toml
+++ b/crates/authkestra-op/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 exclude.workspace = true
 name = "authkestra-op"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 description = "OpenID Provider (OP) support for the authkestra framework — issue tokens and run the authorization code grant, rather than only consuming an external IdP"
 repository.workspace = true

--- a/crates/authkestra-op/Cargo.toml
+++ b/crates/authkestra-op/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude.workspace = true
 name = "authkestra-op"
 version = "0.2.2"
 edition.workspace = true

--- a/crates/authkestra-op/src/sqlx_store.rs
+++ b/crates/authkestra-op/src/sqlx_store.rs
@@ -824,7 +824,6 @@ impl_opstore_sql! {
 #[cfg(all(test, feature = "sqlx-postgres"))]
 mod postgres_tests {
     use super::*;
-    use crate::client::{ClientRegistration, ClientStore};
     use crate::code::{AuthorizationCode, AuthorizationCodeStore};
     use chrono::{Duration, Utc};
     use sqlx::postgres::PgPoolOptions;
@@ -994,7 +993,6 @@ mod postgres_tests {
 #[cfg(all(test, feature = "sqlx-sqlite"))]
 mod sqlite_tests {
     use super::*;
-    use crate::client::{ClientRegistration, ClientStore};
     use crate::code::{AuthorizationCode, AuthorizationCodeStore};
     use chrono::{Duration, Utc};
     use sqlx::sqlite::SqlitePoolOptions;
@@ -1156,7 +1154,6 @@ mod sqlite_tests {
 #[cfg(all(test, feature = "sqlx-mysql"))]
 mod mysql_tests {
     use super::*;
-    use crate::client::{ClientRegistration, ClientStore};
     use crate::code::{AuthorizationCode, AuthorizationCodeStore};
     use chrono::{Duration, Utc};
     use sqlx::mysql::MySqlPoolOptions;

--- a/crates/authkestra-providers/Cargo.toml
+++ b/crates/authkestra-providers/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude.workspace = true
 name = "authkestra-providers"
 version = "0.2.2"
 edition.workspace = true

--- a/crates/authkestra-providers/Cargo.toml
+++ b/crates/authkestra-providers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 exclude.workspace = true
 name = "authkestra-providers"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 description = "Consolidated OAuth providers for the authkestra framework"
 repository.workspace = true

--- a/crates/authkestra-resource/Cargo.toml
+++ b/crates/authkestra-resource/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude.workspace = true
 name = "authkestra-resource"
 version = "0.2.2"
 edition.workspace = true

--- a/crates/authkestra-resource/Cargo.toml
+++ b/crates/authkestra-resource/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 exclude.workspace = true
 name = "authkestra-resource"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 description = "Resource server enforcement and validation for the authkestra framework"
 repository.workspace = true

--- a/crates/authkestra/Cargo.toml
+++ b/crates/authkestra/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude.workspace = true
 name = "authkestra"
 version = "0.2.2"
 edition.workspace = true

--- a/crates/authkestra/Cargo.toml
+++ b/crates/authkestra/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 exclude.workspace = true
 name = "authkestra"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 description = "A modular authentication framework for Rust"
 repository.workspace = true

--- a/crates/authkestra/tests/examples_e2e.rs
+++ b/crates/authkestra/tests/examples_e2e.rs
@@ -46,7 +46,7 @@ async fn run_oauth_example(example_bin: &str, provider: &str, login_path: &str) 
         .env(env_client_id, "test_id")
         .env(env_client_secret, "test_secret")
         .spawn()
-        .expect(&format!("Failed to start {}", example_bin));
+        .unwrap_or_else(|_| panic!("Failed to start {}", example_bin));
 
     let mut attempt = 0;
     let client = reqwest::Client::builder()
@@ -65,7 +65,7 @@ async fn run_oauth_example(example_bin: &str, provider: &str, login_path: &str) 
         attempt += 1;
     }
 
-    let resp = resp.expect(&format!("{} failed to start after 180s", example_bin));
+    let resp = resp.unwrap_or_else(|| panic!("{} failed to start after 180s", example_bin));
 
     assert!(
         resp.status().is_redirection(),
@@ -83,6 +83,7 @@ async fn run_oauth_example(example_bin: &str, provider: &str, login_path: &str) 
     );
 
     child.kill().expect("Failed to kill child process");
+    child.wait().expect("Failed to wait on child");
 
     // Give the OS a moment to release the port
     tokio::time::sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
## Description
Fixes the bloated crate sizes (previously ~46.6 KiB) by explicitly ignoring all non-library files from publish artifacts. 

- Added global  configuration in the root  (ignores tests, examples, docs, workflows, and ).
- Configured all member crates to inherit .
- Evaluated via .cargo_vcs_info.json
Cargo.lock
Cargo.toml
Cargo.toml.orig
README.md
src/aliases.rs
src/auth/discovery.rs
src/auth/error.rs
src/auth/mod.rs
src/auth/pkce.rs
src/auth/session.rs
src/auth/state.rs
src/auth/strategy.rs
src/engine.rs
src/flow/client_credentials_flow.rs
src/flow/device_flow.rs
src/flow/mod.rs
src/flow/oauth2.rs
src/lib.rs
src/protocol/mod.rs
src/store/memory.rs
src/store/mod.rs
src/store/redis.rs
src/store/sql.rs
src/tests.rs
src/token/jwk.rs
src/token/mod.rs
.cargo_vcs_info.json
Cargo.lock
Cargo.toml
Cargo.toml.orig
README.md
src/actix.rs
src/axum.rs
src/derive.rs
src/lib.rs
.cargo_vcs_info.json
Cargo.lock
Cargo.toml
Cargo.toml.orig
README.md
src/jwt.rs
src/lib.rs
.cargo_vcs_info.json
Cargo.lock
Cargo.toml
Cargo.toml.orig
README.md
src/client.rs
src/code.rs
src/config.rs
src/device.rs
src/error.rs
src/handlers/authorize.rs
src/handlers/device_authorization.rs
src/handlers/device_verify.rs
src/handlers/discovery.rs
src/handlers/jwks.rs
src/handlers/mod.rs
src/handlers/token/device_tests.rs
src/handlers/token.rs
src/handlers/userinfo.rs
src/lib.rs
src/refresh.rs
src/sqlx_store.rs
src/store.rs
.cargo_vcs_info.json
Cargo.lock
Cargo.toml
Cargo.toml.orig
README.md
src/helpers.rs
src/lib.rs
src/op.rs
.cargo_vcs_info.json
Cargo.lock
Cargo.toml
Cargo.toml.orig
README.md
src/helpers.rs
src/lib.rs
src/op.rs
.cargo_vcs_info.json
Cargo.lock
Cargo.toml
Cargo.toml.orig
README.md
src/error.rs
src/lib.rs
src/provider.rs
.cargo_vcs_info.json
Cargo.lock
Cargo.toml
Cargo.toml.orig
README.md
src/discord.rs
src/github.rs
src/google.rs
src/lib.rs
src/macros.rs
.cargo_vcs_info.json
Cargo.lock
Cargo.toml
Cargo.toml.orig
README.md
src/lib.rs
static/index.html which now correctly omits the ignored directories and resolves to a much smaller release payload.