### PR TITLE
feat(op): asymmetric client authentication (private_key_jwt, RFC 7523 §2.2)

### DIFF
--- a/crates/authkestra-actix/examples/op_server.rs
+++ b/crates/authkestra-actix/examples/op_server.rs
@@ -54,6 +54,8 @@ async fn main() -> std::io::Result<()> {
                 scopes: vec!["openid".to_string(), "profile".to_string()],
                 grant_types: vec![authkestra_op::client::GrantType::AuthorizationCode],
                 allowed_audiences: vec![],
+                token_endpoint_auth_method: None,
+                jwks: None,
             },
             std::time::Duration::from_secs(31536000),
         )

--- a/crates/authkestra-actix/examples/op_server_custom_grant.rs
+++ b/crates/authkestra-actix/examples/op_server_custom_grant.rs
@@ -212,6 +212,8 @@ async fn main() -> std::io::Result<()> {
                     authkestra_op::client::GrantType::Custom("urn:example:custom".to_string()),
                 ],
                 allowed_audiences: vec![],
+                token_endpoint_auth_method: None,
+                jwks: None,
             },
             std::time::Duration::from_secs(31536000),
         )

--- a/crates/authkestra-axum/examples/op_server.rs
+++ b/crates/authkestra-axum/examples/op_server.rs
@@ -55,6 +55,8 @@ async fn main() {
                 scopes: vec!["openid".to_string(), "profile".to_string()],
                 grant_types: vec![authkestra_op::client::GrantType::AuthorizationCode],
                 allowed_audiences: vec![],
+                token_endpoint_auth_method: None,
+                jwks: None,
             },
             std::time::Duration::from_secs(31536000),
         )

--- a/crates/authkestra-axum/examples/op_server_custom_grant.rs
+++ b/crates/authkestra-axum/examples/op_server_custom_grant.rs
@@ -213,6 +213,8 @@ async fn main() {
                     authkestra_op::client::GrantType::Custom("urn:example:custom".to_string()),
                 ],
                 allowed_audiences: vec![],
+                token_endpoint_auth_method: None,
+                jwks: None,
             },
             std::time::Duration::from_secs(31536000),
         )

--- a/crates/authkestra-op/src/client.rs
+++ b/crates/authkestra-op/src/client.rs
@@ -57,6 +57,33 @@ impl<'de> Deserialize<'de> for GrantType {
     }
 }
 
+/// The single client-authentication method a client is bound to at the token
+/// endpoint (OIDC Core §9 / RFC 7591 `token_endpoint_auth_method`).
+///
+/// A registration names **one** method and the token endpoint accepts only
+/// that one. This is not pedantry: a client that may authenticate *either*
+/// with a shared secret *or* with a signed assertion is only ever as strong
+/// as the weaker of the two, so an attacker holding the leaked secret of a
+/// `private_key_jwt` client could simply present it instead and never touch
+/// the private key. Binding the registration to one method removes that
+/// downgrade entirely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TokenEndpointAuthMethod {
+    /// Shared secret presented in the HTTP `Authorization: Basic` header.
+    ClientSecretBasic,
+    /// Shared secret presented as the `client_secret` form field.
+    ClientSecretPost,
+    /// A JWT assertion signed by the client's private key and verified
+    /// against [`ClientRegistration::jwks`] (RFC 7523 §2.2). See
+    /// [`crate::client_assertion`].
+    PrivateKeyJwt,
+    /// No client authentication at all — public clients only, where PKCE
+    /// rather than a credential is what protects the exchange.
+    #[serde(rename = "none")]
+    NoAuth,
+}
+
 /// A registered OAuth2/OIDC client application.
 ///
 /// `redirect_uris` are matched **exactly** (no prefix/wildcard matching) —
