### PR TITLE
fix: remove circular dev-dependencies from axum and actix adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authkestra"
-version = "0.2.6"
+version = "0.2.5"
 dependencies = [
  "authkestra-actix",
  "authkestra-axum",
@@ -446,13 +446,12 @@ dependencies = [
 
 [[package]]
 name = "authkestra-actix"
-version = "0.2.6"
+version = "0.2.5"
 dependencies = [
  "actix-files",
  "actix-utils",
  "actix-web",
  "async-trait",
- "authkestra",
  "authkestra-devsig",
  "authkestra-engine",
  "authkestra-macros",
@@ -486,11 +485,10 @@ dependencies = [
 
 [[package]]
 name = "authkestra-axum"
-version = "0.2.6"
+version = "0.2.5"
 dependencies = [
  "actix-files",
  "async-trait",
- "authkestra",
  "authkestra-devsig",
  "authkestra-engine",
  "authkestra-macros",
@@ -529,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-devsig"
-version = "0.2.6"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -548,18 +546,11 @@ dependencies = [
 
 [[package]]
 name = "authkestra-engine"
-version = "0.2.6"
+version = "0.2.5"
 dependencies = [
  "actix-files",
  "aes-gcm",
  "async-trait",
- "authkestra",
- "authkestra-engine",
- "authkestra-macros",
- "authkestra-oidc",
- "authkestra-op",
- "authkestra-providers",
- "authkestra-resource",
  "base64 0.22.1",
  "chrono",
  "dotenvy",
@@ -587,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-macros"
-version = "0.2.6"
+version = "0.2.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -597,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-oidc"
-version = "0.2.6"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "authkestra-engine",
@@ -614,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-op"
-version = "0.2.6"
+version = "0.2.5"
 dependencies = [
  "argon2",
  "async-trait",
@@ -641,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-providers"
-version = "0.2.6"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "authkestra-engine",
@@ -656,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-resource"
-version = "0.2.6"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "authkestra-engine",

--- a/crates/authkestra-actix/Cargo.toml
+++ b/crates/authkestra-actix/Cargo.toml
@@ -31,7 +31,7 @@ http = "1"
 
 [dev-dependencies]
 
-authkestra = { workspace = true, features = ["full"] }
+
 authkestra-engine = { workspace = true, features = ["token", "session", "memory", "redis", "sql-sqlite", "totp", "webauthn"] }
 authkestra-resource = { workspace = true }
 authkestra-providers = { workspace = true, features = ["github", "google", "discord"] }

--- a/crates/authkestra-actix/examples/basic_setup.rs
+++ b/crates/authkestra-actix/examples/basic_setup.rs
@@ -5,9 +5,9 @@
 
 use actix_files::Files;
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
-use authkestra_engine::flow::Engine;
 use authkestra_actix::{ActixExt, ActixState, AuthSession};
 use authkestra_engine::auth::SessionStore;
+use authkestra_engine::flow::Engine;
 use authkestra_engine::SessionConfig;
 use serde_json::json;
 use std::sync::Arc;

--- a/crates/authkestra-actix/examples/basic_setup.rs
+++ b/crates/authkestra-actix/examples/basic_setup.rs
@@ -5,7 +5,7 @@
 
 use actix_files::Files;
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
-use authkestra::flow::Engine;
+use authkestra_engine::flow::Engine;
 use authkestra_actix::{ActixExt, ActixState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::SessionConfig;

--- a/crates/authkestra-actix/examples/oauth2_github.rs
+++ b/crates/authkestra-actix/examples/oauth2_github.rs
@@ -8,9 +8,9 @@
 
 use actix_files::Files;
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
-use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_actix::{ActixExt, ActixState, AuthSession};
 use authkestra_engine::auth::SessionStore;
+use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_engine::{AkWebAppEngine, SessionConfig};
 use authkestra_providers::github::GithubProvider;
 use serde_json::json;

--- a/crates/authkestra-actix/examples/oauth2_github.rs
+++ b/crates/authkestra-actix/examples/oauth2_github.rs
@@ -8,7 +8,7 @@
 
 use actix_files::Files;
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
-use authkestra::flow::{Engine, OAuth2Flow};
+use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_actix::{ActixExt, ActixState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{AkWebAppEngine, SessionConfig};

--- a/crates/authkestra-actix/examples/oauth_stateless.rs
+++ b/crates/authkestra-actix/examples/oauth_stateless.rs
@@ -8,7 +8,7 @@
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
 use actix_web::{get, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
-use authkestra::flow::{Engine, OAuth2Flow};
+use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_actix::{helpers, ActixState, AuthToken};
 use authkestra_engine::{AkApiEngine, TokenManagerState};
 use authkestra_providers::github::GithubProvider;

--- a/crates/authkestra-actix/examples/oauth_stateless.rs
+++ b/crates/authkestra-actix/examples/oauth_stateless.rs
@@ -8,8 +8,8 @@
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
 use actix_web::{get, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
-use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_actix::{helpers, ActixState, AuthToken};
+use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_engine::{AkApiEngine, TokenManagerState};
 use authkestra_providers::github::GithubProvider;
 use serde_json::json;

--- a/crates/authkestra-actix/examples/oidc_google.rs
+++ b/crates/authkestra-actix/examples/oidc_google.rs
@@ -8,9 +8,9 @@
 
 use actix_files::Files;
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
-use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_actix::{ActixExt, ActixState, AuthSession};
 use authkestra_engine::auth::SessionStore;
+use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_engine::{AkWebAppEngine, SessionConfig};
 use authkestra_providers::google::GoogleProvider;
 use serde_json::json;

--- a/crates/authkestra-actix/examples/oidc_google.rs
+++ b/crates/authkestra-actix/examples/oidc_google.rs
@@ -8,7 +8,7 @@
 
 use actix_files::Files;
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
-use authkestra::flow::{Engine, OAuth2Flow};
+use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_actix::{ActixExt, ActixState, AuthSession};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{AkWebAppEngine, SessionConfig};

--- a/crates/authkestra-actix/examples/op_server.rs
+++ b/crates/authkestra-actix/examples/op_server.rs
@@ -9,8 +9,8 @@
 use authkestra_engine::store::KvStore;
 
 use actix_web::{App, HttpServer};
-use authkestra_engine::flow::Engine;
 use authkestra_actix::{ActixState, OpExt};
+use authkestra_engine::flow::Engine;
 use authkestra_engine::store::redis::RedisStore;
 use authkestra_engine::{SessionConfig, TokenManager};
 use authkestra_op::{client::ClientRegistration, config::OpConfig};

--- a/crates/authkestra-actix/examples/op_server.rs
+++ b/crates/authkestra-actix/examples/op_server.rs
@@ -9,7 +9,7 @@
 use authkestra_engine::store::KvStore;
 
 use actix_web::{App, HttpServer};
-use authkestra::flow::Engine;
+use authkestra_engine::flow::Engine;
 use authkestra_actix::{ActixState, OpExt};
 use authkestra_engine::store::redis::RedisStore;
 use authkestra_engine::{SessionConfig, TokenManager};

--- a/crates/authkestra-actix/examples/op_server_custom_grant.rs
+++ b/crates/authkestra-actix/examples/op_server_custom_grant.rs
@@ -4,8 +4,8 @@
 use authkestra_engine::store::KvStore;
 
 use actix_web::{App, HttpServer};
-use authkestra_engine::flow::Engine;
 use authkestra_actix::{ActixState, OpExt};
+use authkestra_engine::flow::Engine;
 use authkestra_engine::store::memory::MemoryStore;
 use authkestra_op::client::ClientStore;
 use authkestra_op::code::AuthorizationCodeStore;

--- a/crates/authkestra-actix/examples/op_server_custom_grant.rs
+++ b/crates/authkestra-actix/examples/op_server_custom_grant.rs
@@ -4,7 +4,7 @@
 use authkestra_engine::store::KvStore;
 
 use actix_web::{App, HttpServer};
-use authkestra::flow::Engine;
+use authkestra_engine::flow::Engine;
 use authkestra_actix::{ActixState, OpExt};
 use authkestra_engine::store::memory::MemoryStore;
 use authkestra_op::client::ClientStore;

--- a/crates/authkestra-actix/examples/op_server_sqlx.rs
+++ b/crates/authkestra-actix/examples/op_server_sqlx.rs
@@ -3,8 +3,8 @@
 //! This example demonstrates setting up an OpenID Connect Provider using authkestra-op and Actix.
 //! It uses the batteries-included `SqlxOpStore` for a production-ready relational database schema.
 use actix_web::{App, HttpServer};
-use authkestra_engine::flow::Engine;
 use authkestra_actix::{ActixState, OpExt};
+use authkestra_engine::flow::Engine;
 use authkestra_engine::TokenManager;
 use authkestra_op::config::OpConfig;
 use authkestra_op::sqlx_store::SqlxOpStore;

--- a/crates/authkestra-actix/examples/op_server_sqlx.rs
+++ b/crates/authkestra-actix/examples/op_server_sqlx.rs
@@ -3,7 +3,7 @@
 //! This example demonstrates setting up an OpenID Connect Provider using authkestra-op and Actix.
 //! It uses the batteries-included `SqlxOpStore` for a production-ready relational database schema.
 use actix_web::{App, HttpServer};
-use authkestra::flow::Engine;
+use authkestra_engine::flow::Engine;
 use authkestra_actix::{ActixState, OpExt};
 use authkestra_engine::TokenManager;
 use authkestra_op::config::OpConfig;

--- a/crates/authkestra-axum/Cargo.toml
+++ b/crates/authkestra-axum/Cargo.toml
@@ -35,7 +35,7 @@ bytes = { version = "1", optional = true }
 
 [dev-dependencies]
 
-authkestra = { workspace = true, features = ["full"] }
+
 authkestra-engine = { workspace = true, features = ["token", "session", "memory", "redis", "sql-sqlite", "totp", "webauthn"] }
 authkestra-resource = { workspace = true }
 authkestra-providers = { workspace = true, features = ["github", "google", "discord"] }

--- a/crates/authkestra-axum/examples/basic_setup.rs
+++ b/crates/authkestra-axum/examples/basic_setup.rs
@@ -3,9 +3,9 @@
 //! This example demonstrates the most basic setup of Engine with Axum.
 //! It uses an in-memory session store and a mock authentication provider.
 
-use authkestra_engine::flow::Engine;
 use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
+use authkestra_engine::flow::Engine;
 use authkestra_engine::{AkWebAppEngine, SessionConfig};
 use axum::{
     response::{IntoResponse, Json},

--- a/crates/authkestra-axum/examples/basic_setup.rs
+++ b/crates/authkestra-axum/examples/basic_setup.rs
@@ -3,7 +3,7 @@
 //! This example demonstrates the most basic setup of Engine with Axum.
 //! It uses an in-memory session store and a mock authentication provider.
 
-use authkestra::flow::Engine;
+use authkestra_engine::flow::Engine;
 use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{AkWebAppEngine, SessionConfig};

--- a/crates/authkestra-axum/examples/data_layer_macros.rs
+++ b/crates/authkestra-axum/examples/data_layer_macros.rs
@@ -8,9 +8,9 @@
 //! it automatically generates the implementations for the data layer traits by delegating
 //! to the internal unified `SqlKvStore`.
 
-use authkestra_engine::flow::Engine;
 use authkestra_axum::{AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
+use authkestra_engine::flow::Engine;
 use authkestra_engine::SessionConfig;
 use authkestra_macros::KvStore;
 use axum::Router;

--- a/crates/authkestra-axum/examples/data_layer_macros.rs
+++ b/crates/authkestra-axum/examples/data_layer_macros.rs
@@ -8,7 +8,7 @@
 //! it automatically generates the implementations for the data layer traits by delegating
 //! to the internal unified `SqlKvStore`.
 
-use authkestra::flow::Engine;
+use authkestra_engine::flow::Engine;
 use authkestra_axum::{AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::SessionConfig;

--- a/crates/authkestra-axum/examples/oauth2_github.rs
+++ b/crates/authkestra-axum/examples/oauth2_github.rs
@@ -6,7 +6,7 @@
 //! - `AUTHKESTRA_GITHUB_CLIENT_ID`
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
-use authkestra::flow::{Engine, OAuth2Flow};
+use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{AkWebAppEngine, SessionConfig};

--- a/crates/authkestra-axum/examples/oauth2_github.rs
+++ b/crates/authkestra-axum/examples/oauth2_github.rs
@@ -6,9 +6,9 @@
 //! - `AUTHKESTRA_GITHUB_CLIENT_ID`
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
-use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
+use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_engine::{AkWebAppEngine, SessionConfig};
 use authkestra_providers::github::GithubProvider;
 use axum::{

--- a/crates/authkestra-axum/examples/oauth_stateless.rs
+++ b/crates/authkestra-axum/examples/oauth_stateless.rs
@@ -7,8 +7,8 @@
 //! - `AUTHKESTRA_GITHUB_CLIENT_ID`
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
-use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_axum::{helpers, AuthToken, AxumError, AxumState};
+use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_engine::{token::TokenManager, AkApiEngine, Configured, Missing};
 use authkestra_providers::github::GithubProvider;
 use axum::{

--- a/crates/authkestra-axum/examples/oauth_stateless.rs
+++ b/crates/authkestra-axum/examples/oauth_stateless.rs
@@ -7,7 +7,7 @@
 //! - `AUTHKESTRA_GITHUB_CLIENT_ID`
 //! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
 
-use authkestra::flow::{Engine, OAuth2Flow};
+use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_axum::{helpers, AuthToken, AxumError, AxumState};
 use authkestra_engine::{token::TokenManager, AkApiEngine, Configured, Missing};
 use authkestra_providers::github::GithubProvider;

--- a/crates/authkestra-axum/examples/oidc_google.rs
+++ b/crates/authkestra-axum/examples/oidc_google.rs
@@ -6,9 +6,9 @@
 //! - `AUTHKESTRA_GOOGLE_CLIENT_ID`
 //! - `AUTHKESTRA_GOOGLE_CLIENT_SECRET`
 
-use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
+use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_engine::{AkWebAppEngine, SessionConfig};
 use authkestra_providers::google::GoogleProvider;
 use axum::{

--- a/crates/authkestra-axum/examples/oidc_google.rs
+++ b/crates/authkestra-axum/examples/oidc_google.rs
@@ -6,7 +6,7 @@
 //! - `AUTHKESTRA_GOOGLE_CLIENT_ID`
 //! - `AUTHKESTRA_GOOGLE_CLIENT_SECRET`
 
-use authkestra::flow::{Engine, OAuth2Flow};
+use authkestra_engine::flow::{Engine, OAuth2Flow};
 use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::{AkWebAppEngine, SessionConfig};

--- a/crates/authkestra-axum/examples/session_redis.rs
+++ b/crates/authkestra-axum/examples/session_redis.rs
@@ -6,7 +6,7 @@
 //! - A running Redis instance
 //! - `REDIS_URL` environment variable (e.g., `redis://127.0.0.1/`)
 
-use authkestra::flow::Engine;
+use authkestra_engine::flow::Engine;
 use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::store::redis::RedisStore;

--- a/crates/authkestra-axum/examples/session_redis.rs
+++ b/crates/authkestra-axum/examples/session_redis.rs
@@ -6,9 +6,9 @@
 //! - A running Redis instance
 //! - `REDIS_URL` environment variable (e.g., `redis://127.0.0.1/`)
 
-use authkestra_engine::flow::Engine;
 use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
+use authkestra_engine::flow::Engine;
 use authkestra_engine::store::redis::RedisStore;
 use authkestra_engine::{AkWebAppEngine, SessionConfig};
 use axum::{

--- a/crates/authkestra-axum/examples/sql_store.rs
+++ b/crates/authkestra-axum/examples/sql_store.rs
@@ -4,9 +4,9 @@
 //! This example demonstrates how to use `SqlKvStore` (with SQLite) as a session store with Axum.
 //! It also demonstrates how to manage the database table lifecycle by calling `.migrate().await`.
 
-use authkestra_engine::flow::Engine;
 use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
+use authkestra_engine::flow::Engine;
 use authkestra_engine::store::sql::SqlKvStore;
 use authkestra_engine::{AkWebAppEngine, SessionConfig};
 use axum::{

--- a/crates/authkestra-axum/examples/sql_store.rs
+++ b/crates/authkestra-axum/examples/sql_store.rs
@@ -4,7 +4,7 @@
 //! This example demonstrates how to use `SqlKvStore` (with SQLite) as a session store with Axum.
 //! It also demonstrates how to manage the database table lifecycle by calling `.migrate().await`.
 
-use authkestra::flow::Engine;
+use authkestra_engine::flow::Engine;
 use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
 use authkestra_engine::auth::SessionStore;
 use authkestra_engine::store::sql::SqlKvStore;

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,3 @@
+[workspace]
+git_release_name = "v{{ version }}"
+git_tag_name = "v{{ version }}"


### PR DESCRIPTION
Just like `authkestra-engine`, the `authkestra-axum` and `authkestra-actix` adapters had a circular dev-dependency on the root `authkestra` crate. This fixes the publish workflow for these adapters!