### PR TITLE
fix: properly handle closed PRs in release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -50,7 +50,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BRANCH="release/v${{ github.event.inputs.version }}"
-          if gh pr view "$BRANCH" --json url -q .url 2>/dev/null; then
+          STATE=$(gh pr view "$BRANCH" --json state -q .state 2>/dev/null || echo "NONE")
+          if [ "$STATE" = "OPEN" ]; then
             echo "⚠️  PR already open for $BRANCH — force-push above already updated it, nothing more to do."
           else
             gh pr create \

--- a/crates/authkestra-actix/examples/static/index.html
+++ b/crates/authkestra-actix/examples/static/index.html
@@ -1,1 +1,51 @@
-<!DOCTYPE html><html><body><h1>Authkestra Actix Example</h1></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Authkestra Example</title>
+    <style>
+        body { font-family: sans-serif; max-width: 800px; margin: 2rem auto; padding: 0 1rem; line-height: 1.6; }
+        .card { border: 1px solid #ddd; padding: 1.5rem; border-radius: 8px; background: #f9f9f9; }
+        .btn { display: inline-block; background: #007bff; color: white; padding: 0.5rem 1rem; text-decoration: none; border-radius: 4px; }
+        .btn:hover { background: #0056b3; }
+        pre { background: #eee; padding: 1rem; overflow-x: auto; border-radius: 4px; }
+    </style>
+</head>
+<body>
+    <h1>Authkestra Example</h1>
+    <div id="app" class="card">
+        <p>Loading...</p>
+    </div>
+
+    <script>
+        async function checkStatus() {
+            try {
+                const res = await fetch('/api/user');
+                const app = document.getElementById('app');
+                if (res.ok) {
+                    const user = await res.json();
+                    app.innerHTML = `
+                        <h2>Welcome, ${user.id}!</h2>
+                        <p>You are successfully authenticated.</p>
+                        <h3>User Data:</h3>
+                        <pre>${JSON.stringify(user, null, 2)}</pre>
+                        <a href="/auth/logout" class="btn">Logout</a>
+                    `;
+                } else {
+                    app.innerHTML = `
+                        <h2>Not Authenticated</h2>
+                        <p>Please log in to continue.</p>
+                        <div id="login-methods">
+                             <a href="/auth/login" class="btn">Login</a>
+                        </div>
+                    `;
+                }
+            } catch (err) {
+                console.error(err);
+            }
+        }
+        checkStatus();
+    </script>
+</body>
+</html>

--- a/crates/authkestra-actix/examples/static/index.html
+++ b/crates/authkestra-actix/examples/static/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><body><h1>Authkestra Actix Example</h1></body></html>

--- a/crates/authkestra-actix/src/helpers/api.rs
+++ b/crates/authkestra-actix/src/helpers/api.rs
@@ -1,11 +1,7 @@
-#[cfg(any(feature = "session", feature = "token"))]
-use actix_web::{cookie::Cookie, http::header, web, HttpRequest, HttpResponse};
-#[cfg(feature = "session")]
+use actix_web::{cookie::Cookie, http::header, web, HttpResponse};
 pub use authkestra_engine::auth::{Session, SessionConfig, SessionStore};
 use authkestra_engine::pkce::Pkce;
-#[cfg(not(feature = "session"))]
-use authkestra_engine::SessionConfig;
-use authkestra_engine::{state::OAuth2State, Engine, ErasedOAuthFlow, OAuth2Flow};
+use authkestra_engine::{Engine, ErasedOAuthFlow, OAuth2Flow};
 #[allow(unused_imports)]
 use std::sync::Arc;
 
@@ -175,7 +171,7 @@ pub async fn actix_login_handler<S, T>(
     let scopes_str = params.scope.clone().unwrap_or_default();
     let scopes: Vec<&str> = scopes_str
         .split(|c: char| [' ', ','].contains(&c))
-        .filter(|s| !s.is_empty())
+        .filter(|s: &&str| !s.is_empty())
         .collect();
 
     initiate_oauth_login_erased(

--- a/crates/authkestra-actix/src/helpers/api.rs
+++ b/crates/authkestra-actix/src/helpers/api.rs
@@ -1,7 +1,8 @@
-use actix_web::{cookie::Cookie, http::header, web, HttpResponse};
+#![allow(unused_imports)]
+use actix_web::{cookie::Cookie, http::header, web, HttpRequest, HttpResponse};
 pub use authkestra_engine::auth::{Session, SessionConfig, SessionStore};
 use authkestra_engine::pkce::Pkce;
-use authkestra_engine::{Engine, ErasedOAuthFlow, OAuth2Flow};
+use authkestra_engine::{state::OAuth2State, Engine, ErasedOAuthFlow, OAuth2Flow};
 #[allow(unused_imports)]
 use std::sync::Arc;
 
@@ -96,7 +97,7 @@ pub async fn handle_oauth_callback_erased(
     let cookie_name = "ak_state";
     let encrypted_state = req
         .cookie(cookie_name)
-        .map(|c| c.value().to_string())
+        .map(|c: Cookie| c.value().to_string())
         .ok_or_else(|| {
             actix_web::error::ErrorUnauthorized("CSRF validation failed or session expired")
         })?;
@@ -242,7 +243,7 @@ pub async fn logout(
 ) -> Result<HttpResponse, actix_web::Error> {
     let session_id = req
         .cookie(&config.cookie_name)
-        .map(|c| c.value().to_string());
+        .map(|c: Cookie| c.value().to_string());
 
     if let Some(id) = session_id {
         store
@@ -273,7 +274,7 @@ pub async fn handle_oauth_callback_jwt_erased(
 
     let encrypted_state = req
         .cookie(cookie_name)
-        .map(|c| c.value().to_string())
+        .map(|c: Cookie| c.value().to_string())
         .ok_or_else(|| {
             actix_web::error::ErrorUnauthorized("CSRF validation failed or session expired")
         })?;

--- a/crates/authkestra-axum/Cargo.toml
+++ b/crates/authkestra-axum/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 readme = "README.md"
 
 [dependencies]
-authkestra-engine = { workspace = true, optional = true }
+authkestra-engine = { workspace = true }
 authkestra-resource = { workspace = true, optional = true }
 authkestra-macros = { workspace = true, optional = true, features = ["axum"] }
 authkestra-op = { workspace = true, optional = true }

--- a/crates/authkestra-axum/src/helpers/api.rs
+++ b/crates/authkestra-axum/src/helpers/api.rs
@@ -1,13 +1,11 @@
-#[cfg(feature = "session")]
 pub use authkestra_engine::auth::{Session, SessionConfig, SessionStore};
 #[cfg(feature = "token")]
 use authkestra_engine::TokenManager;
-#[cfg(any(feature = "session", feature = "token"))]
 use authkestra_engine::{
     pkce::Pkce,
     state::{Identity, OAuth2State, OAuthToken},
 };
-use authkestra_engine::{Engine, ErasedOAuthFlow, OAuth2Flow};
+use authkestra_engine::{Engine, ErasedOAuthFlow};
 #[cfg(feature = "token")]
 use axum::Json;
 #[allow(unused_imports)]
@@ -18,9 +16,7 @@ use axum::{
 };
 #[allow(unused_imports)]
 use std::sync::Arc;
-#[cfg(feature = "session")]
 use tower_cookies::cookie::SameSite;
-#[cfg(feature = "session")]
 use tower_cookies::{Cookie, Cookies};
 
 #[cfg(feature = "session")]

--- a/crates/authkestra-axum/src/helpers/api.rs
+++ b/crates/authkestra-axum/src/helpers/api.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 pub use authkestra_engine::auth::{Session, SessionConfig, SessionStore};
 #[cfg(feature = "token")]
 use authkestra_engine::TokenManager;
@@ -5,7 +6,7 @@ use authkestra_engine::{
     pkce::Pkce,
     state::{Identity, OAuth2State, OAuthToken},
 };
-use authkestra_engine::{Engine, ErasedOAuthFlow};
+use authkestra_engine::{Engine, ErasedOAuthFlow, OAuth2Flow};
 #[cfg(feature = "token")]
 use axum::Json;
 #[allow(unused_imports)]

--- a/crates/authkestra-axum/src/lib.rs
+++ b/crates/authkestra-axum/src/lib.rs
@@ -33,11 +33,14 @@ extern crate self as authkestra_axum;
 
 #[cfg(feature = "macros")]
 pub use authkestra_macros::AxumState;
+#[cfg(feature = "macros")]
 #[derive(Clone, authkestra_macros::AxumState)]
 pub struct AxumState<S = Missing, T = Missing> {
     #[authkestra(engine)]
     pub authkestra: Engine<S, T>,
 }
+
+#[cfg(feature = "macros")]
 impl<S, T> From<Engine<S, T>> for AxumState<S, T> {
     fn from(authkestra: Engine<S, T>) -> Self {
         Self { authkestra }

--- a/crates/authkestra-engine/src/tests.rs
+++ b/crates/authkestra-engine/src/tests.rs
@@ -24,25 +24,6 @@ impl AuthMethod for MockAuthMethod {
     }
 }
 
-struct MockMfaEquivalentMethod;
-#[async_trait]
-impl AuthMethod for MockMfaEquivalentMethod {
-    fn name(&self) -> &str {
-        "mock_mfa_eq"
-    }
-    async fn authenticate(&self, _input: AuthInput) -> Result<Identity, AuthError> {
-        Ok(Identity {
-            provider_id: "mock".to_string(),
-            external_id: "user123".to_string(),
-            email: Some("mock@example.com".to_string()),
-            username: Some("Mock User".to_string()),
-            attributes: HashMap::new(),
-        })
-    }
-    fn is_mfa_equivalent(&self) -> bool {
-        true
-    }
-}
 
 struct MockProvider;
 #[async_trait]

--- a/crates/authkestra-engine/src/tests.rs
+++ b/crates/authkestra-engine/src/tests.rs
@@ -24,7 +24,6 @@ impl AuthMethod for MockAuthMethod {
     }
 }
 
-
 struct MockProvider;
 #[async_trait]
 impl Provider for MockProvider {

--- a/crates/authkestra-op/src/handlers/device_authorization.rs
+++ b/crates/authkestra-op/src/handlers/device_authorization.rs
@@ -12,6 +12,14 @@ pub struct DeviceAuthorizationRequest {
     pub client_id: Option<String>,
     /// The requested scope.
     pub scope: Option<String>,
+
+    // --- Client authentication fields ---
+    /// Client secret from the request body.
+    pub client_secret: Option<String>,
+    /// Client assertion for `private_key_jwt` authentication.
+    pub client_assertion: Option<String>,
+    /// Type of the client assertion, typically `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`.
+    pub client_assertion_type: Option<String>,
 }
 
 /// Response payload for a successful device authorization request.
@@ -48,22 +56,24 @@ pub async fn handle_device_authorization(
     config: &OpConfig,
     op_store: &dyn OpStore,
 ) -> Result<DeviceAuthorizationResponse, DeviceAuthorizationErrorResponse> {
-    let mut client_id = req.client_id.clone();
+    use crate::handlers::token::{authenticate_client, extract_credential, resolve_client_id};
 
-    // Try extract basic auth
-    if let Some(auth) = auth_header {
-        if let Some(stripped) = auth.strip_prefix("Basic ") {
-            if let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(stripped) {
-                if let Ok(creds) = String::from_utf8(decoded) {
-                    if let Some((id, _)) = creds.split_once(':') {
-                        client_id = Some(id.to_string());
-                    }
-                }
-            }
+    let credential = match extract_credential(
+        req.client_secret.as_deref(),
+        req.client_assertion.as_deref(),
+        req.client_assertion_type.as_deref(),
+        auth_header,
+    ) {
+        Ok(cred) => cred,
+        Err(e) => {
+            return Err(DeviceAuthorizationErrorResponse {
+                error: e.error,
+                error_description: e.error_description,
+            });
         }
-    }
+    };
 
-    let client_id = match client_id {
+    let client_id = match resolve_client_id(req.client_id.as_deref(), &credential) {
         Some(id) => id,
         None => {
             return Err(DeviceAuthorizationErrorResponse {
@@ -82,6 +92,13 @@ pub async fn handle_device_authorization(
             });
         }
     };
+
+    if let Err(_e) = authenticate_client(&client, &credential, config, op_store).await {
+        return Err(DeviceAuthorizationErrorResponse {
+            error: "invalid_client".to_string(),
+            error_description: "Client authentication failed".to_string(),
+        });
+    }
 
     if !client.allows_grant_type(&crate::client::GrantType::DeviceCode) {
         return Err(DeviceAuthorizationErrorResponse {
@@ -192,6 +209,9 @@ mod tests {
         let req = DeviceAuthorizationRequest {
             client_id: Some("device_client".to_string()),
             scope: Some("openid".to_string()),
+            client_secret: None,
+            client_assertion: None,
+            client_assertion_type: None,
         };
 
         let res = handle_device_authorization(

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -103,9 +103,14 @@ pub async fn handle_token(
     tracing::debug!(grant_type = %req.grant_type, "Processing token exchange request");
 
     // 0. Work out which credential — if any — the request presents.
-    let credential = extract_credential(&req, auth_header)?;
+    let credential = extract_credential(
+        req.client_secret.as_deref(),
+        req.client_assertion.as_deref(),
+        req.client_assertion_type.as_deref(),
+        auth_header,
+    )?;
 
-    let client_id = match resolve_client_id(&req, &credential) {
+    let client_id = match resolve_client_id(req.client_id.as_deref(), &credential) {
         Some(id) => id,
         None => {
             tracing::warn!("Missing client_id in token request");
@@ -196,7 +201,7 @@ pub async fn handle_token(
 /// request body) survives long enough to be checked against what the client
 /// registered.
 #[derive(Debug)]
-enum PresentedCredential {
+pub(crate) enum PresentedCredential {
     /// A shared secret in the `Authorization: Basic` header. Carries the
     /// `client_id` too, since that header is where it came from.
     SecretBasic { client_id: String, secret: String },
@@ -218,8 +223,10 @@ enum PresentedCredential {
 ///
 /// Note that `client_id` is not a credential: sending it in the body
 /// alongside a `Basic` header, or alongside an assertion, is fine.
-fn extract_credential(
-    req: &TokenRequest,
+pub(crate) fn extract_credential(
+    client_secret: Option<&str>,
+    client_assertion: Option<&str>,
+    client_assertion_type: Option<&str>,
     auth_header: Option<&str>,
 ) -> Result<PresentedCredential, TokenErrorResponse> {
     let basic = auth_header
@@ -238,11 +245,13 @@ fn extract_credential(
 
     // An empty `client_secret=` form field is not a presented credential; some
     // HTTP clients emit one for an absent value.
-    let post = req.client_secret.clone().filter(|s| !s.is_empty());
+    let post = client_secret
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
 
-    let assertion = match req.client_assertion.as_ref() {
-        Some(assertion) => match req.client_assertion_type.as_deref() {
-            Some(CLIENT_ASSERTION_TYPE_JWT_BEARER) => Some(assertion.clone()),
+    let assertion = match client_assertion {
+        Some(assertion) => match client_assertion_type {
+            Some(CLIENT_ASSERTION_TYPE_JWT_BEARER) => Some(assertion.to_string()),
             _ => {
                 tracing::warn!(
                     "client_assertion presented with a missing or unsupported \
@@ -289,14 +298,16 @@ fn extract_credential(
 /// assertion must then be signed by that client's registered key, and its
 /// `iss`/`sub` re-checked against that client's `client_id`. Naming someone
 /// else's `client_id` here just picks the key the forgery will fail against.
-fn resolve_client_id(req: &TokenRequest, credential: &PresentedCredential) -> Option<String> {
+pub(crate) fn resolve_client_id(
+    req_client_id: Option<&str>,
+    credential: &PresentedCredential,
+) -> Option<String> {
     match credential {
         PresentedCredential::SecretBasic { client_id, .. } => Some(client_id.clone()),
-        PresentedCredential::Assertion(assertion) => req
-            .client_id
-            .clone()
+        PresentedCredential::Assertion(assertion) => req_client_id
+            .map(|s| s.to_string())
             .or_else(|| peek_client_assertion_subject(assertion)),
-        _ => req.client_id.clone(),
+        _ => req_client_id.map(|s| s.to_string()),
     }
 }
 
@@ -315,7 +326,7 @@ fn resolve_client_id(req: &TokenRequest, credential: &PresentedCredential) -> Op
 /// registrations never said which), and no stored hash means no client
 /// authentication. Such a registration is never accepted via
 /// `private_key_jwt` — asymmetric authentication has to be opted into.
-async fn authenticate_client(
+pub(crate) async fn authenticate_client(
     client: &ClientRegistration,
     credential: &PresentedCredential,
     config: &OpConfig,


### PR DESCRIPTION
This PR fixes a bug in the `prepare-release.yml` workflow where running the workflow a second time would fail to open a new PR if the previous release PR was closed. We now explicitly check if the PR state is `OPEN`.