@@ -82,6 +109,27 @@ pub struct ClientRegistration {
     /// during token exchange.
     #[serde(default)]
     pub allowed_audiences: Vec<String>,
+    /// The client-authentication method this client is bound to at `/token`.
+    ///
+    /// `None` means the registration predates this field. Such a client keeps
+    /// exactly the historical behaviour — a shared secret if
+    /// `client_secret_hash` is set, no authentication otherwise — and is
+    /// **never** accepted via `private_key_jwt`, which has to be opted into
+    /// explicitly. Enforcement lives in `handlers::token`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_endpoint_auth_method: Option<TokenEndpointAuthMethod>,
+    /// The client's public keys as an inline JWK Set (`{"keys": [...]}`) —
+    /// the public half of the keypair used for `private_key_jwt`. There is
+    /// deliberately no `jwks_uri` counterpart; see the module docs of
+    /// [`crate::client_assertion`] for why.
+    ///
+    /// Kept as raw JSON rather than a typed `JwkSet` for the same reason
+    /// `attestation::EnrolmentChallenge::public_jwk` is: a typed parse
+    /// silently drops members it has no field for — including a smuggled
+    /// private `d` — so the raw value is re-validated from scratch at every
+    /// use through `attestation::parse_public_jwk`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub jwks: Option<serde_json::Value>,
 }
 
 impl ClientRegistration {
@@ -171,6 +219,8 @@ mod tests {
             scopes: vec![],
             require_pkce: false,
             allowed_audiences: vec![],
+            token_endpoint_auth_method: None,
+            jwks: None,
         };
 
         assert!(client.verify_secret("super_secret"));
@@ -193,6 +243,8 @@ mod tests {
             scopes: vec![],
             require_pkce: false,
             allowed_audiences: vec![],
+            token_endpoint_auth_method: None,
+            jwks: None,
         };
 
         assert!(!client.verify_secret("wrong_secret"));
@@ -208,6 +260,8 @@ mod tests {
             scopes: vec![],
             require_pkce: false,
             allowed_audiences: vec![],
+            token_endpoint_auth_method: None,
+            jwks: None,
         };
 
         assert!(!client.verify_secret("some_secret"));
@@ -227,6 +281,8 @@ mod tests {
             scopes: vec![],
             require_pkce: false,
             allowed_audiences: vec![],
+            token_endpoint_auth_method: None,
+            jwks: None,
         };
 
         let serialized = serde_json::to_string(&client).unwrap();

--- a/crates/authkestra-op/src/client_assertion.rs
+++ b/crates/authkestra-op/src/client_assertion.rs
@@ -1,0 +1,785 @@
+//! Asymmetric client authentication — `private_key_jwt` (RFC 7523 §2.2,
+//! OIDC Core §9).
+//!
+//! A confidential client that is a *backend service* often cannot use a
+//! shared `client_secret` at all. Signing anything with a shared secret means
+//! HMAC, and a deployment that bans symmetric algorithms outright — because
+//! verifying an HMAC requires holding the same secret, which defeats the
+//! point of asking the client to prove anything — has nowhere to put one.
+//! The alternatives are worse: `client_credentials` or token exchange add a
+//! network round trip per request, which a hot path cannot absorb.
+//! `private_key_jwt` is the standard answer: the client owns an asymmetric
+//! keypair, the OP stores only the **public** half, and the client
+//! authenticates by signing a short-lived JWT assertion.
+//!
+//! **Inline `jwks`, no `jwks_uri`.** OIDC permits either. `jwks_uri` would
+//! make the OP an HTTP client — outbound fetch, cache, refresh task, and a
+//! new failure mode where client authentication depends on a third party
+//! being reachable, plus an attacker-influenced URL to fetch (SSRF). This
+//! crate today has no HTTP client dependency at all, and the simpler option
+//! is fully sufficient for the machine-to-machine case this exists to serve.
+//! An inline JWK Set can hold several keys, so rotation is still just
+//! "publish both, then drop the old one".
+//!
+//! Everything here exists to make exactly one thing impossible: accepting an
+//! assertion that the client's registered *public* key did not sign. Hence
+//! the algorithm is derived from the key rather than from the
+//! attacker-controlled header ([`assertion_algorithms`]), symmetric
+//! algorithms are refused before the key is even loaded, and a `jti` may be
+//! spent only once ([`ClientAssertionStore`]).
+
+use crate::attestation::parse_public_jwk;
+use crate::client::ClientRegistration;
+use crate::error::OpError;
+use async_trait::async_trait;
+use base64::Engine;
+use chrono::{DateTime, TimeZone, Utc};
+use jsonwebtoken::jwk::{AlgorithmParameters, EllipticCurve, Jwk};
+use jsonwebtoken::{Algorithm, DecodingKey, Validation};
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// The only `client_assertion_type` this OP accepts (RFC 7523 §2.2).
+pub const CLIENT_ASSERTION_TYPE_JWT_BEARER: &str =
+    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+
+/// Upper bound on how far in the future a client assertion's `exp` may sit.
+///
+/// RFC 7523 §3 requires `exp` to be present and unexpired but sets no ceiling,
+/// and an assertion is a bearer credential for its whole lifetime. Two things
+/// follow: a decade-long assertion is a permanent password in JWT clothing,
+/// and — because replay tracking has to remember every `jti` until it expires
+/// — it is also an unbounded write into the replay store. A constant rather
+/// than an `OpConfig` field on purpose: `OpConfig`'s fields are all public and
+/// it is constructed with struct literals throughout this workspace, so
+/// growing it is a breaking change that this feature does not need to make.
+pub const MAX_CLIENT_ASSERTION_LIFETIME_SECS: i64 = 300;
+
+/// What a caller learns from a successfully verified client assertion.
+///
+/// Only the replay-relevant parts: identity was already checked against the
+/// `client_id` during verification, so there is nothing else worth handing
+/// back.
+#[derive(Debug, Clone)]
+pub struct VerifiedClientAssertion {
+    /// The assertion's `jti`, to be spent exactly once.
+    pub jti: String,
+    /// The assertion's `exp`. Replay tracking need only remember `jti` until
+    /// this instant — after it, the assertion is refused on `exp` anyway.
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Records that a client assertion's `jti` has been spent.
+///
+/// `record_jti` **must** be atomic — a `get`-then-`set` implemented as two
+/// separate storage calls is a TOCTOU race, and the race is precisely the
+/// replay this trait exists to prevent: two concurrent presentations of the
+/// same captured assertion would both observe "not yet seen". Same
+/// requirement, and the same reasoning, as
+/// `AuthorizationCodeStore::consume_code`.
+#[async_trait]
+pub trait ClientAssertionStore: Send + Sync {
+    /// Atomically records `jti` as spent until `expires_at`.
+    ///
+    /// Returns `Ok(true)` if this is its first use (accept the assertion) and
+    /// `Ok(false)` if it was already recorded (a replay — reject).
+    async fn record_jti(&self, jti: &str, expires_at: DateTime<Utc>) -> Result<bool, OpError>;
+}
+
+/// The fail-closed default: refuses every assertion.
+///
+/// A deployment that has not wired replay tracking cannot provide the
+/// single-use guarantee RFC 7523 §3 requires, and accepting assertions
+/// without it would be strictly worse than not supporting the method —
+/// clients would believe they had proof-of-possession authentication while a
+/// captured assertion stayed replayable for its whole lifetime. So the
+/// default refuses rather than silently degrades.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoClientAssertionStore;
+
+#[async_trait]
+impl ClientAssertionStore for NoClientAssertionStore {
+    async fn record_jti(&self, _jti: &str, _expires_at: DateTime<Utc>) -> Result<bool, OpError> {
+        tracing::error!(
+            "a private_key_jwt assertion was presented but no ClientAssertionStore is wired; \
+             refusing it rather than accepting an assertion that could be replayed"
+        );
+        Err(OpError::ReplayProtectionUnavailable)
+    }
+}
+
+/// Single-process, in-memory replay tracking.
+///
+/// Atomic **within one process** — the map is behind a single `Mutex`, so the
+/// check and the insert cannot interleave. Across processes it is not shared,
+/// so a multi-node deployment gets one accepted replay per node; such a
+/// deployment must supply a store backed by something shared (Redis `SET NX`,
+/// a SQL unique index) instead. Same trade-off, and the same intended use, as
+/// `authkestra_engine::store::memory::MemoryStore`: correct for single-node
+/// and for tests, not a production cluster answer.
+#[derive(Debug, Default)]
+pub struct MemoryClientAssertionStore {
+    seen: Mutex<HashMap<String, DateTime<Utc>>>,
+}
+
+impl MemoryClientAssertionStore {
+    /// Creates an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl ClientAssertionStore for MemoryClientAssertionStore {
+    async fn record_jti(&self, jti: &str, expires_at: DateTime<Utc>) -> Result<bool, OpError> {
+        let now = Utc::now();
+        let mut seen = self.seen.lock().map_err(|_| {
+            // A poisoned mutex means a previous holder panicked mid-update, so
+            // the map's contents can no longer be trusted to be complete —
+            // and an incomplete replay set is indistinguishable from no
+            // replay protection. Refuse rather than guess.
+            tracing::error!("client assertion replay map is poisoned; refusing the assertion");
+            OpError::Storage
+        })?;
+
+        // Expired entries can never cause a rejection again (the assertion
+        // itself would fail `exp`), so drop them here rather than growing the
+        // map forever or running a sweeper task for it.
+        seen.retain(|_, exp| *exp > now);
+
+        if seen.contains_key(jti) {
+            return Ok(false);
+        }
+        seen.insert(jti.to_string(), expires_at);
+        Ok(true)
+    }
+}
+
+/// The signature algorithms a given registered public key may legitimately
+/// have produced.
+///
+/// Derived from the **key**, never from the assertion's header — the same
+/// "`alg` comes from configuration, never from the token" rule
+/// `attestation::verify_challenge_signature` follows. An attacker who could
+/// choose the algorithm could choose `HS256` and have the OP verify an HMAC
+/// keyed by the *public* key bytes, which are public: the classic JWT
+/// algorithm-confusion attack. Because the returned set never contains an
+/// `HS*` variant, that attack has nowhere to land even if the header peek
+/// below were removed.
+///
+/// A set rather than the single algorithm
+/// `attestation::expected_algorithm` returns, because an RSA key carries no
+/// hint of which RSASSA variant its owner signs with, and refusing all but
+/// `RS256` would reject conformant clients for no security gain — every
+/// member of the returned set still requires the same private key.
+fn assertion_algorithms(jwk: &Jwk) -> Result<Vec<Algorithm>, OpError> {
+    match &jwk.algorithm {
+        AlgorithmParameters::EllipticCurve(params) => match params.curve {
+            EllipticCurve::P256 => Ok(vec![Algorithm::ES256]),
+            EllipticCurve::P384 => Ok(vec![Algorithm::ES384]),
+            EllipticCurve::P521 => Err(OpError::BadJwk(
+                "P-521 has no corresponding jsonwebtoken::Algorithm".to_string(),
+            )),
+            EllipticCurve::Ed25519 => Err(OpError::BadJwk(
+                "Ed25519 must be represented as an OctetKeyPair, not an EllipticCurve key"
+                    .to_string(),
+            )),
+        },
+        AlgorithmParameters::RSA(_) => Ok(vec![
+            Algorithm::RS256,
+            Algorithm::RS384,
+            Algorithm::RS512,
+            Algorithm::PS256,
+            Algorithm::PS384,
+            Algorithm::PS512,
+        ]),
+        AlgorithmParameters::OctetKeyPair(_) => Ok(vec![Algorithm::EdDSA]),
+        AlgorithmParameters::OctetKey(_) => {
+            unreachable!("symmetric keys are rejected by parse_public_jwk before this is reached")
+        }
+    }
+}
+
+/// The protected header fields this module reads before handing a compact JWS
+/// to `jsonwebtoken`'s typed API.
+#[derive(Debug, Deserialize)]
+struct AssertionHeader {
+    alg: String,
+    #[serde(default)]
+    kid: Option<String>,
+}
+
+/// Decodes the protected header of a compact JWS without verifying anything.
+///
+/// Peeking the raw `alg` as a *string* is deliberate:
+/// `jsonwebtoken::Algorithm`'s deserializer hard-fails on `"none"` or an
+/// unrecognised value, which would collapse the specific "you offered a
+/// disallowed algorithm" case into an opaque parse failure. Same technique,
+/// same reason, as `attestation::verify_challenge_signature`.
+fn peek_header(compact_jws: &str) -> Result<AssertionHeader, OpError> {
+    let header_b64 = compact_jws
+        .split('.')
+        .next()
+        .filter(|s| !s.is_empty())
+        .ok_or(OpError::InvalidClientAssertion)?;
+
+    let header_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(header_b64)
+        .map_err(|_| OpError::InvalidClientAssertion)?;
+
+    serde_json::from_slice(&header_bytes).map_err(|_| OpError::InvalidClientAssertion)
+}
+
+/// The claims RFC 7523 §3 requires an authentication assertion to carry.
+///
+/// `aud` is deliberately absent: it may be a string or an array, and
+/// `jsonwebtoken`'s `Validation` already handles both shapes correctly.
+/// Everything listed here is non-`Option`, so a missing claim fails
+/// deserialization — presence checking and parsing in one step, rather than
+/// relying on `required_spec_claims` for claims it documents as ignored
+/// (it only honours `exp`, `nbf`, `aud`, `iss`, `sub`).
+#[derive(Debug, Deserialize)]
+struct ClientAssertionClaims {
+    iss: String,
+    sub: String,
+    jti: String,
+    exp: i64,
+}
+
+/// Reads the `sub` of a compact JWS **without verifying its signature**,
+/// purely to look up which client to verify against.
+///
+/// Safe only because of what happens next: the looked-up client's registered
+/// key must then verify the signature, and `iss`/`sub` are re-checked against
+/// that client's `client_id` (see [`verify_client_assertion`]). An attacker
+/// naming someone else's `client_id` here only selects the key their
+/// assertion will fail against. Needed because RFC 7521 §4.2 makes the
+/// `client_id` parameter optional when a `client_assertion` is present.
+pub fn peek_client_assertion_subject(compact_jws: &str) -> Option<String> {
+    let payload_b64 = compact_jws.split('.').nth(1)?;
+    let payload_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload_b64)
+        .ok()?;
+    let payload: Value = serde_json::from_slice(&payload_bytes).ok()?;
+    payload
+        .get("sub")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+/// Selects the registered key that should verify this assertion.
+///
+/// With a `kid` in the header, only the key carrying that exact `kid` is
+/// considered — no "try them all" fallback, so a client with several
+/// registered keys cannot have a signature attributed to a key it did not
+/// use. Without a `kid`, the set must hold exactly one key; anything else is
+/// ambiguous, and resolving ambiguity by trial is how a revoked-but-still-
+/// listed key ends up authenticating someone.
+fn select_key(jwks: &Value, kid: Option<&str>) -> Result<Jwk, OpError> {
+    let keys = jwks.get("keys").and_then(Value::as_array).ok_or_else(|| {
+        OpError::BadJwk("client jwks must be an object with a `keys` array".into())
+    })?;
+
+    let raw = match kid {
+        Some(kid) => keys
+            .iter()
+            .find(|k| k.get("kid").and_then(Value::as_str) == Some(kid))
+            .ok_or_else(|| {
+                tracing::warn!(kid = %kid, "client assertion names a kid that is not registered");
+                OpError::InvalidClientAssertion
+            })?,
+        None => {
+            if keys.len() != 1 {
+                tracing::warn!(
+                    key_count = keys.len(),
+                    "client assertion carries no kid and the client's jwks does not hold exactly \
+                     one key; refusing to guess which key signed it"
+                );
+                return Err(OpError::InvalidClientAssertion);
+            }
+            &keys[0]
+        }
+    };
+
+    // Re-validated from scratch at every use, never trusted because it was
+    // accepted at registration time — this is what catches a JWK Set carrying
+    // a private component or a symmetric key.
+    parse_public_jwk(raw)
+}
+
+/// Verifies a `private_key_jwt` client assertion against `client`, per RFC
+/// 7523 §3.
+///
+/// On success the caller still owes one step: spending the returned `jti`
+/// through a [`ClientAssertionStore`]. Replay tracking is left out of this
+/// function so that it stays pure — every claim and signature rule below is
+/// unit-testable without a store, and the store's own failure modes cannot be
+/// mistaken for a verification failure.
+///
+/// `expected_audiences` should hold the OP's token endpoint URL and its
+/// issuer identifier. RFC 7523 §3 names the token endpoint; OIDC Core §9 says
+/// the OP's Issuer identifier is also acceptable, and real clients emit both.
+pub fn verify_client_assertion(
+    assertion: &str,
+    client: &ClientRegistration,
+    expected_audiences: &[String],
+) -> Result<VerifiedClientAssertion, OpError> {
+    let header = peek_header(assertion)?;
+
+    // First gate, before a key is even loaded: an assertion is only ever
+    // verified against a *public* key, so a symmetric algorithm — or `none` —
+    // can never be legitimate here, whatever the client registered.
+    if header.alg.eq_ignore_ascii_case("none")
+        || matches!(header.alg.as_str(), "HS256" | "HS384" | "HS512")
+    {
+        tracing::warn!(
+            client_id = %client.client_id,
+            alg = %header.alg,
+            "client assertion offers a symmetric or `none` algorithm; refusing"
+        );
+        return Err(OpError::BadAlg(header.alg));
+    }
+
+    let jwks = client.jwks.as_ref().ok_or_else(|| {
+        tracing::warn!(
+            client_id = %client.client_id,
+            "client presented a client_assertion but has no registered jwks"
+        );
+        OpError::InvalidClientAssertion
+    })?;
+
+    let jwk = select_key(jwks, header.kid.as_deref())?;
+    let algorithms = assertion_algorithms(&jwk)?;
+    let decoding_key = DecodingKey::from_jwk(&jwk).map_err(|e| {
+        tracing::warn!(client_id = %client.client_id, error = %e, "registered jwk is unusable");
+        OpError::BadJwk(e.to_string())
+    })?;
+
+    let mut validation = Validation::new(algorithms[0]);
+    validation.algorithms = algorithms;
+    validation.validate_exp = true;
+    // `nbf` is optional in RFC 7523 §3, but an assertion that carries one and
+    // is not yet valid must not be accepted early.
+    validation.validate_nbf = true;
+    validation.set_required_spec_claims(&["exp", "aud"]);
+    validation.set_audience(expected_audiences);
+    // `leeway` stays at jsonwebtoken's 60s default: an assertion is minted
+    // seconds before it is presented, and the clocks of the client and the OP
+    // are not the same clock.
+
+    let data = jsonwebtoken::decode::<ClientAssertionClaims>(assertion, &decoding_key, &validation)
+        .map_err(|e| {
+            tracing::warn!(
+                client_id = %client.client_id,
+                error = %e,
+                "client assertion failed signature or claim validation"
+            );
+            OpError::InvalidClientAssertion
+        })?;
+
+    // RFC 7523 §3 points 1-2: the assertion must be self-issued for the
+    // client it authenticates. Checked against the registration we actually
+    // loaded, which is what makes the unverified `sub` peek used for client
+    // lookup harmless.
+    if data.claims.iss != client.client_id || data.claims.sub != client.client_id {
+        tracing::warn!(
+            client_id = %client.client_id,
+            iss = %data.claims.iss,
+            sub = %data.claims.sub,
+            "client assertion iss/sub do not both equal the client_id"
+        );
+        return Err(OpError::InvalidClientAssertion);
+    }
+
+    let expires_at = match Utc.timestamp_opt(data.claims.exp, 0).single() {
+        Some(t) => t,
+        None => {
+            tracing::warn!(client_id = %client.client_id, exp = data.claims.exp, "client assertion exp is not a representable timestamp");
+            return Err(OpError::InvalidClientAssertion);
+        }
+    };
+
+    if expires_at > Utc::now() + chrono::Duration::seconds(MAX_CLIENT_ASSERTION_LIFETIME_SECS) {
+        tracing::warn!(
+            client_id = %client.client_id,
+            "client assertion exp is further out than MAX_CLIENT_ASSERTION_LIFETIME_SECS"
+        );
+        return Err(OpError::InvalidClientAssertion);
+    }
+
+    tracing::debug!(
+        client_id = %client.client_id,
+        "client assertion signature and claims verified; jti still to be spent"
+    );
+
+    Ok(VerifiedClientAssertion {
+        jti: data.claims.jti,
+        expires_at,
+    })
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::client::{GrantType, TokenEndpointAuthMethod};
+    use jsonwebtoken::{EncodingKey, Header};
+    use p256::ecdsa::SigningKey;
+    use p256::elliptic_curve::{JwkEcKey, PublicKey};
+    use p256::pkcs8::EncodePrivateKey;
+    use rand_core::OsRng;
+
+    pub(crate) struct TestKey {
+        pub(crate) pkcs8_der: Vec<u8>,
+        pub(crate) public_jwk: Value,
+    }
+
+    pub(crate) fn generate_test_key(kid: Option<&str>) -> TestKey {
+        let signing_key = SigningKey::random(&mut OsRng);
+        let public_key: PublicKey<p256::NistP256> = signing_key.verifying_key().into();
+        let mut public_jwk = serde_json::to_value(JwkEcKey::from(&public_key)).unwrap();
+        if let Some(kid) = kid {
+            public_jwk["kid"] = Value::String(kid.to_string());
+        }
+        TestKey {
+            pkcs8_der: signing_key.to_pkcs8_der().unwrap().as_bytes().to_vec(),
+            public_jwk,
+        }
+    }
+
+    pub(crate) fn jwks_of(keys: &[&TestKey]) -> Value {
+        serde_json::json!({ "keys": keys.iter().map(|k| k.public_jwk.clone()).collect::<Vec<_>>() })
+    }
+
+    pub(crate) fn test_client(jwks: Option<Value>) -> ClientRegistration {
+        ClientRegistration {
+            client_id: "svc-1".to_string(),
+            client_secret_hash: None,
+            redirect_uris: vec![],
+            grant_types: vec![GrantType::ClientCredentials],
+            scopes: vec![],
+            require_pkce: false,
+            allowed_audiences: vec![],
+            token_endpoint_auth_method: Some(TokenEndpointAuthMethod::PrivateKeyJwt),
+            jwks,
+        }
+    }
+
+    fn audiences() -> Vec<String> {
+        vec![
+            "https://auth.example.com/token".to_string(),
+            "https://auth.example.com".to_string(),
+        ]
+    }
+
+    /// Mints an assertion, letting each test bend exactly one thing.
+    pub(crate) fn sign_assertion(
+        key: &TestKey,
+        kid: Option<&str>,
+        claims: Value,
+        alg: Algorithm,
+    ) -> String {
+        let mut header = Header::new(alg);
+        header.kid = kid.map(str::to_string);
+        jsonwebtoken::encode(&header, &claims, &EncodingKey::from_ec_der(&key.pkcs8_der)).unwrap()
+    }
+
+    pub(crate) fn good_claims() -> Value {
+        serde_json::json!({
+            "iss": "svc-1",
+            "sub": "svc-1",
+            "aud": "https://auth.example.com/token",
+            "jti": "jti-1",
+            "exp": (Utc::now() + chrono::Duration::seconds(60)).timestamp(),
+            "iat": Utc::now().timestamp(),
+        })
+    }
+
+    #[test]
+    fn accepts_a_well_formed_assertion() {
+        let key = generate_test_key(None);
+        let client = test_client(Some(jwks_of(&[&key])));
+        let assertion = sign_assertion(&key, None, good_claims(), Algorithm::ES256);
+
+        let verified = verify_client_assertion(&assertion, &client, &audiences()).unwrap();
+        assert_eq!(verified.jti, "jti-1");
+    }
+
+    #[test]
+    fn accepts_the_issuer_as_audience() {
+        let key = generate_test_key(None);
+        let client = test_client(Some(jwks_of(&[&key])));
+        let mut claims = good_claims();
+        claims["aud"] = Value::String("https://auth.example.com".to_string());
+        let assertion = sign_assertion(&key, None, claims, Algorithm::ES256);
+
+        assert!(verify_client_assertion(&assertion, &client, &audiences()).is_ok());
+    }
+
+    #[test]
+    fn rejects_an_assertion_signed_by_an_unregistered_key() {
+        let registered = generate_test_key(None);
+        let attacker = generate_test_key(None);
+        let client = test_client(Some(jwks_of(&[&registered])));
+        let assertion = sign_assertion(&attacker, None, good_claims(), Algorithm::ES256);
+
+        assert!(matches!(
+            verify_client_assertion(&assertion, &client, &audiences()),
+            Err(OpError::InvalidClientAssertion)
+        ));
+    }
+
+    /// The algorithm-confusion attack: an attacker who knows the client's
+    /// public key (it is public) HMACs the assertion with those very bytes
+    /// and offers `alg: HS256`.
+    #[test]
+    fn rejects_a_symmetric_algorithm() {
+        let key = generate_test_key(None);
+        let client = test_client(Some(jwks_of(&[&key])));
+
+        let public_key_bytes = serde_json::to_vec(&key.public_jwk).unwrap();
+        let forged = jsonwebtoken::encode(
+            &Header::new(Algorithm::HS256),
+            &good_claims(),
+            &EncodingKey::from_secret(&public_key_bytes),
+        )
+        .unwrap();
+
+        assert!(
+            matches!(
+                verify_client_assertion(&forged, &client, &audiences()),
+                Err(OpError::BadAlg(_))
+            ),
+            "an HS* assertion must never be verified against a public key"
+        );
+    }
+
+    #[test]
+    fn rejects_alg_none() {
+        let key = generate_test_key(None);
+        let client = test_client(Some(jwks_of(&[&key])));
+        // Hand-built: no encoder will emit `alg: none` for us.
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(br#"{"alg":"none","typ":"JWT"}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&good_claims()).unwrap());
+        let unsigned = format!("{header}.{payload}.");
+
+        assert!(matches!(
+            verify_client_assertion(&unsigned, &client, &audiences()),
+            Err(OpError::BadAlg(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_a_wrong_audience() {
+        let key = generate_test_key(None);
+        let client = test_client(Some(jwks_of(&[&key])));
+        let mut claims = good_claims();
+        claims["aud"] = Value::String("https://someone-else.example.com/token".to_string());
+        let assertion = sign_assertion(&key, None, claims, Algorithm::ES256);
+
+        assert!(
+            matches!(
+                verify_client_assertion(&assertion, &client, &audiences()),
+                Err(OpError::InvalidClientAssertion)
+            ),
+            "an assertion minted for another OP must not authenticate here"
+        );
+    }
+
+    #[test]
+    fn rejects_a_missing_audience() {
+        let key = generate_test_key(None);
+        let client = test_client(Some(jwks_of(&[&key])));
+        let mut claims = good_claims();
+        claims.as_object_mut().unwrap().remove("aud");
+        let assertion = sign_assertion(&key, None, claims, Algorithm::ES256);
+
+        assert!(matches!(
+            verify_client_assertion(&assertion, &client, &audiences()),
+            Err(OpError::InvalidClientAssertion)
+        ));
+    }
+
+    #[test]
+    fn rejects_an_expired_assertion() {
+        let key = generate_test_key(None);
+        let client = test_client(Some(jwks_of(&[&key])));
+        let mut claims = good_claims();
+        // Beyond jsonwebtoken's 60s default leeway.
+        claims["exp"] = Value::from((Utc::now() - chrono::Duration::seconds(600)).timestamp());
+        let assertion = sign_assertion(&key, None, claims, Algorithm::ES256);
+
+        assert!(matches!(
+            verify_client_assertion(&assertion, &client, &audiences()),
+            Err(OpError::InvalidClientAssertion)
+        ));
+    }
+
+    #[test]
+    fn rejects_a_missing_exp() {
+        let key = generate_test_key(None);
+        let client = test_client(Some(jwks_of(&[&key])));
+        let mut claims = good_claims();
+        claims.as_object_mut().unwrap().remove("exp");
+        let assertion = sign_assertion(&key, None, claims, Algorithm::ES256);
+
+        assert!(matches!(
+            verify_client_assertion(&assertion, &client, &audiences()),
+            Err(OpError::InvalidClientAssertion)
+        ));
+    }
+
+    #[test]
+    fn rejects_an_assertion_that_never_meaningfully_expires() {
+        let key = generate_test_key(None);
+        let client = test_client(Some(jwks_of(&[&key])));
+        let mut claims = good_claims();
+        claims["exp"] = Value::from((Utc::now() + chrono::Duration::days(3650)).timestamp());
+        let assertion = sign_assertion(&key, None, claims, Algorithm::ES256);
+
+        assert!(
+            matches!(
+                verify_client_assertion(&assertion, &client, &audiences()),
+                Err(OpError::InvalidClientAssertion)
+            ),
+            "a decade-long assertion is a permanent bearer credential and an unbounded \
+             write into the replay store"
+        );
+    }
+
+    #[test]
+    fn rejects_a_missing_jti() {
+        let key = generate_test_key(None);
+        let client = test_client(Some(jwks_of(&[&key])));
+        let mut claims = good_claims();
+        claims.as_object_mut().unwrap().remove("jti");
+        let assertion = sign_assertion(&key, None, claims, Algorithm::ES256);
+
+        assert!(
+            matches!(
+                verify_client_assertion(&assertion, &client, &audiences()),
+                Err(OpError::InvalidClientAssertion)
+            ),
+            "without a jti there is nothing to spend, so replay protection would be a no-op"
+        );
+    }
+
+    #[test]
+    fn rejects_an_assertion_issued_for_another_client() {
+        let key = generate_test_key(None);
+        let client = test_client(Some(jwks_of(&[&key])));
+        let mut claims = good_claims();
+        claims["sub"] = Value::String("some-other-client".to_string());
+        let assertion = sign_assertion(&key, None, claims, Algorithm::ES256);
+
+        assert!(matches!(
+            verify_client_assertion(&assertion, &client, &audiences()),
+            Err(OpError::InvalidClientAssertion)
+        ));
+    }
+
+    #[test]
+    fn rejects_iss_and_sub_disagreeing() {
+        let key = generate_test_key(None);
+        let client = test_client(Some(jwks_of(&[&key])));
+        let mut claims = good_claims();
+        claims["iss"] = Value::String("some-other-client".to_string());
+        let assertion = sign_assertion(&key, None, claims, Algorithm::ES256);
+
+        assert!(matches!(
+            verify_client_assertion(&assertion, &client, &audiences()),
+            Err(OpError::InvalidClientAssertion)
+        ));
+    }
+
+    #[test]
+    fn rejects_a_client_with_no_registered_jwks() {
+        let key = generate_test_key(None);
+        let client = test_client(None);
+        let assertion = sign_assertion(&key, None, good_claims(), Algorithm::ES256);
+
+        assert!(matches!(
+            verify_client_assertion(&assertion, &client, &audiences()),
+            Err(OpError::InvalidClientAssertion)
+        ));
+    }
+
+    #[test]
+    fn rejects_a_jwks_carrying_a_private_component() {
+        let key = generate_test_key(None);
+        let mut leaked = key.public_jwk.clone();
+        leaked["d"] = Value::String("smuggled-private-scalar".to_string());
+        let client = test_client(Some(serde_json::json!({ "keys": [leaked] })));
+        let assertion = sign_assertion(&key, None, good_claims(), Algorithm::ES256);
+
+        assert!(matches!(
+            verify_client_assertion(&assertion, &client, &audiences()),
+            Err(OpError::BadJwk(_))
+        ));
+    }
+
+    #[test]
+    fn selects_the_named_key_when_several_are_registered() {
+        let key_a = generate_test_key(Some("a"));
+        let key_b = generate_test_key(Some("b"));
+        let client = test_client(Some(jwks_of(&[&key_a, &key_b])));
+
+        let assertion = sign_assertion(&key_b, Some("b"), good_claims(), Algorithm::ES256);
+        assert!(verify_client_assertion(&assertion, &client, &audiences()).is_ok());
+
+        // Signed by A but claiming to be B: the named key must be the one
+        // used, with no fallback that tries the others.
+        let mismatched = sign_assertion(&key_a, Some("b"), good_claims(), Algorithm::ES256);
+        assert!(matches!(
+            verify_client_assertion(&mismatched, &client, &audiences()),
+            Err(OpError::InvalidClientAssertion)
+        ));
+    }
+
+    #[test]
+    fn refuses_to_guess_between_several_keys_without_a_kid() {
+        let key_a = generate_test_key(Some("a"));
+        let key_b = generate_test_key(Some("b"));
+        let client = test_client(Some(jwks_of(&[&key_a, &key_b])));
+        let assertion = sign_assertion(&key_a, None, good_claims(), Algorithm::ES256);
+
+        assert!(matches!(
+            verify_client_assertion(&assertion, &client, &audiences()),
+            Err(OpError::InvalidClientAssertion)
+        ));
+    }
+
+    #[tokio::test]
+    async fn memory_store_spends_a_jti_exactly_once() {
+        let store = MemoryClientAssertionStore::new();
+        let exp = Utc::now() + chrono::Duration::seconds(60);
+
+        assert!(store.record_jti("jti-1", exp).await.unwrap());
+        assert!(!store.record_jti("jti-1", exp).await.unwrap());
+        assert!(store.record_jti("jti-2", exp).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn no_store_refuses_rather_than_permitting_replay() {
+        let store = NoClientAssertionStore;
+        let exp = Utc::now() + chrono::Duration::seconds(60);
+        assert!(matches!(
+            store.record_jti("jti-1", exp).await,
+            Err(OpError::ReplayProtectionUnavailable)
+        ));
+    }
+
+    #[test]
+    fn peeks_the_subject_without_verifying() {
+        let key = generate_test_key(None);
+        let assertion = sign_assertion(&key, None, good_claims(), Algorithm::ES256);
+        assert_eq!(
+            peek_client_assertion_subject(&assertion).as_deref(),
+            Some("svc-1")
+        );
+        assert_eq!(peek_client_assertion_subject("not-a-jwt"), None);
+    }
+}

--- a/crates/authkestra-op/src/client_assertion.rs
+++ b/crates/authkestra-op/src/client_assertion.rs
@@ -24,7 +24,7 @@
 //! Everything here exists to make exactly one thing impossible: accepting an
 //! assertion that the client's registered *public* key did not sign. Hence
 //! the algorithm is derived from the key rather than from the
-//! attacker-controlled header ([`assertion_algorithms`]), symmetric
+//! attacker-controlled header (see `assertion_algorithms`), symmetric
 //! algorithms are refused before the key is even loaded, and a `jti` may be
 //! spent only once ([`ClientAssertionStore`]).
 

--- a/crates/authkestra-op/src/error.rs
+++ b/crates/authkestra-op/src/error.rs
@@ -29,6 +29,39 @@ pub enum OpError {
     #[error("grant_type not permitted for this client")]
     GrantTypeNotPermitted,
 
+    /// The client presented a credential of a different kind than the one it
+    /// is registered for — a `client_secret` from a `private_key_jwt` client,
+    /// or a `client_assertion` from a `client_secret_*` client. Rejected
+    /// rather than accepted-because-it-verifies: a client that can
+    /// authenticate by either means is only as strong as the weaker of the
+    /// two (see `client::TokenEndpointAuthMethod`).
+    #[error("client authentication method not permitted for this client")]
+    AuthMethodNotPermitted,
+
+    /// The presented `client_assertion` is malformed, was not signed by a key
+    /// in the client's registered JWK Set, or carries claims that do not
+    /// satisfy RFC 7523 §3.
+    ///
+    /// Deliberately one opaque variant covering all of those: the caller of a
+    /// failed client authentication learns only `invalid_client` either way,
+    /// and distinguishing "bad signature" from "wrong `aud`" here only
+    /// creates a way for that distinction to leak into a response.
+    #[error("invalid client assertion")]
+    InvalidClientAssertion,
+
+    /// The presented `client_assertion` carries a `jti` that has already been
+    /// spent (RFC 7523 §3 point 7). A captured assertion is a bearer
+    /// credential until it expires; single-use `jti` is what stops it from
+    /// being one.
+    #[error("client assertion replayed")]
+    ClientAssertionReplayed,
+
+    /// The deployment's `OpStore` provides no `jti` replay tracking, so
+    /// `private_key_jwt` cannot be honoured safely. Fails closed on purpose —
+    /// see `store::OpStore::record_client_assertion_jti`.
+    #[error("client assertion replay protection is not configured")]
+    ReplayProtectionUnavailable,
+
     /// Underlying storage error, opaque to the caller by design — storage
     /// backends should not leak implementation details (e.g. SQL errors)
     /// into OAuth error responses.

--- a/crates/authkestra-op/src/handlers/authorize.rs
+++ b/crates/authkestra-op/src/handlers/authorize.rs
@@ -254,6 +254,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -299,6 +301,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -346,6 +350,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: true,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -391,6 +397,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: true,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -436,6 +444,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: true,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -498,6 +508,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -564,6 +576,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false, // PKCE is optional
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )

--- a/crates/authkestra-op/src/handlers/device_authorization.rs
+++ b/crates/authkestra-op/src/handlers/device_authorization.rs
@@ -180,6 +180,8 @@ mod tests {
                     scopes: vec!["openid".to_string()],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -223,6 +225,8 @@ mod tests {
             actor_token: None,
             actor_token_type: None,
             audience: None,
+            client_assertion: None,
+            client_assertion_type: None,
             requested_token_type: None,
             subject_token: None,
             subject_token_type: None,

--- a/crates/authkestra-op/src/handlers/discovery.rs
+++ b/crates/authkestra-op/src/handlers/discovery.rs
@@ -65,6 +65,27 @@ impl OidcDiscovery {
             ],
         }
     }
+
+    /// Advertises `private_key_jwt` (RFC 7523 §2.2) in
+    /// `token_endpoint_auth_methods_supported`.
+    ///
+    /// Opt-in rather than part of [`OidcDiscovery::from_config`], because
+    /// whether this OP will actually honour an assertion is not something
+    /// `OpConfig` knows: the token endpoint implements the method
+    /// unconditionally, but it refuses every assertion unless the deployment's
+    /// `OpStore` also tracks spent `jti`s (see
+    /// `OpStore::record_client_assertion_jti`, which fails closed). A
+    /// discovery document promising a method the OP will reject at runtime is
+    /// worse than one that stays quiet, so the decision belongs to whoever
+    /// wired the store — call this alongside
+    /// `CompositeOpStore::with_client_assertion_store`.
+    pub fn with_private_key_jwt(mut self) -> Self {
+        let method = "private_key_jwt".to_string();
+        if !self.token_endpoint_auth_methods_supported.contains(&method) {
+            self.token_endpoint_auth_methods_supported.push(method);
+        }
+        self
+    }
 }
 
 #[cfg(test)]
@@ -111,5 +132,48 @@ mod tests {
         assert!(doc
             .id_token_signing_alg_values_supported
             .contains(&"RS256".to_string()));
+    }
+
+    fn discovery_config() -> OpConfig {
+        OpConfig {
+            issuer: "https://auth.example.com".to_string(),
+            scopes_supported: vec!["openid".to_string()],
+            response_types_supported: vec!["code".to_string()],
+            grant_types_supported: vec!["authorization_code".to_string()],
+            id_token_signing_alg: "RS256".to_string(),
+            authorization_code_ttl_secs: 60,
+            access_token_ttl_secs: 3600,
+            device_code_ttl_secs: 600,
+            token_exchange_enabled: false,
+        }
+    }
+
+    /// The document must not promise a method the deployment may not have
+    /// wired a replay store for — silence is the honest default.
+    #[test]
+    fn private_key_jwt_is_not_advertised_by_default() {
+        let doc = OidcDiscovery::from_config(&discovery_config());
+        assert!(!doc
+            .token_endpoint_auth_methods_supported
+            .contains(&"private_key_jwt".to_string()));
+    }
+
+    #[test]
+    fn private_key_jwt_is_advertised_once_when_opted_in() {
+        let doc = OidcDiscovery::from_config(&discovery_config())
+            .with_private_key_jwt()
+            .with_private_key_jwt();
+
+        assert_eq!(
+            doc.token_endpoint_auth_methods_supported
+                .iter()
+                .filter(|m| *m == "private_key_jwt")
+                .count(),
+            1
+        );
+        // The methods that were already supported are untouched.
+        assert!(doc
+            .token_endpoint_auth_methods_supported
+            .contains(&"client_secret_basic".to_string()));
     }
 }

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -1,5 +1,9 @@
-use crate::client::{ClientRegistration, GrantType};
+use crate::client::{ClientRegistration, GrantType, TokenEndpointAuthMethod};
+use crate::client_assertion::{
+    peek_client_assertion_subject, verify_client_assertion, CLIENT_ASSERTION_TYPE_JWT_BEARER,
+};
 use crate::config::OpConfig;
+use crate::error::OpError;
 use crate::refresh::RefreshToken;
 use crate::store::OpStore;
 use authkestra_engine::token::TokenManager;
@@ -43,6 +47,15 @@ pub struct TokenRequest {
     pub requested_token_type: Option<String>,
     /// The logical name of the target service where the client intends to use the requested security token.
     pub audience: Option<String>,
+
+    // Asymmetric client authentication (RFC 7523 §2.2)
+    /// The JWT the client signed with its own private key to authenticate
+    /// itself. See [`crate::client_assertion`].
+    pub client_assertion: Option<String>,
+    /// Must be
+    /// [`crate::client_assertion::CLIENT_ASSERTION_TYPE_JWT_BEARER`] when
+    /// `client_assertion` is present.
+    pub client_assertion_type: Option<String>,
 }
 
 /// Success response for the token endpoint.
@@ -89,24 +102,10 @@ pub async fn handle_token(
 ) -> Result<TokenResponse, TokenErrorResponse> {
     tracing::debug!(grant_type = %req.grant_type, "Processing token exchange request");
 
-    // 0. Extract client credentials
-    let mut req_client_id = req.client_id.clone();
-    let mut req_client_secret = req.client_secret.clone();
+    // 0. Work out which credential — if any — the request presents.
+    let credential = extract_credential(&req, auth_header)?;
 
-    if let Some(auth) = auth_header {
-        if let Some(stripped) = auth.strip_prefix("Basic ") {
-            if let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(stripped) {
-                if let Ok(creds) = String::from_utf8(decoded) {
-                    if let Some((id, secret)) = creds.split_once(':') {
-                        req_client_id = Some(id.to_string());
-                        req_client_secret = Some(secret.to_string());
-                    }
-                }
-            }
-        }
-    }
-
-    let client_id = match req_client_id {
+    let client_id = match resolve_client_id(&req, &credential) {
         Some(id) => id,
         None => {
             tracing::warn!("Missing client_id in token request");
@@ -136,16 +135,15 @@ pub async fn handle_token(
         }
     };
 
-    // Verify secret if provided (required for confidential clients)
-    if client.client_secret_hash.is_some() {
-        let provided_secret = req_client_secret.as_deref().unwrap_or("");
-        if !client.verify_secret(provided_secret) {
-            tracing::warn!(client_id = %client_id, "Invalid client secret");
-            return Err(TokenErrorResponse {
-                error: "invalid_client".to_string(),
-                error_description: "Client authentication failed".to_string(),
-            });
-        }
+    // 2. Client authentication, against the one method this client is bound
+    //    to. A credential of a different kind is a failure and never a
+    //    fallback — see `authenticate_client`.
+    if let Err(e) = authenticate_client(&client, &credential, config, op_store).await {
+        tracing::warn!(client_id = %client_id, error = %e, "Client authentication failed");
+        return Err(TokenErrorResponse {
+            error: "invalid_client".to_string(),
+            error_description: "Client authentication failed".to_string(),
+        });
     }
 
     match req.grant_type.as_str() {
@@ -186,6 +184,211 @@ pub async fn handle_token(
                     tokens,
                 )
                 .await
+        }
+    }
+}
+
+/// The one credential a token request presents, and where it came from.
+///
+/// One value rather than a handful of `Option`s, so that "presented two
+/// credentials" is a case the code has to answer explicitly instead of an
+/// undocumented precedence order — and so the transport (`Basic` header vs
+/// request body) survives long enough to be checked against what the client
+/// registered.
+#[derive(Debug)]
+enum PresentedCredential {
+    /// A shared secret in the `Authorization: Basic` header. Carries the
+    /// `client_id` too, since that header is where it came from.
+    SecretBasic { client_id: String, secret: String },
+    /// A shared secret in the `client_secret` form field.
+    SecretPost { secret: String },
+    /// A JWT assertion signed by the client's own private key (RFC 7523).
+    Assertion(String),
+    /// No credential at all: a public client, or an unauthenticated request.
+    NoCredential,
+}
+
+/// Extracts the credential the request presents, refusing more than one.
+///
+/// RFC 6749 §2.3 forbids a client from using more than one authentication
+/// method in a single request, and RFC 7521 §4.2 repeats it for assertions.
+/// Accepting several and picking a winner by precedence is exactly how a
+/// downgrade slips in — an attacker holding a leaked secret appends it to a
+/// request and the weaker credential wins — so this is a hard error.
+///
+/// Note that `client_id` is not a credential: sending it in the body
+/// alongside a `Basic` header, or alongside an assertion, is fine.
+fn extract_credential(
+    req: &TokenRequest,
+    auth_header: Option<&str>,
+) -> Result<PresentedCredential, TokenErrorResponse> {
+    let basic = auth_header
+        .and_then(|auth| auth.strip_prefix("Basic "))
+        .and_then(|stripped| {
+            base64::engine::general_purpose::STANDARD
+                .decode(stripped)
+                .ok()
+        })
+        .and_then(|decoded| String::from_utf8(decoded).ok())
+        .and_then(|creds| {
+            creds
+                .split_once(':')
+                .map(|(id, secret)| (id.to_string(), secret.to_string()))
+        });
+
+    // An empty `client_secret=` form field is not a presented credential; some
+    // HTTP clients emit one for an absent value.
+    let post = req.client_secret.clone().filter(|s| !s.is_empty());
+
+    let assertion = match req.client_assertion.as_ref() {
+        Some(assertion) => match req.client_assertion_type.as_deref() {
+            Some(CLIENT_ASSERTION_TYPE_JWT_BEARER) => Some(assertion.clone()),
+            _ => {
+                tracing::warn!(
+                    "client_assertion presented with a missing or unsupported \
+                     client_assertion_type"
+                );
+                return Err(TokenErrorResponse {
+                    error: "invalid_request".to_string(),
+                    error_description: format!(
+                        "client_assertion_type must be {CLIENT_ASSERTION_TYPE_JWT_BEARER}"
+                    ),
+                });
+            }
+        },
+        None => None,
+    };
+
+    let presented =
+        u8::from(basic.is_some()) + u8::from(post.is_some()) + u8::from(assertion.is_some());
+    if presented > 1 {
+        tracing::warn!(
+            presented,
+            "token request presents more than one client authentication method"
+        );
+        return Err(TokenErrorResponse {
+            error: "invalid_request".to_string(),
+            error_description: "Only one client authentication method may be used per request"
+                .to_string(),
+        });
+    }
+
+    Ok(match (basic, post, assertion) {
+        (Some((client_id, secret)), _, _) => PresentedCredential::SecretBasic { client_id, secret },
+        (_, Some(secret), _) => PresentedCredential::SecretPost { secret },
+        (_, _, Some(assertion)) => PresentedCredential::Assertion(assertion),
+        (None, None, None) => PresentedCredential::NoCredential,
+    })
+}
+
+/// Works out which client the request claims to be.
+///
+/// With an assertion and no `client_id` parameter — which RFC 7521 §4.2 makes
+/// optional — the `sub` is read out of the *unverified* assertion. That is
+/// safe because it only chooses which registration to verify against: the
+/// assertion must then be signed by that client's registered key, and its
+/// `iss`/`sub` re-checked against that client's `client_id`. Naming someone
+/// else's `client_id` here just picks the key the forgery will fail against.
+fn resolve_client_id(req: &TokenRequest, credential: &PresentedCredential) -> Option<String> {
+    match credential {
+        PresentedCredential::SecretBasic { client_id, .. } => Some(client_id.clone()),
+        PresentedCredential::Assertion(assertion) => req
+            .client_id
+            .clone()
+            .or_else(|| peek_client_assertion_subject(assertion)),
+        _ => req.client_id.clone(),
+    }
+}
+
+/// Authenticates the client against the single method its registration names.
+///
+/// The shape of this match is the security property: a registration binds one
+/// method, and a credential of any other kind is rejected outright rather than
+/// verified on its own merits. Without that, a `private_key_jwt` client whose
+/// (unused, perhaps long-forgotten) secret leaked could be impersonated with
+/// that secret, and a `client_secret_*` client with a stale registered key
+/// could be impersonated with an assertion — a downgrade in both directions.
+///
+/// `token_endpoint_auth_method: None` is the pre-existing behaviour for
+/// registrations that predate the field, preserved exactly: a stored secret
+/// hash means a secret is required (from either transport, since those
+/// registrations never said which), and no stored hash means no client
+/// authentication. Such a registration is never accepted via
+/// `private_key_jwt` — asymmetric authentication has to be opted into.
+async fn authenticate_client(
+    client: &ClientRegistration,
+    credential: &PresentedCredential,
+    config: &OpConfig,
+    op_store: &dyn OpStore,
+) -> Result<(), OpError> {
+    use PresentedCredential as Cred;
+    use TokenEndpointAuthMethod as Method;
+
+    match (client.token_endpoint_auth_method, credential) {
+        (Some(Method::PrivateKeyJwt), Cred::Assertion(assertion)) => {
+            // RFC 7523 §3 accepts the token endpoint URL as `aud`; OIDC Core
+            // §9 also allows the issuer identifier, and real clients emit
+            // both.
+            let verified = verify_client_assertion(
+                assertion,
+                client,
+                &[config.token_endpoint(), config.issuer.clone()],
+            )?;
+
+            // Spending the `jti` is what turns a captured assertion from a
+            // bearer credential valid for its whole lifetime into a
+            // single-use one.
+            if !op_store
+                .record_client_assertion_jti(&verified.jti, verified.expires_at)
+                .await?
+            {
+                tracing::warn!(
+                    client_id = %client.client_id,
+                    "client assertion jti has already been spent — replay refused"
+                );
+                return Err(OpError::ClientAssertionReplayed);
+            }
+
+            tracing::info!(
+                client_id = %client.client_id,
+                "client authenticated via private_key_jwt"
+            );
+            Ok(())
+        }
+        (Some(Method::ClientSecretBasic), Cred::SecretBasic { secret, .. })
+        | (Some(Method::ClientSecretPost), Cred::SecretPost { secret }) => {
+            if client.verify_secret(secret) {
+                Ok(())
+            } else {
+                Err(OpError::InvalidClientCredentials)
+            }
+        }
+        (Some(Method::NoAuth), Cred::NoCredential) => Ok(()),
+
+        // Registered for one method, presenting another — including the right
+        // secret over the wrong transport, which OIDC Core §9 treats as two
+        // distinct methods.
+        (Some(_), _) => Err(OpError::AuthMethodNotPermitted),
+
+        // --- Registrations predating `token_endpoint_auth_method` ---
+        (None, Cred::Assertion(_)) => Err(OpError::AuthMethodNotPermitted),
+        (None, Cred::SecretBasic { secret, .. }) | (None, Cred::SecretPost { secret }) => {
+            if client.client_secret_hash.is_none() {
+                // Public client: a secret it never registered is ignored, as
+                // it always has been.
+                Ok(())
+            } else if client.verify_secret(secret) {
+                Ok(())
+            } else {
+                Err(OpError::InvalidClientCredentials)
+            }
+        }
+        (None, Cred::NoCredential) => {
+            if client.client_secret_hash.is_some() {
+                Err(OpError::InvalidClientCredentials)
+            } else {
+                Ok(())
+            }
         }
     }
 }
@@ -978,6 +1181,8 @@ mod tests {
             actor_token_type: None,
             requested_token_type: None,
             audience: None,
+            client_assertion: None,
+            client_assertion_type: None,
         };
         let clients = authkestra_engine::store::memory::MemoryStore::<
             crate::client::ClientRegistration,
@@ -993,6 +1198,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1036,6 +1243,8 @@ mod tests {
                     scopes: vec!["openid".to_string()],
                     require_pkce: true,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1080,6 +1289,8 @@ mod tests {
             actor_token_type: None,
             requested_token_type: None,
             audience: None,
+            client_assertion: None,
+            client_assertion_type: None,
         };
 
         let res = handle_token(
@@ -1115,6 +1326,8 @@ mod tests {
                     scopes: vec!["openid".to_string()],
                     require_pkce: true,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1154,6 +1367,8 @@ mod tests {
             actor_token_type: None,
             requested_token_type: None,
             audience: None,
+            client_assertion: None,
+            client_assertion_type: None,
         };
         let res = handle_token(
             req,
@@ -1188,6 +1403,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1227,6 +1444,8 @@ mod tests {
             actor_token_type: None,
             requested_token_type: None,
             audience: None,
+            client_assertion: None,
+            client_assertion_type: None,
         };
         let res = handle_token(
             req,
@@ -1261,6 +1480,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: true,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1300,6 +1521,8 @@ mod tests {
             actor_token_type: None,
             requested_token_type: None,
             audience: None,
+            client_assertion: None,
+            client_assertion_type: None,
         };
         let res = handle_token(
             req,
@@ -1334,6 +1557,8 @@ mod tests {
                     scopes: vec!["custom".to_string()],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1355,6 +1580,8 @@ mod tests {
             actor_token_type: None,
             requested_token_type: None,
             audience: None,
+            client_assertion: None,
+            client_assertion_type: None,
         };
         let res = handle_token(
             req,
@@ -1389,6 +1616,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1423,6 +1652,8 @@ mod tests {
             actor_token_type: None,
             requested_token_type: None,
             audience: None,
+            client_assertion: None,
+            client_assertion_type: None,
         };
         let res = handle_token(
             req,
@@ -1461,6 +1692,8 @@ mod tests {
             actor_token_type: None,
             requested_token_type: Some("urn:ietf:params:oauth:token-type:access_token".to_string()),
             audience: None,
+            client_assertion: None,
+            client_assertion_type: None,
         }
     }
 
@@ -1485,6 +1718,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1530,6 +1765,8 @@ mod tests {
                     scopes: vec!["scopeA".to_string(), "scopeC".to_string()],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1576,6 +1813,8 @@ mod tests {
                     scopes: vec!["scopeB".to_string()],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1619,6 +1858,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1663,6 +1904,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1707,6 +1950,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1751,6 +1996,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1795,6 +2042,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec!["serviceA".to_string()],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1843,6 +2092,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec!["serviceA".to_string()],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1887,6 +2138,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1940,6 +2193,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -1981,6 +2236,8 @@ mod tests {
             actor_token_type: None,
             requested_token_type: None,
             audience: None,
+            client_assertion: None,
+            client_assertion_type: None,
         };
 
         let clients = authkestra_engine::store::memory::MemoryStore::<
@@ -1997,6 +2254,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -2040,6 +2299,8 @@ mod tests {
             actor_token_type: None,
             requested_token_type: None,
             audience: None,
+            client_assertion: None,
+            client_assertion_type: None,
         };
 
         let clients = authkestra_engine::store::memory::MemoryStore::<
@@ -2057,6 +2318,8 @@ mod tests {
                     scopes: vec![],
                     require_pkce: false,
                     allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
                 },
                 std::time::Duration::from_secs(31536000),
             )
@@ -2084,3 +2347,6 @@ mod tests {
 
 #[cfg(test)]
 mod device_tests;
+
+#[cfg(test)]
+mod client_auth_tests;

--- a/crates/authkestra-op/src/handlers/token/client_auth_tests.rs
+++ b/crates/authkestra-op/src/handlers/token/client_auth_tests.rs
@@ -1,0 +1,490 @@
+//! End-to-end client-authentication tests for `/token`.
+//!
+//! `client_assertion.rs` covers assertion verification in isolation; what is
+//! tested here is the part that only exists at the endpoint: that a
+//! registration is bound to exactly one authentication method, and that a
+//! `jti` is spent once across the whole request path.
+
+use super::*;
+use crate::client::{ClientRegistration, GrantType, TokenEndpointAuthMethod};
+use crate::client_assertion::tests::{generate_test_key, good_claims, jwks_of, sign_assertion};
+use crate::client_assertion::MemoryClientAssertionStore;
+use crate::handlers::token::tests::{test_config, test_tokens};
+use crate::store::CompositeOpStore;
+use authkestra_engine::store::memory::MemoryStore;
+use authkestra_engine::store::KvStore;
+use jsonwebtoken::Algorithm;
+use serde_json::Value;
+
+const CLIENT_ID: &str = "svc-1";
+const SECRET: &str = "correct-horse-battery-staple";
+
+fn hash_secret(secret: &str) -> String {
+    use argon2::password_hash::{rand_core::OsRng, PasswordHasher, SaltString};
+    let salt = SaltString::generate(&mut OsRng);
+    argon2::Argon2::default()
+        .hash_password(secret.as_bytes(), &salt)
+        .unwrap()
+        .to_string()
+}
+
+fn registration(
+    method: Option<TokenEndpointAuthMethod>,
+    secret_hash: Option<String>,
+    jwks: Option<Value>,
+) -> ClientRegistration {
+    ClientRegistration {
+        client_id: CLIENT_ID.to_string(),
+        client_secret_hash: secret_hash,
+        redirect_uris: vec![],
+        grant_types: vec![GrantType::ClientCredentials],
+        scopes: vec!["api".to_string()],
+        require_pkce: false,
+        allowed_audiences: vec![],
+        token_endpoint_auth_method: method,
+        jwks,
+    }
+}
+
+/// A `client_credentials` request with no credential attached — each test
+/// then adds exactly the one it means to exercise.
+fn bare_request() -> TokenRequest {
+    TokenRequest {
+        grant_type: "client_credentials".to_string(),
+        code: None,
+        device_code: None,
+        redirect_uri: None,
+        client_id: Some(CLIENT_ID.to_string()),
+        client_secret: None,
+        code_verifier: None,
+        scope: None,
+        refresh_token: None,
+        subject_token: None,
+        subject_token_type: None,
+        actor_token: None,
+        actor_token_type: None,
+        requested_token_type: None,
+        audience: None,
+        client_assertion: None,
+        client_assertion_type: None,
+    }
+}
+
+fn with_assertion(mut req: TokenRequest, assertion: &str) -> TokenRequest {
+    req.client_assertion = Some(assertion.to_string());
+    req.client_assertion_type = Some(CLIENT_ASSERTION_TYPE_JWT_BEARER.to_string());
+    req
+}
+
+fn basic_header(client_id: &str, secret: &str) -> String {
+    format!(
+        "Basic {}",
+        base64::engine::general_purpose::STANDARD.encode(format!("{client_id}:{secret}"))
+    )
+}
+
+/// Builds a store holding `client`, with working replay tracking.
+async fn store_with(
+    client: ClientRegistration,
+) -> CompositeOpStore<
+    MemoryStore<ClientRegistration>,
+    MemoryStore<crate::code::AuthorizationCode>,
+    MemoryStore<crate::refresh::RefreshToken>,
+    MemoryStore<crate::device::DeviceCodeSession>,
+    MemoryClientAssertionStore,
+> {
+    let clients = MemoryStore::<ClientRegistration>::new();
+    clients
+        .set(CLIENT_ID, client, std::time::Duration::from_secs(3600))
+        .await
+        .unwrap();
+
+    CompositeOpStore::new(
+        clients,
+        MemoryStore::<crate::code::AuthorizationCode>::new(),
+        MemoryStore::<crate::refresh::RefreshToken>::new(),
+        MemoryStore::<crate::device::DeviceCodeSession>::new(),
+    )
+    .with_client_assertion_store(MemoryClientAssertionStore::new())
+}
+
+/// The same store, but left with the fail-closed default replay slot.
+async fn store_without_replay_protection(
+    client: ClientRegistration,
+) -> CompositeOpStore<
+    MemoryStore<ClientRegistration>,
+    MemoryStore<crate::code::AuthorizationCode>,
+    MemoryStore<crate::refresh::RefreshToken>,
+    MemoryStore<crate::device::DeviceCodeSession>,
+> {
+    let clients = MemoryStore::<ClientRegistration>::new();
+    clients
+        .set(CLIENT_ID, client, std::time::Duration::from_secs(3600))
+        .await
+        .unwrap();
+
+    CompositeOpStore::new(
+        clients,
+        MemoryStore::<crate::code::AuthorizationCode>::new(),
+        MemoryStore::<crate::refresh::RefreshToken>::new(),
+        MemoryStore::<crate::device::DeviceCodeSession>::new(),
+    )
+}
+
+#[tokio::test]
+async fn private_key_jwt_client_gets_a_token() {
+    let key = generate_test_key(None);
+    let store = store_with(registration(
+        Some(TokenEndpointAuthMethod::PrivateKeyJwt),
+        None,
+        Some(jwks_of(&[&key])),
+    ))
+    .await;
+
+    let assertion = sign_assertion(&key, None, good_claims(), Algorithm::ES256);
+    let res = handle_token(
+        with_assertion(bare_request(), &assertion),
+        None,
+        &test_config(false),
+        &store,
+        &test_tokens(),
+    )
+    .await;
+
+    assert!(res.is_ok(), "expected a token, got {:?}", res.err());
+}
+
+/// The headline property, in the direction that matters most: a client
+/// registered for `private_key_jwt` that *also* has a secret hash on file
+/// must not be authenticable with that secret. Otherwise the leaked secret of
+/// a client that has long since moved to keys is still a way in.
+#[tokio::test]
+async fn private_key_jwt_client_is_refused_a_valid_client_secret() {
+    let key = generate_test_key(None);
+    let store = store_with(registration(
+        Some(TokenEndpointAuthMethod::PrivateKeyJwt),
+        Some(hash_secret(SECRET)),
+        Some(jwks_of(&[&key])),
+    ))
+    .await;
+
+    let mut req = bare_request();
+    req.client_secret = Some(SECRET.to_string());
+
+    let err = handle_token(req, None, &test_config(false), &store, &test_tokens())
+        .await
+        .expect_err("a private_key_jwt client must not be authenticable with its secret");
+    assert_eq!(err.error, "invalid_client");
+
+    // ...and the same secret over the Basic transport is no better.
+    let err = handle_token(
+        bare_request(),
+        Some(&basic_header(CLIENT_ID, SECRET)),
+        &test_config(false),
+        &store,
+        &test_tokens(),
+    )
+    .await
+    .expect_err("Basic transport must not be a way around the binding either");
+    assert_eq!(err.error, "invalid_client");
+}
+
+/// The same property in the other direction: a secret-authenticated client
+/// that happens to have a key registered must not be authenticable by signing
+/// with it.
+#[tokio::test]
+async fn client_secret_client_is_refused_a_valid_assertion() {
+    let key = generate_test_key(None);
+    let store = store_with(registration(
+        Some(TokenEndpointAuthMethod::ClientSecretBasic),
+        Some(hash_secret(SECRET)),
+        Some(jwks_of(&[&key])),
+    ))
+    .await;
+
+    let assertion = sign_assertion(&key, None, good_claims(), Algorithm::ES256);
+    let err = handle_token(
+        with_assertion(bare_request(), &assertion),
+        None,
+        &test_config(false),
+        &store,
+        &test_tokens(),
+    )
+    .await
+    .expect_err("a client_secret_basic client must not be authenticable by assertion");
+    assert_eq!(err.error, "invalid_client");
+
+    // The credential it *is* registered for still works, so the rejection
+    // above is about the method and not a broken registration.
+    assert!(handle_token(
+        bare_request(),
+        Some(&basic_header(CLIENT_ID, SECRET)),
+        &test_config(false),
+        &store,
+        &test_tokens(),
+    )
+    .await
+    .is_ok());
+}
+
+/// Registrations written before `token_endpoint_auth_method` existed must not
+/// silently gain asymmetric authentication just because someone later filled
+/// in a `jwks`.
+#[tokio::test]
+async fn a_registration_without_an_auth_method_is_never_accepted_by_assertion() {
+    let key = generate_test_key(None);
+    let store = store_with(registration(None, None, Some(jwks_of(&[&key])))).await;
+
+    let assertion = sign_assertion(&key, None, good_claims(), Algorithm::ES256);
+    let err = handle_token(
+        with_assertion(bare_request(), &assertion),
+        None,
+        &test_config(false),
+        &store,
+        &test_tokens(),
+    )
+    .await
+    .expect_err("private_key_jwt must be opted into, never inferred");
+    assert_eq!(err.error, "invalid_client");
+}
+
+/// Registered for `client_secret_basic`, presenting the right secret over the
+/// `client_secret_post` transport. OIDC Core §9 makes those two distinct
+/// methods, and the registration named one of them.
+#[tokio::test]
+async fn the_secret_transport_is_bound_too() {
+    let store = store_with(registration(
+        Some(TokenEndpointAuthMethod::ClientSecretBasic),
+        Some(hash_secret(SECRET)),
+        None,
+    ))
+    .await;
+
+    let mut req = bare_request();
+    req.client_secret = Some(SECRET.to_string());
+
+    let err = handle_token(req, None, &test_config(false), &store, &test_tokens())
+        .await
+        .expect_err("client_secret_post is not client_secret_basic");
+    assert_eq!(err.error, "invalid_client");
+}
+
+#[tokio::test]
+async fn a_replayed_assertion_is_refused() {
+    let key = generate_test_key(None);
+    let store = store_with(registration(
+        Some(TokenEndpointAuthMethod::PrivateKeyJwt),
+        None,
+        Some(jwks_of(&[&key])),
+    ))
+    .await;
+
+    let assertion = sign_assertion(&key, None, good_claims(), Algorithm::ES256);
+
+    assert!(handle_token(
+        with_assertion(bare_request(), &assertion),
+        None,
+        &test_config(false),
+        &store,
+        &test_tokens(),
+    )
+    .await
+    .is_ok());
+
+    let err = handle_token(
+        with_assertion(bare_request(), &assertion),
+        None,
+        &test_config(false),
+        &store,
+        &test_tokens(),
+    )
+    .await
+    .expect_err("the second presentation of the same assertion is a replay");
+    assert_eq!(err.error, "invalid_client");
+
+    // A fresh assertion from the same client still works, so the rejection is
+    // about the spent `jti` and not about the client being locked out.
+    let mut claims = good_claims();
+    claims["jti"] = Value::String("jti-2".to_string());
+    let fresh = sign_assertion(&key, None, claims, Algorithm::ES256);
+    assert!(handle_token(
+        with_assertion(bare_request(), &fresh),
+        None,
+        &test_config(false),
+        &store,
+        &test_tokens(),
+    )
+    .await
+    .is_ok());
+}
+
+/// Without replay tracking the method cannot be honoured safely, so it is
+/// refused outright rather than served with a silently missing guarantee.
+#[tokio::test]
+async fn assertions_are_refused_when_no_replay_store_is_wired() {
+    let key = generate_test_key(None);
+    let store = store_without_replay_protection(registration(
+        Some(TokenEndpointAuthMethod::PrivateKeyJwt),
+        None,
+        Some(jwks_of(&[&key])),
+    ))
+    .await;
+
+    let assertion = sign_assertion(&key, None, good_claims(), Algorithm::ES256);
+    let err = handle_token(
+        with_assertion(bare_request(), &assertion),
+        None,
+        &test_config(false),
+        &store,
+        &test_tokens(),
+    )
+    .await
+    .expect_err("fail closed, do not accept a replayable assertion");
+    assert_eq!(err.error, "invalid_client");
+}
+
+/// RFC 6749 §2.3: one authentication method per request. A request carrying
+/// both must not be resolved by precedence, because precedence is what an
+/// attacker with the weaker credential would exploit.
+#[tokio::test]
+async fn two_credentials_in_one_request_are_refused() {
+    let key = generate_test_key(None);
+    let store = store_with(registration(
+        Some(TokenEndpointAuthMethod::PrivateKeyJwt),
+        Some(hash_secret(SECRET)),
+        Some(jwks_of(&[&key])),
+    ))
+    .await;
+
+    let assertion = sign_assertion(&key, None, good_claims(), Algorithm::ES256);
+    let mut req = with_assertion(bare_request(), &assertion);
+    req.client_secret = Some(SECRET.to_string());
+
+    let err = handle_token(req, None, &test_config(false), &store, &test_tokens())
+        .await
+        .expect_err("two credentials in one request is a malformed request");
+    assert_eq!(err.error, "invalid_request");
+}
+
+#[tokio::test]
+async fn an_unsupported_client_assertion_type_is_refused() {
+    let key = generate_test_key(None);
+    let store = store_with(registration(
+        Some(TokenEndpointAuthMethod::PrivateKeyJwt),
+        None,
+        Some(jwks_of(&[&key])),
+    ))
+    .await;
+
+    let assertion = sign_assertion(&key, None, good_claims(), Algorithm::ES256);
+    let mut req = bare_request();
+    req.client_assertion = Some(assertion);
+    req.client_assertion_type = Some("urn:example:not-a-real-assertion-type".to_string());
+
+    let err = handle_token(req, None, &test_config(false), &store, &test_tokens())
+        .await
+        .expect_err("only the RFC 7523 jwt-bearer assertion type is accepted");
+    assert_eq!(err.error, "invalid_request");
+}
+
+/// RFC 7521 §4.2 makes `client_id` optional alongside an assertion; the OP
+/// resolves it from the assertion's own `sub`.
+#[tokio::test]
+async fn client_id_may_be_omitted_alongside_an_assertion() {
+    let key = generate_test_key(None);
+    let store = store_with(registration(
+        Some(TokenEndpointAuthMethod::PrivateKeyJwt),
+        None,
+        Some(jwks_of(&[&key])),
+    ))
+    .await;
+
+    let assertion = sign_assertion(&key, None, good_claims(), Algorithm::ES256);
+    let mut req = with_assertion(bare_request(), &assertion);
+    req.client_id = None;
+
+    assert!(
+        handle_token(req, None, &test_config(false), &store, &test_tokens())
+            .await
+            .is_ok()
+    );
+}
+
+/// Naming another client in `client_id` selects that client's registration —
+/// which the forged assertion then fails against, rather than being verified
+/// against the key of the client it claims to be.
+#[tokio::test]
+async fn an_assertion_cannot_be_pointed_at_another_clients_registration() {
+    let victim_key = generate_test_key(None);
+    let attacker_key = generate_test_key(None);
+    let store = store_with(registration(
+        Some(TokenEndpointAuthMethod::PrivateKeyJwt),
+        None,
+        Some(jwks_of(&[&victim_key])),
+    ))
+    .await;
+
+    // Signed by a key the victim never registered, but claiming to be them.
+    let assertion = sign_assertion(&attacker_key, None, good_claims(), Algorithm::ES256);
+    let err = handle_token(
+        with_assertion(bare_request(), &assertion),
+        None,
+        &test_config(false),
+        &store,
+        &test_tokens(),
+    )
+    .await
+    .expect_err("an assertion must be signed by the named client's registered key");
+    assert_eq!(err.error, "invalid_client");
+}
+
+/// Public clients, and secret-bearing registrations that present nothing,
+/// must behave exactly as they did before this change.
+#[tokio::test]
+async fn existing_behaviour_is_unchanged_for_registrations_without_a_method() {
+    let public = store_with(registration(None, None, None)).await;
+    assert!(handle_token(
+        bare_request(),
+        None,
+        &test_config(false),
+        &public,
+        &test_tokens(),
+    )
+    .await
+    .is_ok());
+
+    let confidential = store_with(registration(None, Some(hash_secret(SECRET)), None)).await;
+    let err = handle_token(
+        bare_request(),
+        None,
+        &test_config(false),
+        &confidential,
+        &test_tokens(),
+    )
+    .await
+    .expect_err("a confidential client presenting nothing is not authenticated");
+    assert_eq!(err.error, "invalid_client");
+
+    // Either transport still carries the secret for these registrations,
+    // because they never said which one they use.
+    let mut post = bare_request();
+    post.client_secret = Some(SECRET.to_string());
+    assert!(handle_token(
+        post,
+        None,
+        &test_config(false),
+        &confidential,
+        &test_tokens(),
+    )
+    .await
+    .is_ok());
+    assert!(handle_token(
+        bare_request(),
+        Some(&basic_header(CLIENT_ID, SECRET)),
+        &test_config(false),
+        &confidential,
+        &test_tokens(),
+    )
+    .await
+    .is_ok());
+}

--- a/crates/authkestra-op/src/handlers/token/device_tests.rs
+++ b/crates/authkestra-op/src/handlers/token/device_tests.rs
@@ -26,6 +26,8 @@ fn default_device_req(device_code: &str) -> TokenRequest {
         actor_token_type: None,
         requested_token_type: None,
         audience: None,
+        client_assertion: None,
+        client_assertion_type: None,
     }
 }
 
@@ -73,6 +75,8 @@ async fn setup_store(
                 scopes: vec![],
                 require_pkce: false,
                 allowed_audiences: vec![],
+                token_endpoint_auth_method: None,
+                jwks: None,
             },
             std::time::Duration::from_secs(31536000),
         )
@@ -161,6 +165,8 @@ async fn test_device_expired() {
                 scopes: vec![],
                 require_pkce: false,
                 allowed_audiences: vec![],
+                token_endpoint_auth_method: None,
+                jwks: None,
             },
             std::time::Duration::from_secs(31536000),
         )
@@ -246,6 +252,8 @@ async fn test_device_concurrency() {
                 scopes: vec![],
                 require_pkce: false,
                 allowed_audiences: vec![],
+                token_endpoint_auth_method: None,
+                jwks: None,
             },
             std::time::Duration::from_secs(31536000),
         )

--- a/crates/authkestra-op/src/lib.rs
+++ b/crates/authkestra-op/src/lib.rs
@@ -20,7 +20,15 @@ pub use error::OpError;
 
 /// Registered OAuth2/OIDC client applications.
 pub mod client;
-pub use client::{ClientRegistration, ClientStore, GrantType};
+pub use client::{ClientRegistration, ClientStore, GrantType, TokenEndpointAuthMethod};
+
+/// Asymmetric client authentication (`private_key_jwt`, RFC 7523 §2.2):
+/// assertion verification and the replay tracking it depends on.
+pub mod client_assertion;
+pub use client_assertion::{
+    ClientAssertionStore, MemoryClientAssertionStore, NoClientAssertionStore,
+    CLIENT_ASSERTION_TYPE_JWT_BEARER,
+};
 
 /// Authorization codes issued during the `/authorize` step and consumed at
 /// `/token`.

--- a/crates/authkestra-op/src/sqlx_store.rs
+++ b/crates/authkestra-op/src/sqlx_store.rs
@@ -90,6 +90,16 @@ macro_rules! impl_opstore_sql {
                         grant_types: grant_types.0,
                         scopes: scopes.0,
                         allowed_audiences: allowed_audiences.0,
+                        // Not persisted yet: adding `token_endpoint_auth_method`
+                        // and `jwks` columns needs an ALTER-based migration, and
+                        // this store's `migrate` is CREATE TABLE IF NOT EXISTS —
+                        // it would silently leave existing deployments with a
+                        // SELECT naming columns their table does not have. Until
+                        // that lands, a SqlxOpStore-backed client behaves exactly
+                        // as it does today (secret or public) and cannot use
+                        // private_key_jwt.
+                        token_endpoint_auth_method: None,
+                        jwks: None,
                     }))
                 } else {
                     Ok(None)

--- a/crates/authkestra-op/src/store.rs
+++ b/crates/authkestra-op/src/store.rs
@@ -1,7 +1,10 @@
 use crate::client::ClientStore;
+use crate::client_assertion::{ClientAssertionStore, NoClientAssertionStore};
 use crate::code::AuthorizationCodeStore;
 use crate::device::DeviceCodeStore;
+use crate::error::OpError;
 use crate::refresh::RefreshTokenStore;
+use chrono::{DateTime, Utc};
 
 /// A unified store for all OpenID Provider state.
 /// This supertrait aggregates `ClientStore`, `AuthorizationCodeStore`,
@@ -10,6 +13,30 @@ use crate::refresh::RefreshTokenStore;
 pub trait OpStore:
     ClientStore + AuthorizationCodeStore + RefreshTokenStore + DeviceCodeStore + Send + Sync
 {
+    /// Atomically spends the `jti` of a `private_key_jwt` client assertion,
+    /// returning `Ok(false)` if it was already spent (RFC 7523 §3 point 7).
+    ///
+    /// A defaulted method rather than a fifth supertrait, so that adding
+    /// replay tracking does not break every existing `OpStore`
+    /// implementation — the same reasoning that makes `handle_custom_grant`
+    /// a defaulted method here.
+    ///
+    /// **The default refuses every assertion.** A store that has not
+    /// implemented `jti` tracking cannot offer the single-use guarantee, and
+    /// a `private_key_jwt` deployment without it would be strictly worse than
+    /// one without the method at all: the client would believe it had
+    /// proof-of-possession authentication while a captured assertion stayed
+    /// replayable for its whole lifetime. Failing closed makes that
+    /// impossible to reach by accident. See
+    /// `CompositeOpStore::with_client_assertion_store` for how to wire one.
+    async fn record_client_assertion_jti(
+        &self,
+        jti: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<bool, OpError> {
+        NoClientAssertionStore.record_jti(jti, expires_at).await
+    }
+
     /// Handle a custom grant type request during token exchange.
     ///
     /// By default, this returns an `unsupported_grant_type` error.
@@ -30,26 +57,43 @@ pub trait OpStore:
     }
 }
 
-/// A helper struct that implements `OpStore` by delegating to 4 individual stores.
+/// A helper struct that implements `OpStore` by delegating to 5 individual stores.
 /// Useful if you want to use different backends for different types of data (e.g., config for clients, Redis for codes).
-pub struct CompositeOpStore<C, A, R, D> {
+///
+/// The client-assertion slot defaults to
+/// [`NoClientAssertionStore`], so `private_key_jwt` is refused until a
+/// deployment opts in with [`CompositeOpStore::with_client_assertion_store`].
+/// It is a defaulted type parameter rather than a fifth argument to
+/// [`CompositeOpStore::new`] so that existing four-store call sites keep
+/// compiling untouched.
+pub struct CompositeOpStore<C, A, R, D, J = NoClientAssertionStore> {
     clients: C,
     codes: A,
     refresh: R,
     devices: D,
+    assertions: J,
 }
 
-impl<C, A, R, D> OpStore for CompositeOpStore<C, A, R, D>
+#[async_trait::async_trait]
+impl<C, A, R, D, J> OpStore for CompositeOpStore<C, A, R, D, J>
 where
     C: ClientStore,
     A: AuthorizationCodeStore,
     R: RefreshTokenStore,
     D: DeviceCodeStore,
+    J: ClientAssertionStore,
     Self: Send + Sync,
 {
+    async fn record_client_assertion_jti(
+        &self,
+        jti: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<bool, OpError> {
+        self.assertions.record_jti(jti, expires_at).await
+    }
 }
 
-impl<C, A, R, D> CompositeOpStore<C, A, R, D> {
+impl<C, A, R, D> CompositeOpStore<C, A, R, D, NoClientAssertionStore> {
     /// Create a new `CompositeOpStore` from individual stores.
     pub fn new(clients: C, codes: A, refresh: R, devices: D) -> Self {
         Self {
@@ -57,13 +101,39 @@ impl<C, A, R, D> CompositeOpStore<C, A, R, D> {
             codes,
             refresh,
             devices,
+            assertions: NoClientAssertionStore,
+        }
+    }
+}
+
+impl<C, A, R, D, J> CompositeOpStore<C, A, R, D, J> {
+    /// Swaps in the backend that tracks spent `private_key_jwt` assertion
+    /// `jti`s — the one thing this store needs before it will accept
+    /// asymmetric client authentication at all.
+    ///
+    /// [`crate::client_assertion::MemoryClientAssertionStore`] is correct for
+    /// a single-node deployment; a cluster needs something shared, because an
+    /// unshared map means one accepted replay per node. Whichever is chosen,
+    /// remember to advertise the method with
+    /// [`crate::handlers::discovery::OidcDiscovery::with_private_key_jwt`] —
+    /// discovery is deliberately silent about it otherwise.
+    pub fn with_client_assertion_store<J2: ClientAssertionStore>(
+        self,
+        assertions: J2,
+    ) -> CompositeOpStore<C, A, R, D, J2> {
+        CompositeOpStore {
+            clients: self.clients,
+            codes: self.codes,
+            refresh: self.refresh,
+            devices: self.devices,
+            assertions,
         }
     }
 }
 
 #[async_trait::async_trait]
-impl<C: ClientStore, A: Send + Sync, R: Send + Sync, D: Send + Sync> ClientStore
-    for CompositeOpStore<C, A, R, D>
+impl<C: ClientStore, A: Send + Sync, R: Send + Sync, D: Send + Sync, J: Send + Sync> ClientStore
+    for CompositeOpStore<C, A, R, D, J>
 {
     #[tracing::instrument(skip(self))]
     async fn find_client(
@@ -76,8 +146,8 @@ impl<C: ClientStore, A: Send + Sync, R: Send + Sync, D: Send + Sync> ClientStore
 }
 
 #[async_trait::async_trait]
-impl<C: Send + Sync, A: AuthorizationCodeStore, R: Send + Sync, D: Send + Sync>
-    AuthorizationCodeStore for CompositeOpStore<C, A, R, D>
+impl<C: Send + Sync, A: AuthorizationCodeStore, R: Send + Sync, D: Send + Sync, J: Send + Sync>
+    AuthorizationCodeStore for CompositeOpStore<C, A, R, D, J>
 {
     #[tracing::instrument(skip(self, code))]
     async fn store_code(
@@ -99,8 +169,8 @@ impl<C: Send + Sync, A: AuthorizationCodeStore, R: Send + Sync, D: Send + Sync>
 }
 
 #[async_trait::async_trait]
-impl<C: Send + Sync, A: Send + Sync, R: RefreshTokenStore, D: Send + Sync> RefreshTokenStore
-    for CompositeOpStore<C, A, R, D>
+impl<C: Send + Sync, A: Send + Sync, R: RefreshTokenStore, D: Send + Sync, J: Send + Sync>
+    RefreshTokenStore for CompositeOpStore<C, A, R, D, J>
 {
     #[tracing::instrument(skip(self, token))]
     async fn store_token(
@@ -137,8 +207,8 @@ impl<C: Send + Sync, A: Send + Sync, R: RefreshTokenStore, D: Send + Sync> Refre
 }
 
 #[async_trait::async_trait]
-impl<C: Send + Sync, A: Send + Sync, R: Send + Sync, D: DeviceCodeStore> DeviceCodeStore
-    for CompositeOpStore<C, A, R, D>
+impl<C: Send + Sync, A: Send + Sync, R: Send + Sync, D: DeviceCodeStore, J: Send + Sync>
+    DeviceCodeStore for CompositeOpStore<C, A, R, D, J>
 {
     #[tracing::instrument(skip(self, session))]
     async fn store_device_code(


### PR DESCRIPTION
Closes #143.

## Summary

Adds `private_key_jwt` client authentication (RFC 7523 §2.2 / OIDC Core §9) to `authkestra-op`, so a confidential client can authenticate at `/token` by signing a short-lived JWT with its own private key instead of presenting a shared `client_secret`. The OP stores only the public half.

Motivation and the gap analysis are in #143. Briefly: a backend-service client that must sign locally cannot hold a shared secret, because signing with a shared secret means HMAC and this codebase already refuses symmetric algorithms wherever a signature is verified (`OpConfig::id_token_signing_alg`, `attestation::parse_public_jwk`, `attestation::verify_challenge_signature`). The round-trip alternatives are too expensive on a hot path.

## Design decisions, and why

**Inline `jwks`, not `jwks_uri`.** OIDC allows either. `jwks_uri` turns the OP into an outbound HTTP client: a fetch, a cache, a background refresh, an attacker-influenced URL to resolve (SSRF), and a new failure mode where *client authentication* stops working because a third-party host is unreachable. `authkestra-op` has no HTTP client dependency at all today, and adding one for this would be the largest part of the change by far. An inline JWK Set holds several keys, so rotation is still "publish both, then drop the old one" — the case `jwks_uri` is usually reached for. If you want `jwks_uri` later it can be layered on as a resolver in front of the same verification code; nothing here forecloses it.

**One method per registration, enforced.** `ClientRegistration::token_endpoint_auth_method` binds a client to exactly one of `client_secret_basic` / `client_secret_post` / `private_key_jwt` / `none`. A credential of a different kind is rejected outright rather than verified on its own merits. This is the single most important property in the change: a client that can authenticate *either* way is only as strong as the weaker credential, so an attacker with the leaked secret of a `private_key_jwt` client would never need to touch the private key. Tested in both directions.

The field is `Option`, and `None` — a registration written before this field existed — keeps *exactly* the previous behaviour: a stored secret hash means a secret is required, from either transport since such a registration never said which; no stored hash means no client authentication. A `None` registration is never accepted by assertion, so asymmetric authentication cannot be acquired by accident, e.g. by someone filling in `jwks` alone.

**Algorithm comes from the key, never from the header.** `assertion_algorithms()` derives the permitted set from the registered key's type. `HS*` and `none` are additionally refused by a raw header peek before a key is even loaded, mirroring `attestation::verify_challenge_signature`. This is the algorithm-confusion attack: an `alg: HS256` assertion HMACed with the client's *public* key bytes, which are public.

**Replay protection fails closed — please read this one.** RFC 7523 §3 needs a `jti` to be spendable once, and the crate has no store with the right shape: `AtomicConsume` is fetch-and-remove, whereas this needs atomic insert-if-absent. Rather than skip replay protection quietly, this PR adds the smallest thing that works:

- a `ClientAssertionStore` trait with a documented atomicity requirement;
- `OpStore::record_client_assertion_jti`, a **defaulted** method (like `handle_custom_grant`) so no existing `OpStore` implementation breaks. Its default **refuses every assertion**. A deployment without replay tracking would otherwise hand clients an authentication method they believe is proof-of-possession while a captured assertion stays replayable for its full lifetime — strictly worse than not offering the method;
- `MemoryClientAssertionStore`, atomic within one process (single `Mutex`), for single-node deployments and tests — same trade-off and same intended use as `authkestra_engine::store::memory::MemoryStore`. A cluster needs something shared (Redis `SET NX`, a SQL unique index), and the doc comment says so;
- `CompositeOpStore` gains a **defaulted fifth type parameter** for the slot, so `CompositeOpStore::new(a, b, c, d)` call sites — including the examples and the custom-grant wrapper — compile untouched. Opt in with `.with_client_assertion_store(...)`.

I would still rather hear whether you want the primitive on `authkestra_engine::store` instead (an `insert_if_absent` sibling to `AtomicConsume`); this shape was chosen to keep the change inside `authkestra-op` and non-breaking, not because it is the only option.

**Discovery stays honest.** `from_config()` does *not* advertise `private_key_jwt`, because whether an assertion will actually be honoured is not something `OpConfig` knows — it depends on the store the deployment wired, which fails closed. `OidcDiscovery::with_private_key_jwt()` is the explicit opt-in, called by whoever wired the store, and it is documented next to `with_client_assertion_store`.

**Assertion lifetime is capped** at `MAX_CLIENT_ASSERTION_LIFETIME_SECS` (300s). RFC 7523 requires `exp` but sets no ceiling, and an assertion is a bearer credential for its whole lifetime — a decade-long one is a permanent password in JWT clothing, and it is also an unbounded write into the replay store, which must remember every `jti` until it expires. A module constant rather than an `OpConfig` field on purpose: `OpConfig`'s fields are all public and it is built with struct literals throughout this workspace, so growing it would be a breaking change this feature does not need to make. Happy to move it if you'd rather it be configurable.

**One credential per request.** RFC 6749 §2.3 and RFC 7521 §4.2 both forbid presenting more than one authentication method. A request carrying two is now `invalid_request` rather than resolved by an unwritten precedence order — precedence is exactly what an attacker holding the weaker credential would exploit. *This is a small behaviour change:* previously, a `Basic` header and a body `client_secret` in the same request silently preferred the header.

## Files

- `client.rs` — `TokenEndpointAuthMethod`; `ClientRegistration::{token_endpoint_auth_method, jwks}`
- `client_assertion.rs` *(new)* — verification, `ClientAssertionStore`, `MemoryClientAssertionStore`, `NoClientAssertionStore`
- `handlers/token.rs` — `PresentedCredential`, `extract_credential`, `resolve_client_id`, `authenticate_client`; `TokenRequest::{client_assertion, client_assertion_type}`
- `handlers/token/client_auth_tests.rs` *(new)* — endpoint-level tests
- `store.rs` — defaulted `OpStore::record_client_assertion_jti`; `CompositeOpStore`'s fifth slot
- `handlers/discovery.rs` — `with_private_key_jwt()`
- `error.rs` — `AuthMethodNotPermitted`, `InvalidClientAssertion`, `ClientAssertionReplayed`, `ReplayProtectionUnavailable`

Every failure path is `invalid_client` with a fixed description; the specific reason goes to `tracing` only, so nothing about *why* authentication failed leaks into the response.

## Deliberately not in this PR

- **`SqlxOpStore` does not persist the two new fields** (`find_client` returns `None` for both), so a `SqlxOpStore`-backed deployment behaves exactly as it does today and cannot use `private_key_jwt`. Adding columns needs an `ALTER`-based migration, and `SqlxOpStore::migrate` is `CREATE TABLE IF NOT EXISTS` across three dialects — it would silently leave existing tables without the columns while the `SELECT` starts naming them. That is its own change with its own migration story; happy to open a follow-up issue.
- **`jwks_uri`** — see above.
- **`client_secret_jwt`** — the other RFC 7523 method. It is HMAC over the shared secret, i.e. the exact thing #143 exists to avoid, so it was not worth the surface.
- **`/device_authorization` client authentication.** Noticed while working here, unrelated to this change and pre-existing: `handle_device_authorization` extracts `client_id` from the `Basic` header but never verifies the secret, so a confidential client is not authenticated at that endpoint at all. Left alone rather than folded into a client-authentication PR; say the word and I'll file it.
- **The `op`-only feature build of the adapters is already broken on `develop`** — `cargo check -p authkestra-axum --no-default-features --features op` fails with `cannot find type SessionConfig`, and the actix equivalent with `AuthSession: FromRequest` not satisfied. Verified against `git stash`ed `develop` (69a5412); untouched by this PR. `cargo check -p authkestra-op --no-default-features` is clean.

## Verification

All run locally against this branch:

```
cargo fmt --all --check                                          # clean
cargo clippy --workspace --all-targets --all-features -- -D warnings   # clean
cargo test --workspace --all-features                            # all suites pass, 0 failures
cargo check -p authkestra-op --no-default-features                # clean
```

`authkestra-op --lib`: 101 tests pass, 34 of them new (67 pre-existing, all unchanged and still green).

### Mutation testing — the tests were proven to fail

Every security property was verified by breaking the implementation, confirming the test fails for the predicted reason, and restoring. A test that passes against both the fixed and the broken code proves nothing, so each of these was actually run:

| Deliberate break | Tests that failed |
|---|---|
| Mixed-method acceptance: verify whatever credential is presented, whatever the registration says | `private_key_jwt_client_is_refused_a_valid_client_secret`, `client_secret_client_is_refused_a_valid_assertion`, `the_secret_transport_is_bound_too` |
| Legacy registration silently accepts an assertion | `a_registration_without_an_auth_method_is_never_accepted_by_assertion` |
| `jti` never spent (replay protection removed) | `a_replayed_assertion_is_refused`, `assertions_are_refused_when_no_replay_store_is_wired` |
| `NoClientAssertionStore` fails open instead of closed | `no_store_refuses_rather_than_permitting_replay`, `assertions_are_refused_when_no_replay_store_is_wired` |
| Symmetric / `none` algorithm guard removed | `rejects_a_symmetric_algorithm`, `rejects_alg_none` |
| `iss`/`sub` no longer checked against `client_id` | `rejects_an_assertion_issued_for_another_client`, `rejects_iss_and_sub_disagreeing` |
| `aud` not validated | `rejects_a_wrong_audience` |
| `kid` ignored, first registered key used | `selects_the_named_key_when_several_are_registered` |
| No cap on assertion lifetime | `rejects_an_assertion_that_never_meaningfully_expires` |
| Several credentials in one request resolved by precedence | `two_credentials_in_one_request_are_refused` |

Each mutation was caught by exactly the listed tests and nothing else; the tree was restored and the full suite re-run green afterwards.

## Reviewer focus

1. The `authenticate_client` match in `handlers/token.rs` — the shape of that match *is* the no-downgrade property.
2. The fail-closed replay default. It means `private_key_jwt` does nothing until a deployment opts in, which is a deliberate choice and the one most worth arguing with.
3. Whether the replay primitive belongs on `authkestra_engine::store` instead of as a defaulted `OpStore` method.
4. `MAX_CLIENT_ASSERTION_LIFETIME_SECS` as a constant rather than configuration.

## AI Usage Declaration

Claude Code was used to survey the crate, draft the implementation, tests and this description. The design decisions above (inline `jwks`, one-method binding, fail-closed replay, discovery opt-in, the deliberate exclusions) were made and are owned by me. I ran `fmt`/`clippy`/`test` and the mutation table myself and read the real output; the pre-existing `develop` breakages listed under "deliberately not in this PR" were confirmed by stashing this branch's changes and re-running against clean `develop`. I can explain every line here.
