### PR TITLE
fix(op): pre-auth cost amplification in reissue, op-standalone build, stale doc

### DIFF
--- a/crates/authkestra-actix/Cargo.toml
+++ b/crates/authkestra-actix/Cargo.toml
@@ -60,7 +60,16 @@ session = ["authkestra-engine/session"]
 flow = ["authkestra-engine/flow", "authkestra-engine/session", "authkestra-engine/token"]
 token = ["authkestra-engine/token"]
 resource = ["dep:authkestra-resource"]
-op = ["dep:authkestra-op", "session", "token"]
+# Unlike authkestra-axum's `op` feature, this crate's own op.rs genuinely
+# uses `AuthSession` (actix_authorize_handler checks for an existing
+# browser session on /authorize to skip the login redirect) — AuthSession's
+# `FromRequest` impl here is gated on `all(flow, session)` because it reads
+# `SessionConfig` from actix app-data, and `SessionConfig` only exists
+# under `flow`. So `op` must enable `flow` itself in this crate, not just
+# `session` + `token` — omitting it left `--features op` uncompilable
+# standalone (`Option<AuthSession>` required `AuthSession: FromRequest`,
+# which didn't exist without `flow`).
+op = ["dep:authkestra-op", "flow", "session", "token"]
 macros = ["dep:authkestra-macros"]
 captcha = ["authkestra-engine/captcha"]
 devsig = ["dep:authkestra-devsig"]

--- a/crates/authkestra-axum/src/lib.rs
+++ b/crates/authkestra-axum/src/lib.rs
@@ -50,10 +50,22 @@ impl<S, T> From<Engine<S, T>> for AxumState<S, T> {
 }
 
 /// The extractor for a validated session.
-#[cfg(feature = "session")]
+///
+/// Gated on `flow`, not just `session`: this extractor pulls `SessionConfig`
+/// out of Axum state via `FromRef`, and `SessionConfig` is only exported
+/// under `flow` (see the `pub use authkestra_engine::{Engine, Missing,
+/// SessionConfig}` above). `op` enables `session` alone (no `flow`) —
+/// gating on `session` only meant `--features op` failed to compile
+/// standalone with `SessionConfig` undefined, even though `op`'s own code
+/// never uses `AuthSession`. If a `session`-without-`flow` consumer ever
+/// needs session extraction without the `Engine`/`AxumState` state shape,
+/// that's a real feature to design, not a cfg to loosen back to `session`
+/// alone — it would reintroduce this exact failure for every other
+/// `session`-without-`flow` combination.
+#[cfg(all(feature = "session", feature = "flow"))]
 pub struct AuthSession(pub Session);
 
-#[cfg(feature = "session")]
+#[cfg(all(feature = "session", feature = "flow"))]
 impl<S> FromRequestParts<S> for AuthSession
 where
     S: Send + Sync,

--- a/crates/authkestra-op/src/handlers/enrolment.rs
+++ b/crates/authkestra-op/src/handlers/enrolment.rs
@@ -167,13 +167,22 @@ pub async fn handle_reissue_start(
     challenges: &dyn EnrolmentChallengeStore,
     config: &AttestationConfig,
 ) -> Result<ChallengeResponse, OpError> {
-    let jwk = parse_public_jwk(&req.public_jwk)?;
-    let jkt = compute_cnf_jkt(&jwk)?;
-
+    // Validate the presented attestation FIRST, before doing any work on the
+    // caller-supplied public_jwk. parse_public_jwk/compute_cnf_jkt used to
+    // run before this check, which meant an unauthenticated caller could
+    // force JSON parsing and a SHA-256 computation on every hit to this
+    // endpoint just by supplying a garbage `attestation` — a real, if
+    // low-severity, pre-auth cost-amplification vector even after
+    // compute_cnf_jkt itself was hardened against panicking on malformed
+    // input. Nothing below this point needs the caller's JWK until the
+    // attestation is already known to be genuine.
     let claims = tokens.validate_token(&req.attestation, None).map_err(|e| {
         tracing::warn!(error = ?e, "presented attestation failed validation at re-issuance");
         OpError::AttestationInvalid
     })?;
+
+    let jwk = parse_public_jwk(&req.public_jwk)?;
+    let jkt = compute_cnf_jkt(&jwk)?;
 
     let bound_jkt = claims
         .extra
@@ -925,6 +934,50 @@ mod tests {
 
         let claims = tokens.validate_token(&reissued.attestation, None).unwrap();
         assert_eq!(claims.extra.get("att").unwrap()["kyc_level"], 1);
+    }
+
+    /// Pre-auth cost-amplification regression guard: `handle_reissue_start`
+    /// must validate the presented `attestation` BEFORE doing any work on
+    /// the caller-supplied `public_jwk` (parsing it, computing its
+    /// thumbprint). This was flagged in review — `parse_public_jwk` and
+    /// `compute_cnf_jkt` used to run first, letting any unauthenticated
+    /// caller force JSON parsing and a SHA-256 computation on every hit to
+    /// this endpoint just by supplying a garbage `attestation`.
+    ///
+    /// Proven here by supplying BOTH an invalid attestation AND a
+    /// malformed public_jwk (one `parse_public_jwk` would itself reject
+    /// with `OpError::BadJwk`) in the same request. If attestation
+    /// validation still ran first, the error must be `AttestationInvalid`
+    /// — never `BadJwk`, which would only surface if `parse_public_jwk`
+    /// had already run, meaning the old, vulnerable order had regressed.
+    #[tokio::test]
+    async fn reissue_validates_attestation_before_touching_the_presented_jwk() {
+        let challenges = MemoryStore::<EnrolmentChallenge>::new();
+        let tokens = test_tokens();
+        let config = test_config();
+
+        let malformed_jwk = serde_json::json!({"this": "is not a valid jwk"});
+
+        let err = handle_reissue_start(
+            ReissueStartRequest {
+                attestation: "not.a.valid.jws".to_string(),
+                public_jwk: malformed_jwk,
+                requested_cnf_jkt: None,
+            },
+            &tokens,
+            None,
+            &challenges,
+            &config,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, OpError::AttestationInvalid),
+            "expected AttestationInvalid (attestation checked first); got {err:?} — \
+             a BadJwk error here would mean parse_public_jwk ran before attestation \
+             validation, i.e. the pre-auth cost-amplification vector has regressed"
+        );
     }
 
     /// Conformance case 5/19 spirit, applied to challenge signing: `alg:

