### PR TITLE
fix(ci): grant release-plz access to crates.io token

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -13,6 +13,7 @@ jobs:
   release-plz:
     name: Release-plz
     runs-on: ubuntu-latest
+    environment: prod
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The previous release failed because the `CARGO_REGISTRY_TOKEN` was empty. This is because the token is stored in the `prod` GitHub Environment, but the `release-plz` job didn't specify `environment: prod`. This PR fixes that!