### PR TITLE
fix(deps): let consumers choose the TLS backend instead of forcing aws-lc-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,17 +38,21 @@ exclude = [
 ]
 
 [workspace.dependencies]
-authkestra-engine = { version = "0.3.2", path = "crates/authkestra-engine" }
-authkestra-providers = { version = "0.3.2", path = "crates/authkestra-providers" }
-authkestra-axum = { version = "0.3.2", path = "crates/authkestra-axum" }
-authkestra-macros = { version = "0.3.0", path = "crates/authkestra-macros" }
-authkestra-oidc = { version = "0.3.2", path = "crates/authkestra-oidc" }
-authkestra-actix = { version = "0.3.2", path = "crates/authkestra-actix" }
-authkestra-resource = { version = "0.3.2", path = "crates/authkestra-resource" }
-authkestra = { version = "0.3.2", path = "crates/authkestra" }
+# `default-features = false` here so that a member crate can turn the default
+# features of a sibling off. Cargo ignores `default-features = false` on an
+# inherited dependency unless the workspace entry sets it too, which is what
+# lets the TLS-backend choice below reach every crate in the graph.
+authkestra-engine = { version = "0.3.2", path = "crates/authkestra-engine", default-features = false }
+authkestra-providers = { version = "0.3.2", path = "crates/authkestra-providers", default-features = false }
+authkestra-axum = { version = "0.3.2", path = "crates/authkestra-axum", default-features = false }
+authkestra-macros = { version = "0.3.0", path = "crates/authkestra-macros", default-features = false }
+authkestra-oidc = { version = "0.3.2", path = "crates/authkestra-oidc", default-features = false }
+authkestra-actix = { version = "0.3.2", path = "crates/authkestra-actix", default-features = false }
+authkestra-resource = { version = "0.3.2", path = "crates/authkestra-resource", default-features = false }
+authkestra = { version = "0.3.2", path = "crates/authkestra", default-features = false }
 
-authkestra-op = { version = "0.3.2", path = "crates/authkestra-op" }
-authkestra-devsig = { version = "0.3.2", path = "crates/authkestra-devsig" }
+authkestra-op = { version = "0.3.2", path = "crates/authkestra-op", default-features = false }
+authkestra-devsig = { version = "0.3.2", path = "crates/authkestra-devsig", default-features = false }
 rand = "0.9.2"
 url = "2.5"
 sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,40 @@ authkestra = { version = "0.3", features = ["axum", "github"] }
 
 For advanced users, individual crates are still available and can be used independently if preferred.
 