--- a/crates/authkestra-op/src/lib.rs
+++ b/crates/authkestra-op/src/lib.rs
@@ -9,8 +9,10 @@
 //! `op` feature flag) wrap these types into framework-native routes.
 //!
 //! ## Status
-//! This crate is a skeleton (RFC-003, PR `OP.0`). No handler logic has
-//! landed yet — see `docs/rfc-003-oidc-provider.md` for the full plan.
+//! Handler logic has landed (see `handlers` for the OIDC endpoint handlers
+//! — discovery, JWKS, authorize, token — and `handlers::enrolment` for the
+//! device/service attestation enrolment and re-issuance ceremony). See
+//! `docs/rfc-003-oidc-provider.md` for the RFC this crate implements.
 
 #![warn(missing_docs)]
 
@@ -58,7 +60,3 @@ pub mod sqlx_store;
 /// types).
 pub mod config;
 pub use config::OpConfig;
-
-// `handlers` lands in OP.2 onward (discovery, jwks, authorize, token,
-// userinfo). Left out of this skeleton PR deliberately — see RFC-003 §5 for
-// the planned module layout.


### PR DESCRIPTION
## Summary

Addresses all three items from your `CHANGES_REQUESTED` review on #139 (https://github.com/marcjazz/authkestra/pull/139#pullrequestreview-4820581745). Verified each was still present on `develop` (`224a7ce`) before fixing anything — the review and the merge were 30 minutes apart with no commit in between, so I checked rather than assumed.

1. **Pre-auth cost amplification in `handle_reissue_start`, still live.** `parse_public_jwk`/`compute_cnf_jkt` ran before `tokens.validate_token`. Reordered — attestation validated first, JWK only touched once it's known genuine.
2. **`--features op` still failed standalone on both adapters.** Reproduced both failures directly:
   - `authkestra-axum`: `AuthSession`'s `FromRequestParts` impl needs `SessionConfig` (only exported under `flow`) but was gated on `session` alone; `op` enables `session`+`token`, not `flow`. Fixed by scoping `AuthSession` itself to `all(session, flow)` — confirmed `op.rs` in this crate never references `AuthSession`, so nothing in `op` needed it.
   - `authkestra-actix`: same `SessionConfig`/`flow` coupling, but this crate's own `op.rs` (`actix_authorize_handler`) genuinely uses `Option<AuthSession>` to recognise an existing browser session on `/authorize` — the axum-style fix would have broken `op` here. Went the other way: `op` now also enables `flow` in this crate's `Cargo.toml`, matching the second option you offered in review. Picked per-crate based on what each crate's own `op.rs` actually needs, not applied uniformly.
3. **Stale "skeleton, no handler logic" doc, still stale.** `authkestra-op/src/lib.rs`'s `## Status` section corrected to describe what's actually there.

## Verification

```
cargo test --workspace --all-features
```
All green. `authkestra-op`: 74/74 (73 before + 1 new regression test).

```
cargo clippy --workspace --all-features -- -D warnings   # clean
cargo fmt --check                                          # clean
cargo check -p authkestra-axum --features op --no-default-features    # clean
cargo check -p authkestra-actix --features op --no-default-features   # clean
```

The new test (`reissue_validates_attestation_before_touching_the_presented_jwk`) sends both an invalid attestation *and* a malformed JWK, and asserts the error is `AttestationInvalid`, never `BadJwk` (which would only surface if `parse_public_jwk` had already run). I didn't just add it and assume it works — temporarily reverted the reordering, confirmed the test fails with exactly `BadJwk` as predicted, then restored the fix.

Not merging — your call, same as before.
