### PR TITLE
chore: rollback workspace version to 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authkestra"
-version = "0.2.5"
+version = "0.2.4"
 dependencies = [
  "authkestra-actix",
  "authkestra-axum",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-actix"
-version = "0.2.5"
+version = "0.2.4"
 dependencies = [
  "actix-files",
  "actix-utils",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-axum"
-version = "0.2.5"
+version = "0.2.4"
 dependencies = [
  "actix-files",
  "async-trait",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-devsig"
-version = "0.2.5"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-engine"
-version = "0.2.5"
+version = "0.2.4"
 dependencies = [
  "actix-files",
  "aes-gcm",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-macros"
-version = "0.2.5"
+version = "0.2.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-oidc"
-version = "0.2.5"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "authkestra-engine",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-op"
-version = "0.2.5"
+version = "0.2.4"
 dependencies = [
  "argon2",
  "async-trait",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-providers"
-version = "0.2.5"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "authkestra-engine",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "authkestra-resource"
-version = "0.2.5"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "authkestra-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.2.5"
+version = "0.2.4"
 repository = "https://github.com/marcjazz/authkestra"
 license = "MIT OR Apache-2.0"
 keywords = ["auth", "authentication", "oauth2", "oidc"]
@@ -38,17 +38,17 @@ exclude = [
 ]
 
 [workspace.dependencies]
-authkestra-engine = { version = "0.2.5", path = "crates/authkestra-engine" }
-authkestra-providers = { version = "0.2.5", path = "crates/authkestra-providers" }
-authkestra-axum = { version = "0.2.5", path = "crates/authkestra-axum" }
-authkestra-macros = { version = "0.2.5", path = "crates/authkestra-macros" }
-authkestra-oidc = { version = "0.2.5", path = "crates/authkestra-oidc" }
-authkestra-actix = { version = "0.2.5", path = "crates/authkestra-actix" }
-authkestra-resource = { version = "0.2.5", path = "crates/authkestra-resource" }
-authkestra = { version = "0.2.5", path = "crates/authkestra" }
+authkestra-engine = { version = "0.2.4", path = "crates/authkestra-engine" }
+authkestra-providers = { version = "0.2.4", path = "crates/authkestra-providers" }
+authkestra-axum = { version = "0.2.4", path = "crates/authkestra-axum" }
+authkestra-macros = { version = "0.2.4", path = "crates/authkestra-macros" }
+authkestra-oidc = { version = "0.2.4", path = "crates/authkestra-oidc" }
+authkestra-actix = { version = "0.2.4", path = "crates/authkestra-actix" }
+authkestra-resource = { version = "0.2.4", path = "crates/authkestra-resource" }
+authkestra = { version = "0.2.4", path = "crates/authkestra" }
 
-authkestra-op = { version = "0.2.5", path = "crates/authkestra-op" }
-authkestra-devsig = { version = "0.2.5", path = "crates/authkestra-devsig" }
+authkestra-op = { version = "0.2.4", path = "crates/authkestra-op" }
+authkestra-devsig = { version = "0.2.4", path = "crates/authkestra-devsig" }
 rand = "0.9.2"
 url = "2.5"
 sha2 = "0.10"

--- a/crates/authkestra-actix/Cargo.toml
+++ b/crates/authkestra-actix/Cargo.toml
@@ -32,12 +32,12 @@ http = "1"
 [dev-dependencies]
 
 
-authkestra-engine = { workspace = true, features = ["token", "session", "memory", "redis", "sql-sqlite", "totp", "webauthn"] }
-authkestra-resource = { workspace = true }
-authkestra-providers = { workspace = true, features = ["github", "google", "discord"] }
-authkestra-oidc = { workspace = true }
-authkestra-op = { workspace = true, features = ["sqlx-sqlite"] }
-authkestra-macros = { workspace = true }
+authkestra-engine = { path = "../authkestra-engine", features = ["token", "session", "memory", "redis", "sql-sqlite", "totp", "webauthn"] }
+authkestra-resource = { path = "../authkestra-resource" }
+authkestra-providers = { path = "../authkestra-providers", features = ["github", "google", "discord"] }
+authkestra-oidc = { path = "../authkestra-oidc" }
+authkestra-op = { path = "../authkestra-op", features = ["sqlx-sqlite"] }
+authkestra-macros = { path = "../authkestra-macros" }
 dotenvy = "0.15"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
 redis = { version = "0.27", features = ["tokio-comp"] }

--- a/crates/authkestra-axum/Cargo.toml
+++ b/crates/authkestra-axum/Cargo.toml
@@ -36,12 +36,12 @@ bytes = { version = "1", optional = true }
 [dev-dependencies]
 
 
-authkestra-engine = { workspace = true, features = ["token", "session", "memory", "redis", "sql-sqlite", "totp", "webauthn"] }
-authkestra-resource = { workspace = true }
-authkestra-providers = { workspace = true, features = ["github", "google", "discord"] }
-authkestra-oidc = { workspace = true }
-authkestra-op = { workspace = true, features = ["sqlx-sqlite"] }
-authkestra-macros = { workspace = true }
+authkestra-engine = { path = "../authkestra-engine", features = ["token", "session", "memory", "redis", "sql-sqlite", "totp", "webauthn"] }
+authkestra-resource = { path = "../authkestra-resource" }
+authkestra-providers = { path = "../authkestra-providers", features = ["github", "google", "discord"] }
+authkestra-oidc = { path = "../authkestra-oidc" }
+authkestra-op = { path = "../authkestra-op", features = ["sqlx-sqlite"] }
+authkestra-macros = { path = "../authkestra-macros" }
 dotenvy = "0.15"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
 redis = { version = "0.27", features = ["tokio-comp"] }


### PR DESCRIPTION
Reverts the workspace version back to 0.2.4 as requested.