### PR TITLE
chore(release): use a single unified tag for the workspace

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,3 @@
+[workspace]
+git_release_name = "v{{ version }}"
+git_tag_name = "v{{ version }}"


### PR DESCRIPTION
By default, `release-plz` creates a tag for every crate individually (e.g., `authkestra-resource-v0.2.5`). Since our entire workspace shares a single unified version (`0.2.5`), this PR configures `release-plz` to use a single simple tag (`v0.2.5`) for everything instead.