### PR TITLE
fix: remove global git tag configuration in release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,3 @@
 [workspace]
-git_release_name = "v{{ version }}"
-git_tag_name = "v{{ version }}"
 publish_no_verify = true
 release_commits = "^(feat|fix|perf|refactor|revert)"


### PR DESCRIPTION
Remove `git_tag_name = \"v{{ version }}\"` to allow per-crate tags and prevent tag conflicts during publish