### PR TITLE
chore: add semi-automated release workflow

### DIFF
--- a/.github/scripts/bump-version.sh
+++ b/.github/scripts/bump-version.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# bump-version.sh <new-version>
+#
+# Atomically bumps the version across the entire authkestra workspace:
+#   - [package] version in every crates/*/Cargo.toml
+#   - [workspace.dependencies] pins in the root Cargo.toml
+#   - Version strings in website docs and README.md
+#
+# Usage:
+#   bash .github/scripts/bump-version.sh 0.2.4
+set -euo pipefail
+
+NEW_VERSION="${1:?Usage: bump-version.sh <new-version>  (e.g. 0.2.4)}"
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+echo "🔖 Bumping all crates to $NEW_VERSION"
+echo ""
+
+# ── 1. Every crate's [package] version ───────────────────────────────────────
+# Uses awk to only touch the first `version = "..."` inside a [package] block,
+# avoiding false positives on third-party dependency version pins.
+for toml in "$ROOT"/crates/*/Cargo.toml; do
+  crate="$(basename "$(dirname "$toml")")"
+  awk -v ver="$NEW_VERSION" '
+    /^\[package\]/ { in_pkg=1 }
+    /^\[/ && !/^\[package\]/ { in_pkg=0 }
+    in_pkg && /^version = "/ {
+      sub(/version = "[^"]*"/, "version = \"" ver "\"")
+    }
+    { print }
+  ' "$toml" > "$toml.tmp" && mv "$toml.tmp" "$toml"
+  echo "  ✔ $crate"
+done
+
+# ── 2. Root Cargo.toml [workspace.dependencies] pins ─────────────────────────
+# Matches lines of the form:
+#   authkestra-engine = { version = "0.2.3", path = "..." }
+sed -i -E \
+  's/(authkestra[a-z-]* = \{ version = ")[^"]*/\1'"$NEW_VERSION"'/' \
+  "$ROOT/Cargo.toml"
+echo "  ✔ root Cargo.toml (workspace.dependencies)"
+
+# ── 3. Website docs + README version strings in TOML code blocks ──────────────
+# Only replaces version = "0.x.y" style strings (not prose mentions of versions).
+FILES=$(grep -rl 'version = "0\.' \
+  "$ROOT/website/src/content/docs/" \
+  "$ROOT/README.md" 2>/dev/null || true)
+
+if [ -n "$FILES" ]; then
+  echo "$FILES" | xargs sed -i -E \
+    's/version = "0\.[0-9]+\.[0-9]+"/version = "'"$NEW_VERSION"'"/g'
+  echo "$FILES" | while read -r f; do
+    echo "  ✔ ${f#"$ROOT/"}"
+  done
+fi
+
+echo ""
+echo "✅ All locations bumped to $NEW_VERSION"
+echo "   Verify: grep -r 'version = \"$NEW_VERSION\"' crates/*/Cargo.toml"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,64 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version (e.g. 0.2.4)'
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    name: Bump versions and open release PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build
+        uses: swatinem/rust-cache@v2
+
+      - name: Bump versions
+        run: |
+          chmod +x .github/scripts/bump-version.sh
+          .github/scripts/bump-version.sh "${{ github.event.inputs.version }}"
+
+      - name: Sanity check (cargo check)
+        run: cargo check --workspace
+
+      - name: Commit and push release branch
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "release/v${{ github.event.inputs.version }}"
+          git add -A
+          git commit -m "chore: release v${{ github.event.inputs.version }}"
+          git push origin "release/v${{ github.event.inputs.version }}"
+
+      - name: Open PR to main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "release/v${{ github.event.inputs.version }}" \
+            --title "chore: release v${{ github.event.inputs.version }}" \
+            --body "## Release v${{ github.event.inputs.version }}
+
+          Automated version bump across all workspace crates, docs, and README.
+
+          **Checklist before merging:**
+          - [ ] All CI checks pass on this PR
+          - [ ] Diff contains only version string changes (no unintended modifications)
+          - [ ] CHANGELOG updated (if applicable)
+
+          > ⚠️ Merging this PR will automatically create the \`v${{ github.event.inputs.version }}\` tag and publish all crates to crates.io."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,11 @@
 name: Publish Rust Crates
 
 on:
+  # Fires automatically when tag-release.yml pushes a v* tag after a release/* PR merge
+  push:
+    tags:
+      - 'v*'
+
   workflow_dispatch:
     inputs:
       deploy_environment:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,51 @@
+name: Tag Release
+
+# Fires only when a PR is merged into main.
+# The job-level `if` guard restricts tagging to PRs whose source branch
+# is literally named `release/v*` — no other merge can trigger this.
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create tag and GitHub Release
+    # Double guard:
+    #   1. PR must have been merged (not just closed/declined)
+    #   2. Source branch must start with `release/v`
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from branch name
+        id: ver
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "📦 Releasing v$VERSION"
+
+      - name: Create and push tag
+        run: |
+          git tag "v${{ steps.ver.outputs.version }}"
+          git push origin "v${{ steps.ver.outputs.version }}"
+
+      - name: Create GitHub Release with auto-generated notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.ver.outputs.version }}" \
+            --title "v${{ steps.ver.outputs.version }}" \
+            --generate-notes \
+            --latest


### PR DESCRIPTION
## What

Adds a fully wired semi-automated release pipeline. No more manual Python bump scripts.

## New files

| File | Purpose |
|---|---|
| `.github/scripts/bump-version.sh` | Atomically bumps all 9 crates, workspace dep pins, 14 doc files, README |
| `.github/workflows/prepare-release.yml` | `workflow_dispatch` — bumps versions, cargo-checks, opens `release/v*` PR to `main` |
| `.github/workflows/tag-release.yml` | On `release/v*` → `main` merge: creates tag + GitHub Release with auto-generated notes |
| `.github/workflows/publish.yml` | Added `push: tags: ['v*']` trigger |

## Release flow

```
gh workflow run prepare-release.yml -f version=0.2.4
  → CI runs on the PR
  → you review & merge
  → tag v0.2.4 created automatically
  → GitHub Release created with auto-generated notes
  → crates.io publish fires
```

## Safety

`tag-release.yml` is gated on `startsWith(head.ref, 'release/v')` — only PRs from branches literally named `release/v*` merged into `main` can trigger a tag. A stray commit message or PR from any other branch cannot accidentally trigger a release.

## Verified locally

```
bash .github/scripts/bump-version.sh 0.2.4
# All 9 crates + 5 workspace dep pins + 14 doc files + README bumped correctly
git checkout -- .
cargo check --workspace  # ✅ clean
```