+### 🔐 TLS backend
+
+Authkestra talks to identity providers over HTTPS, so it needs a TLS backend. It
+is selected by a feature flag rather than by `reqwest`'s defaults, so you can
+choose the crypto provider yourself:
+
+| Feature | Backend | Notes |
+| --- | --- | --- |
+| `rustls-aws-lc-rs` | rustls + [`aws-lc-rs`](https://crates.io/crates/aws-lc-rs) | **Default.** Compiles C and assembly, so it needs a C toolchain. |
+| `rustls-no-provider` | rustls, provider chosen by you | Pure-Rust builds (`ring`), `*-unknown-linux-musl`, `cargo-deny` policies that ban `aws-lc-rs`. |
+
+The default keeps the historical behaviour, so no change is needed unless you
+want to get off `aws-lc-rs`. To do that, turn the default off and install a
+provider yourself:
+
+```toml
+[dependencies]
+authkestra = { version = "0.3", default-features = false, features = ["axum", "github", "rustls-no-provider"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
+```
+
+```rust,ignore
+// Must run before any Authkestra call that builds an HTTP client,
+// otherwise reqwest panics at client construction.
+rustls::crypto::ring::default_provider()
+    .install_default()
+    .expect("failed to install rustls crypto provider");
+```
+
+Every Authkestra crate that speaks HTTPS exposes the same two features and
+forwards them to `authkestra-engine`. Cargo features are additive, so if any
+crate in your graph still enables `rustls-aws-lc-rs`, `aws-lc-rs` comes back —
+check with `cargo tree -i aws-lc-rs -e features`.
+
 ## 🚀 Features
 
 - **Modular & Unified Core**: Following our RFC-001 architecture, core concerns are unified in `authkestra-engine` while adapters like `authkestra-axum` and `authkestra-actix` provide seamless framework integrations.

--- a/crates/authkestra-actix/Cargo.toml
+++ b/crates/authkestra-actix/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 readme = "README.md"
 
 [dependencies]
-authkestra-engine = { workspace = true }
-authkestra-resource = { workspace = true, optional = true }
-authkestra-op = { workspace = true, optional = true }
+authkestra-engine = { workspace = true, default-features = false, features = ["token"] }
+authkestra-resource = { workspace = true, optional = true, default-features = false }
+authkestra-op = { workspace = true, optional = true, default-features = false }
 authkestra-macros = { workspace = true, optional = true, features = ["actix"] }
 authkestra-devsig = { workspace = true, optional = true }
 actix-web = "4"
@@ -30,7 +30,7 @@ tracing = "0.1"
 http = "1"
 
 [features]
-default = []
+default = ["rustls-aws-lc-rs"]
 session = ["authkestra-engine/session"]
 
 token = ["authkestra-engine/token"]
@@ -39,5 +39,18 @@ op = ["dep:authkestra-op", "session", "token"]
 macros = ["dep:authkestra-macros"]
 captcha = ["authkestra-engine/captcha"]
 devsig = ["dep:authkestra-devsig"]
+
+# TLS backend, forwarded to authkestra-engine. See its documentation for the
+# `rustls-no-provider` contract.
+rustls-aws-lc-rs = [
+    "authkestra-engine/rustls-aws-lc-rs",
+    "authkestra-resource?/rustls-aws-lc-rs",
+    "authkestra-op?/rustls-aws-lc-rs",
+]
+rustls-no-provider = [
+    "authkestra-engine/rustls-no-provider",
+    "authkestra-resource?/rustls-no-provider",
+    "authkestra-op?/rustls-no-provider",
+]
 
 

--- a/crates/authkestra-axum/Cargo.toml
+++ b/crates/authkestra-axum/Cargo.toml
@@ -11,10 +11,10 @@ categories.workspace = true
 readme = "README.md"
 
 [dependencies]
-authkestra-engine = { workspace = true }
-authkestra-resource = { workspace = true, optional = true }
+authkestra-engine = { workspace = true, default-features = false, features = ["token"] }
+authkestra-resource = { workspace = true, optional = true, default-features = false }
 authkestra-macros = { workspace = true, optional = true, features = ["axum"] }
-authkestra-op = { workspace = true, optional = true }
+authkestra-op = { workspace = true, optional = true, default-features = false }
 authkestra-devsig = { workspace = true, optional = true }
 axum = { version = "0.8.8", features = ["macros"] }
 jsonwebtoken = "11"
@@ -36,7 +36,7 @@ bytes = { version = "1", optional = true }
 
 
 [features]
-default = ["macros"]
+default = ["macros", "rustls-aws-lc-rs"]
 macros = ["authkestra-macros"]
 session = ["authkestra-engine/session"]
 
@@ -50,6 +50,19 @@ devsig = [
     "dep:tower-service",
     "dep:http-body-util",
     "dep:bytes",
+]
+
+# TLS backend, forwarded to authkestra-engine. See its documentation for the
+# `rustls-no-provider` contract.
+rustls-aws-lc-rs = [
+    "authkestra-engine/rustls-aws-lc-rs",
+    "authkestra-resource?/rustls-aws-lc-rs",
+    "authkestra-op?/rustls-aws-lc-rs",
+]
+rustls-no-provider = [
+    "authkestra-engine/rustls-no-provider",
+    "authkestra-resource?/rustls-no-provider",
+    "authkestra-op?/rustls-no-provider",
 ]
 
 

--- a/crates/authkestra-engine/Cargo.toml
+++ b/crates/authkestra-engine/Cargo.toml
@@ -11,7 +11,15 @@ readme.workspace = true
 [dependencies]
 # From authkestra-core
 serde = { version = "1.0", features = ["derive"] }
-reqwest = { version = "0.13.1", features = ["json", "form"] }
+# The TLS backend is selected by the `rustls-*` features below, not by
+# reqwest's defaults, so consumers can pick their own crypto provider.
+reqwest = { version = "0.13.1", default-features = false, features = [
+    "json",
+    "form",
+    "charset",
+    "http2",
+    "system-proxy",
+] }
 url = { workspace = true }
 http = "1"
 thiserror = "2.0.18"
@@ -38,8 +46,27 @@ webauthn-rs = { version = "0.5.0", optional = true, features = ["danger-allow-st
 totp-rs = { version = "5.7", features = ["gen_secret", "otpauth"], optional = true }
 
 [features]
-default = ["token"]
+default = ["token", "rustls-aws-lc-rs"]
 token = []
+
+# TLS backend for the outbound HTTP client. Exactly one of these must be
+# enabled; the crate does not compile without a backend.
+#
+# `rustls-aws-lc-rs` is the default and keeps the historical behaviour
+# (rustls with the `aws-lc-rs` provider, which builds C and assembly).
+#
+# `rustls-no-provider` leaves the choice of `rustls::CryptoProvider` to the
+# application, which lets it use a pure-Rust provider such as `ring`. The
+# application MUST install a provider before any `reqwest::Client` is built,
+# otherwise reqwest panics at client construction:
+#
+# ```rust,ignore
+# rustls::crypto::ring::default_provider()
+#     .install_default()
+#     .expect("failed to install rustls crypto provider");
+# ```
+rustls-aws-lc-rs = ["reqwest/rustls"]
+rustls-no-provider = ["reqwest/rustls-no-provider"]
 
 session = []
 memory = []
@@ -57,7 +84,7 @@ captcha = []
 dotenvy = "0.15"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
 redis = { version = "0.27", features = ["tokio-comp"] }
-reqwest = { version = "0.13", features = ["json"] }
+reqwest = { version = "0.13", default-features = false, features = ["json"] }
 tower-http = { version = "0.6", features = ["fs"] }
 actix-files = "0.6"
 

--- a/crates/authkestra-engine/src/lib.rs
+++ b/crates/authkestra-engine/src/lib.rs
@@ -1,3 +1,11 @@
+// The outbound HTTP client needs a TLS backend. Fail loudly at compile time
+// rather than letting `reqwest::Client::new()` panic at runtime.
+#[cfg(not(any(feature = "rustls-aws-lc-rs", feature = "rustls-no-provider")))]
+compile_error!(
+    "authkestra-engine needs a TLS backend: enable the `rustls-aws-lc-rs` feature (the default) \
+     or the `rustls-no-provider` feature and install a `rustls::CryptoProvider` yourself."
+);
+
 pub mod auth;
 pub mod engine;
 pub mod flow;

--- a/crates/authkestra-oidc/Cargo.toml
+++ b/crates/authkestra-oidc/Cargo.toml
@@ -11,9 +11,15 @@ categories.workspace = true
 readme = "README.md"
 
 [dependencies]
-authkestra-engine = { workspace = true, features = ["token"] }
-authkestra-resource = { workspace = true }
-reqwest = { version = "0.13.1", features = ["json"] }
+authkestra-engine = { workspace = true, default-features = false, features = ["token"] }
+authkestra-resource = { workspace = true, default-features = false }
+# TLS backend comes from authkestra-engine's `rustls-*` features (see below).
+reqwest = { version = "0.13.1", default-features = false, features = [
+    "json",
+    "charset",
+    "http2",
+    "system-proxy",
+] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0.18"
@@ -22,6 +28,20 @@ tracing = "0.1"
 tokio = { version = "1.0", features = ["full"] }
 jsonwebtoken = { version = "11", features = ["rust_crypto"] }
 urlencoding = "2.1.3"
+
+[features]
+default = ["rustls-aws-lc-rs"]
+
+# TLS backend, forwarded to authkestra-engine. See its documentation for the
+# `rustls-no-provider` contract.
+rustls-aws-lc-rs = [
+    "authkestra-engine/rustls-aws-lc-rs",
+    "authkestra-resource/rustls-aws-lc-rs",
+]
+rustls-no-provider = [
+    "authkestra-engine/rustls-no-provider",
+    "authkestra-resource/rustls-no-provider",
+]
 
 [dev-dependencies]
 wiremock = "0.6.5"

--- a/crates/authkestra-op/Cargo.toml
+++ b/crates/authkestra-op/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-authkestra-engine = { workspace = true, features = ["token", "memory"] }
-authkestra-resource = { workspace = true }
+authkestra-engine = { workspace = true, default-features = false, features = ["token", "memory"] }
+authkestra-resource = { workspace = true, default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0.18"
@@ -29,10 +29,23 @@ argon2 = "0.5.3"
 sqlx = { version = "0.8", optional = true, features = ["runtime-tokio", "json", "chrono"] }
 
 [features]
+default = ["rustls-aws-lc-rs"]
+
 sqlx = ["dep:sqlx"]
 sqlx-postgres = ["sqlx", "sqlx/postgres"]
 sqlx-sqlite = ["sqlx", "sqlx/sqlite"]
 sqlx-mysql = ["sqlx", "sqlx/mysql"]
+
+# TLS backend, forwarded to authkestra-engine. See its documentation for the
+# `rustls-no-provider` contract.
+rustls-aws-lc-rs = [
+    "authkestra-engine/rustls-aws-lc-rs",
+    "authkestra-resource/rustls-aws-lc-rs",
+]
+rustls-no-provider = [
+    "authkestra-engine/rustls-no-provider",
+    "authkestra-resource/rustls-no-provider",
+]
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }

--- a/crates/authkestra-providers/Cargo.toml
+++ b/crates/authkestra-providers/Cargo.toml
@@ -11,15 +11,27 @@ categories.workspace = true
 readme.workspace = true
 
 [features]
-default = []
+default = ["rustls-aws-lc-rs"]
 github = []
 google = []
 discord = ["urlencoding"]
 
+# TLS backend, forwarded to authkestra-engine. See its documentation for the
+# `rustls-no-provider` contract.
+rustls-aws-lc-rs = ["authkestra-engine/rustls-aws-lc-rs"]
+rustls-no-provider = ["authkestra-engine/rustls-no-provider"]
+
 [dependencies]
-authkestra-engine = { workspace = true }
+authkestra-engine = { workspace = true, default-features = false, features = ["token"] }
 async-trait = "0.1"
-reqwest = { version = "0.13.1", features = ["json", "form"] }
+# TLS backend comes from authkestra-engine's `rustls-*` features (see above).
+reqwest = { version = "0.13.1", default-features = false, features = [
+    "json",
+    "form",
+    "charset",
+    "http2",
+    "system-proxy",
+] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 urlencoding = { version = "2.1", optional = true }

--- a/crates/authkestra-resource/Cargo.toml
+++ b/crates/authkestra-resource/Cargo.toml
@@ -11,16 +11,30 @@ categories.workspace = true
 readme = "README.md"
 
 [dependencies]
-authkestra-engine = { workspace = true }
+authkestra-engine = { workspace = true, default-features = false, features = ["token"] }
 async-trait = "0.1"
 jsonwebtoken = { version = "11", features = ["rust_crypto"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.13.1", features = ["json"] }
+# TLS backend comes from authkestra-engine's `rustls-*` features (see below).
+reqwest = { version = "0.13.1", default-features = false, features = [
+    "json",
+    "charset",
+    "http2",
+    "system-proxy",
+] }
 tokio = { version = "1.0", features = ["full"] }
 thiserror = "2.0.18"
 http = "1"
 base64 = "0.22.1"
+
+[features]
+default = ["rustls-aws-lc-rs"]
+
+# TLS backend, forwarded to authkestra-engine. See its documentation for the
+# `rustls-no-provider` contract.
+rustls-aws-lc-rs = ["authkestra-engine/rustls-aws-lc-rs"]
+rustls-no-provider = ["authkestra-engine/rustls-no-provider"]
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/crates/authkestra/Cargo.toml
+++ b/crates/authkestra/Cargo.toml
@@ -11,15 +11,15 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-authkestra-engine = { workspace = true }
-authkestra-oidc = { workspace = true, optional = true }
-authkestra-axum = { workspace = true, optional = true }
-authkestra-actix = { workspace = true, optional = true }
-authkestra-providers = { workspace = true, optional = true }
-authkestra-resource = { workspace = true, optional = true }
+authkestra-engine = { workspace = true, default-features = false, features = ["token"] }
+authkestra-oidc = { workspace = true, optional = true, default-features = false }
+authkestra-axum = { workspace = true, optional = true, default-features = false }
+authkestra-actix = { workspace = true, optional = true, default-features = false }
+authkestra-providers = { workspace = true, optional = true, default-features = false }
+authkestra-resource = { workspace = true, optional = true, default-features = false }
 
 [dev-dependencies]
-reqwest = { version = "0.13", features = ["json"] }
+reqwest = { version = "0.13", default-features = false, features = ["json"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
 wiremock = "0.6"
@@ -60,8 +60,27 @@ uuid = { version = "1.0", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 [features]
-default = []
+default = ["rustls-aws-lc-rs"]
 full = ["session", "token", "oidc", "axum", "actix", "github", "google", "discord"]
+
+# TLS backend, forwarded to every sub-crate that speaks HTTPS. See
+# authkestra-engine's documentation for the `rustls-no-provider` contract.
+rustls-aws-lc-rs = [
+    "authkestra-engine/rustls-aws-lc-rs",
+    "authkestra-oidc?/rustls-aws-lc-rs",
+    "authkestra-axum?/rustls-aws-lc-rs",
+    "authkestra-actix?/rustls-aws-lc-rs",
+    "authkestra-providers?/rustls-aws-lc-rs",
+    "authkestra-resource?/rustls-aws-lc-rs",
+]
+rustls-no-provider = [
+    "authkestra-engine/rustls-no-provider",
+    "authkestra-oidc?/rustls-no-provider",
+    "authkestra-axum?/rustls-no-provider",
+    "authkestra-actix?/rustls-no-provider",
+    "authkestra-providers?/rustls-no-provider",
+    "authkestra-resource?/rustls-no-provider",
+]
 
 # Core features
 
@@ -71,7 +90,7 @@ oidc = ["dep:authkestra-oidc"]
 resource = ["dep:authkestra-resource", "authkestra-actix?/resource", "authkestra-axum?/resource"]
 
 # Web frameworks
-axum = ["dep:authkestra-axum", "authkestra-axum/session", "authkestra-axum/token", "authkestra-axum/resource"]
+axum = ["dep:authkestra-axum", "authkestra-axum/macros", "authkestra-axum/session", "authkestra-axum/token", "authkestra-axum/resource"]
 actix = ["dep:authkestra-actix", "authkestra-actix/session", "authkestra-actix/token", "authkestra-actix/resource"]
 
 # Providers


### PR DESCRIPTION
Closes #178.

## Problem

Four crates declared `reqwest` with default features:

| Crate | Line |
| --- | --- |
| `authkestra-engine` | `reqwest = { version = "0.13.1", features = ["json", "form"] }` |
| `authkestra-oidc` | `reqwest = { version = "0.13.1", features = ["json"] }` |
| `authkestra-providers` | `reqwest = { version = "0.13.1", features = ["json", "form"] }` |
| `authkestra-resource` | `reqwest = { version = "0.13.1", features = ["json"] }` |

reqwest 0.13's `default` includes `default-tls` → `rustls` → `__rustls-aws-lc-rs`, so **`aws-lc-rs` landed in every consumer's graph**. Because Cargo features are additive and unified, a downstream crate could not opt out — `default-features = false` on its *own* reqwest doesn't undo what authkestra asks for. That blocks static `*-unknown-linux-musl` / `scratch` builds and any `cargo-deny` policy that bans `aws-lc-rs`.

The issue only named `authkestra-engine`; it was actually all four.

## Fix

1. **`default-features = false` on every `reqwest` entry**, re-adding the non-TLS defaults reqwest was quietly providing (`charset`, `http2`, `system-proxy`) so nothing else changes behaviour.
2. **The TLS backend becomes a feature**, and every HTTPS-speaking crate forwards it to `authkestra-engine`:
   - `rustls-aws-lc-rs` — **default**, rustls + `aws-lc-rs`, byte-for-byte today's behaviour
   - `rustls-no-provider` — rustls with the `CryptoProvider` chosen by the application (e.g. `ring`)
3. **`[workspace.dependencies]` now sets `default-features = false`** on the first-party crates. This one is easy to miss: Cargo *silently ignores* `default-features = false` on an inherited dependency unless the workspace entry sets it too (it currently only warns, "could become a hard error in the future"). Without it the facade kept re-enabling the sub-crates' defaults and the opt-out never reached the graph.
4. **`compile_error!` in `authkestra-engine`** when neither backend is selected, so a mis-configured `default-features = false` fails at build time instead of panicking inside `reqwest::Client::new()`.
5. README section documenting the choice.

I kept `rustls-aws-lc-rs` as the default rather than switching to `rustls-no-provider` as the issue suggested: `rustls-no-provider` with no installed provider **panics** at `Client::new()`, so making it the default would turn a silent dependency change into a runtime crash for every existing user. Opt-in is the safe direction here.

### Why not `native-tls`?

It doesn't help the case in the issue — `native-tls` on musl needs vendored OpenSSL, i.e. the C toolchain we were trying to avoid — so I left that surface out.

## Consumer-visible impact

**Nothing changes by default.** `authkestra = { version = "0.3", features = ["axum", "github"] }` resolves to the same graph, `aws-lc-rs` included.

**Breaking only for consumers who already set `default-features = false`** on an authkestra crate. They previously still got TLS (reqwest's defaults were unconditional); now they must name a backend, and the `compile_error!` tells them so.

To get off `aws-lc-rs`:

```toml
[dependencies]
authkestra = { version = "0.3", default-features = false, features = ["axum", "github", "rustls-no-provider"] }
rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
```

```rust
rustls::crypto::ring::default_provider()
    .install_default()
    .expect("failed to install rustls crypto provider");
```

The usual additive-features caveat applies: if anything in the graph still enables `rustls-aws-lc-rs`, it comes back. `cargo tree -i aws-lc-rs -e features` shows who.

## Verification

Workspace, on this branch:

```console
$ cargo fmt --all -- --check                                            # exit 0
$ cargo clippy --workspace --all-targets --all-features -- -D warnings  # exit 0
$ cargo test --workspace --all-features                                 # exit 0, 197 passed / 0 failed
$ cargo test --workspace --no-run                                       # exit 0 (default features)
```

(`docker compose up -d` first, for the testcontainers-backed tests.)

Throwaway consumer crates against this branch:

```console
# depends on authkestra-engine, default features
$ cargo tree -i aws-lc-rs
aws-lc-rs v1.17.3 …                                       # unchanged, as intended

# depends on authkestra { default-features = false, features = ["full", "rustls-no-provider"] }
$ cargo tree -i aws-lc-rs
error: package ID specification `aws-lc-rs` did not match any packages

# depends on authkestra-engine { default-features = false, features = ["token", "rustls-no-provider"] }
$ cargo tree -i aws-lc-rs
error: package ID specification `aws-lc-rs` did not match any packages

# neither backend selected
$ cargo check
error: authkestra-engine needs a TLS backend: enable the `rustls-aws-lc-rs` feature (the default)
       or the `rustls-no-provider` feature and install a `rustls::CryptoProvider` yourself.
```

The `full` + `rustls-no-provider` consumer also builds and does real HTTPS on `ring`:

```console
$ cargo run
https via ring -> Ok(403)      # 403 is crates.io rejecting the empty UA; the handshake succeeded
```

…and cross-compiles to musl (`rust:alpine`, `apk add musl-dev`, no cmake, no C toolchain beyond musl-dev):

```console
$ cargo tree -i aws-lc-rs
error: package ID specification `aws-lc-rs` did not match any packages
$ cargo build --release
    Finished `release` profile [optimized] target(s) in 2m 14s
$ ldd target/release/c2
/lib/ld-musl-aarch64.so.1: …: Not a valid dynamic program     # statically linked
```

## Reviewer focus

- The `[workspace.dependencies] default-features = false` change is the load-bearing part and the least obvious — worth a second look.
- `authkestra`'s `axum` feature gained `"authkestra-axum/macros"`. `authkestra-axum`'s `default` is `["macros"]`, and the facade used to pick that up implicitly; now that it depends on it with `default-features = false`, the macros have to be named. `authkestra-actix`'s default was `[]`, so no equivalent line there.
- Feature lists are ordered so the TLS block sits at the end of each `[features]` table; the rest of the table is untouched.

---
AI assistance: drafted with Claude, reviewed and verified by me — every command above was run locally and the outputs are real, not reconstructed.
