### PR TITLE
docs: update version references to 0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
 # Use the facade with the features you need
-authkestra = { version = "0.2.0", features = ["axum", "github"] }
+authkestra = { version = "0.2.3", features = ["axum", "github"] }
 ```
 
 For advanced users, individual crates are still available and can be used independently if preferred.

--- a/crates/authkestra-axum/README.md
+++ b/crates/authkestra-axum/README.md
@@ -28,7 +28,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-authkestra-axum = { version = "0.2.0", features = ["macros"] }
+authkestra-axum = { version = "0.2.3", features = ["macros"] }
 tower-cookies = "0.10" # Required for session support
 ```
 

--- a/website/src/content/docs/advanced/op-server.md
+++ b/website/src/content/docs/advanced/op-server.md
@@ -15,10 +15,10 @@ Because OP Servers are an advanced use case, the OP logic is not included in the
 
 ```toml
 [dependencies]
-authkestra-op = "0.2.2"
-authkestra-axum = { version = "0.2.2", features = ["op"] }
+authkestra-op = "0.2.3"
+authkestra-axum = { version = "0.2.3", features = ["op"] }
 # Or if using Actix:
-# authkestra-actix = { version = "0.2.2", features = ["op"] }
+# authkestra-actix = { version = "0.2.3", features = ["op"] }
 ```
 
 ## The OpStore Interface
@@ -48,7 +48,7 @@ let op_store = CompositeOpStore::new(
 ```
 
 > [!TIP]
-> **Implementing Custom Stores:** If you build your own combined store type (e.g. `struct MyCustomStore { ... }`), you must explicitly implement the `OpStore` trait for it (`impl OpStore for MyCustomStore {}`). This is a minor breaking change from `0.2.2` where a blanket implementation was provided, which was removed to allow for overriding the `handle_custom_grant` method.
+> **Implementing Custom Stores:** If you build your own combined store type (e.g. `struct MyCustomStore { ... }`), you must explicitly implement the `OpStore` trait for it (`impl OpStore for MyCustomStore {}`). This is a minor breaking change from `0.2.3` where a blanket implementation was provided, which was removed to allow for overriding the `handle_custom_grant` method.
 
 Check the `op_server.rs` example in the repository for full database wiring code.
 

--- a/website/src/content/docs/advanced/resource-server.md
+++ b/website/src/content/docs/advanced/resource-server.md
@@ -17,10 +17,10 @@ Like the OP Server, the Resource Server is an advanced component and is not incl
 
 ```toml
 [dependencies]
-authkestra-resource = "0.2.2"
-authkestra-axum = { version = "0.2.2", features = ["resource"] }
+authkestra-resource = "0.2.3"
+authkestra-axum = { version = "0.2.3", features = ["resource"] }
 # Or if using Actix:
-# authkestra-actix = { version = "0.2.2", features = ["resource"] }
+# authkestra-actix = { version = "0.2.3", features = ["resource"] }
 ```
 
 ## Building with Authkestra Guard

--- a/website/src/content/docs/guides/framework-integration.mdx
+++ b/website/src/content/docs/guides/framework-integration.mdx
@@ -15,7 +15,7 @@ Ensure you have enabled the correct web framework feature on the `authkestra` cr
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.2", features = ["axum", "session"] }
+authkestra = { version = "0.2.3", features = ["axum", "session"] }
 ```
 
   </TabItem>
@@ -23,7 +23,7 @@ authkestra = { version = "0.2.2", features = ["axum", "session"] }
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.2", features = ["actix", "session"] }
+authkestra = { version = "0.2.3", features = ["actix", "session"] }
 ```
 
   </TabItem>

--- a/website/src/content/docs/guides/quickstart.mdx
+++ b/website/src/content/docs/guides/quickstart.mdx
@@ -16,7 +16,7 @@ Add the `authkestra` facade crate to your `Cargo.toml`. The facade re-exports al
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.2", features = ["axum", "github"] }
+authkestra = { version = "0.2.3", features = ["axum", "github"] }
 ```
 
   </TabItem>
@@ -24,7 +24,7 @@ authkestra = { version = "0.2.2", features = ["axum", "github"] }
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.2", features = ["actix", "github"] }
+authkestra = { version = "0.2.3", features = ["actix", "github"] }
 ```
 
   </TabItem>

--- a/website/src/content/docs/providers/client-credentials.md
+++ b/website/src/content/docs/providers/client-credentials.md
@@ -11,7 +11,7 @@ The Client Credentials flow is built natively into the `authkestra-engine`. If y
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.2" }
+authkestra = { version = "0.2.3" }
 ```
 
 ## Using `ClientCredentialsFlow`

--- a/website/src/content/docs/providers/device-flow.md
+++ b/website/src/content/docs/providers/device-flow.md
@@ -13,7 +13,7 @@ The Device Flow logic is built natively into the `authkestra-engine`. Ensure you
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.2" }
+authkestra = { version = "0.2.3" }
 ```
 
 ## Using `DeviceFlow`

--- a/website/src/content/docs/providers/oauth2.md
+++ b/website/src/content/docs/providers/oauth2.md
@@ -17,7 +17,7 @@ If you are using multiple OAuth providers (e.g., GitHub and Google), you must en
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.2", features = ["github", "google"] }
+authkestra = { version = "0.2.3", features = ["github", "google"] }
 ```
 
 ## Stateless Engine Configuration

--- a/website/src/content/docs/providers/oidc.md
+++ b/website/src/content/docs/providers/oidc.md
@@ -11,7 +11,7 @@ To use the OIDC client, you must enable the `oidc` feature on the `authkestra` c
 
 ```toml
 [dependencies]
-authkestra = { version = "0.2.2", features = ["oidc"] }
+authkestra = { version = "0.2.3", features = ["oidc"] }
 ```
 
 ## Configuring the OIDC Provider

--- a/website/src/content/docs/storage/overview.md
+++ b/website/src/content/docs/storage/overview.md
@@ -27,7 +27,7 @@ Authkestra comes with a few generic implementations out of the box for convenien
 ```toml
 [dependencies]
 # Example: Using Redis and SQLite stores
-authkestra = { version = "0.2.2", features = ["redis", "sql-sqlite"] }
+authkestra = { version = "0.2.3", features = ["redis", "sql-sqlite"] }
 ```
 
 The available built-in stores and their feature flags are:
@@ -46,6 +46,6 @@ Unlike the generic `SqlKvStore` which stores JSON blobs, `SqlxOpStore` provides 
 To use it, enable the respective feature flag:
 ```toml
 [dependencies]
-authkestra-op = { version = "0.2.2", features = ["sqlx-postgres"] }
+authkestra-op = { version = "0.2.3", features = ["sqlx-postgres"] }
 # or sqlx-mysql, sqlx-sqlite
 ```


### PR DESCRIPTION
Updates all READMEs and website docs to reference the newly published 0.2.3 version.