### PR TITLE
fix: change workspace dev-dependencies to path-only

### DIFF
--- a/crates/authkestra-actix/Cargo.toml
+++ b/crates/authkestra-actix/Cargo.toml
@@ -32,12 +32,12 @@ http = "1"
 [dev-dependencies]
 
 
-authkestra-engine = { workspace = true, features = ["token", "session", "memory", "redis", "sql-sqlite", "totp", "webauthn"] }
-authkestra-resource = { workspace = true }
-authkestra-providers = { workspace = true, features = ["github", "google", "discord"] }
-authkestra-oidc = { workspace = true }
-authkestra-op = { workspace = true, features = ["sqlx-sqlite"] }
-authkestra-macros = { workspace = true }
+authkestra-engine = { path = "../authkestra-engine", features = ["token", "session", "memory", "redis", "sql-sqlite", "totp", "webauthn"] }
+authkestra-resource = { path = "../authkestra-resource" }
+authkestra-providers = { path = "../authkestra-providers", features = ["github", "google", "discord"] }
+authkestra-oidc = { path = "../authkestra-oidc" }
+authkestra-op = { path = "../authkestra-op", features = ["sqlx-sqlite"] }
+authkestra-macros = { path = "../authkestra-macros" }
 dotenvy = "0.15"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
 redis = { version = "0.27", features = ["tokio-comp"] }

--- a/crates/authkestra-axum/Cargo.toml
+++ b/crates/authkestra-axum/Cargo.toml
@@ -36,12 +36,12 @@ bytes = { version = "1", optional = true }
 [dev-dependencies]
 
 
-authkestra-engine = { workspace = true, features = ["token", "session", "memory", "redis", "sql-sqlite", "totp", "webauthn"] }
-authkestra-resource = { workspace = true }
-authkestra-providers = { workspace = true, features = ["github", "google", "discord"] }
-authkestra-oidc = { workspace = true }
-authkestra-op = { workspace = true, features = ["sqlx-sqlite"] }
-authkestra-macros = { workspace = true }
+authkestra-engine = { path = "../authkestra-engine", features = ["token", "session", "memory", "redis", "sql-sqlite", "totp", "webauthn"] }
+authkestra-resource = { path = "../authkestra-resource" }
+authkestra-providers = { path = "../authkestra-providers", features = ["github", "google", "discord"] }
+authkestra-oidc = { path = "../authkestra-oidc" }
+authkestra-op = { path = "../authkestra-op", features = ["sqlx-sqlite"] }
+authkestra-macros = { path = "../authkestra-macros" }
 dotenvy = "0.15"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
 redis = { version = "0.27", features = ["tokio-comp"] }


### PR DESCRIPTION
Even with `publish_no_verify = true`, `cargo package` parses `workspace = true` dev-dependencies into strict registry requirements during the `Updating crates.io index` phase. This causes `cargo publish` to fail immediately because it requires unpublished peer crates (like `authkestra-oidc`) to exist on crates.io before `authkestra-axum` can be packaged.

By changing these to `path` dependencies without a version, Cargo treats them strictly as local development tools and strips them out of the published `.crate` file's metadata requirements entirely. This completely resolves the publish cycle lock.