### PR TITLE
fix(engine): derive the asymmetric decoding key from the public half

### DIFF
--- a/crates/authkestra-engine/src/token/mod.rs
+++ b/crates/authkestra-engine/src/token/mod.rs
@@ -61,8 +61,6 @@ impl TokenManager {
     ) -> Result<Self, AuthError> {
         let encoding_key = EncodingKey::from_rsa_pem(private_key_pem)
             .map_err(|e| AuthError::Token(e.to_string()))?;
-        let decoding_key = DecodingKey::from_rsa_pem(private_key_pem)
-            .map_err(|e| AuthError::Token(e.to_string()))?;
 
         let pem_str = std::str::from_utf8(private_key_pem)
             .map_err(|_| AuthError::Token("Invalid PEM UTF-8".into()))?;
@@ -88,6 +86,12 @@ impl TokenManager {
             n: Some(n),
             e: Some(e),
         };
+
+        // The decoding key must come from the PUBLIC half. `DecodingKey::from_rsa_pem`
+        // expects a public-key PEM; handed a private one it still constructs, but every
+        // later `validate_token` fails with `InvalidSignature`. Deriving it from the JWK
+        // we just built keeps both halves provably in sync with what `/jwks` publishes.
+        let decoding_key = jwk.to_decoding_key()?;
 
         Ok(Self {
             encoding_key,
@@ -333,6 +337,36 @@ mod tests {
     use crate::auth::state::Identity;
     use std::collections::HashMap;
 
+    /// Throwaway RSA-2048 private key, test-only.
+    const TEST_RSA_PRIVATE_KEY_PEM: &[u8] = b"-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDA5hJIcQ+2rxMz
+VM8ZH5WAmguCr0xmNDAdy0IzzsUeFLG7BebB7izOkU36J4t8t5tUaQwrBMnx2Fvt
+VqJjbdE242UDpvWF/8m9zJ2HR5298cbwT5cGMKLB0HWzDMahugs+Bbh2lCgwyLZk
+Tr3Diwxp5SwFew/Wb+Ke9cNG9Hu5IFH3BCuJ839d9hfqisIeYrBPfb52xxckM37R
+7zSGu/eDP/HZAeLkQuptZJW4A3u7xni14u4qyqXDqsHsYFNgJaxMSAwWgBRY6HNu
+TnvBArTXCiVfL+F73B2L6mdYr64g+QS9nK9v97MlJu/E3mSduz54pren4mpCHc9m
+/S2+VjCZAgMBAAECggEAASC9qQbGnL7XuExRDOIn/m4bWx92ehjo0lCTibhpY3LW
+umbSbpfbhmmuSj3CjW9VZsaM3hBTgSjoTX72lbY/eIUXD7c0memUK5pV4XcEIrQw
+AZlPIye6ckx4I7ZGnKasO8FoAel9dd7DXw36AuBK3LBzJwtzkEFsBc0e3/wixqmG
+UJBbbt/+5ya7CxyjuePaQhKtkLD5R6DpvN2XnCYq5nHJNJdvSVg1pOzsTHYIf+Ee
+2Rz42fGsfFKqeEQCcBFRZaGb/ELeP4c6UZdktZAvmHb1p1fursVZc6X9JXmiJ2OJ
+Kv2H2tMKuysP8L0fXFOMgkH2SVt6rcdHkO6xhlhWsQKBgQDqR8rAJeEE5BFoXA8T
+VVW6CLMlW51x4ey7PEGOaYh39dTG2Q+GZQBZ9G+SZk3f5Y85UCACSyc//4qaz/c3
+0nWsegZ+JPyymmuc79wzIAFFvXB7pL6wyn0Ed1P620kOZTtA8iBcXrsuxL+KP7iu
+MXfWmU1QiZpbndILtyDnY+70uwKBgQDSyCljWkydQCaPU+fiAXLxP8CvcJTSSNQD
+mVUlwJ+OpHnU+Alsi1rBavMgUtLlYbFqzH7NmYrLC8Yadq3ZOwLt0VEK0r8qstAL
+7QCDUD2WNuQjpZupRnXuMUl3iXB96i2gb+VQKGuUAJvVWjdIbYa4+Gu+sBMfcDcX
+dBihDLuEuwKBgAgX4tEwfc2Fc3R/eaXZVNTQaB/qQk4k1+C//CPHUYeTXn5gEUE7
+S//PiesszZPmgkQgmHp7zidP1KH0fT3Yb2g97ut8q54f54fMYXcCrAiUusYKsuu4
+kwkMdkI8QRHWPW3I74VBYIYFFfjYqrCZ1OH8+cbGeiagFRmCggh8U0zxAoGAVW3u
+6Ge22Z0gg8LcHsu7jG/sZq7Ygool8/d3fT+e669Z+ak2GJo6hF4WgClRdMqtn72W
+PzpV+ImjFyK2v26dd0n48MwN0v56N/ss1Av3iiRhPtlmR6tZLNspDZvUzhPVvkrb
+xCs9vtSoVEamVWKe0eVNthGjDoDqs0TInq2MavUCgYB6REavSJs/CLkSS7iimjxZ
+G7g5YQi9/p1lXLOEUDiwEmvRr0XTwzzxUsIc535IXhh/ZUYpthenW+qBBzn85pEC
+TowIqciHu5redqlQ8rITA8/AOY98vaDIhppDg1rfpnHHaZHFbXD/keYAEbhBtbvf
+a0QMqKUcs8+YTy5R5K6qtw==
+-----END PRIVATE KEY-----";
+
     #[test]
     fn test_claims_serialization() {
         let mut extra = HashMap::new();
@@ -392,37 +426,8 @@ mod tests {
 
     #[test]
     fn test_token_manager_asymmetric_issuance() {
-        let pem = b"-----BEGIN PRIVATE KEY-----
-MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDA5hJIcQ+2rxMz
-VM8ZH5WAmguCr0xmNDAdy0IzzsUeFLG7BebB7izOkU36J4t8t5tUaQwrBMnx2Fvt
-VqJjbdE242UDpvWF/8m9zJ2HR5298cbwT5cGMKLB0HWzDMahugs+Bbh2lCgwyLZk
-Tr3Diwxp5SwFew/Wb+Ke9cNG9Hu5IFH3BCuJ839d9hfqisIeYrBPfb52xxckM37R
-7zSGu/eDP/HZAeLkQuptZJW4A3u7xni14u4qyqXDqsHsYFNgJaxMSAwWgBRY6HNu
-TnvBArTXCiVfL+F73B2L6mdYr64g+QS9nK9v97MlJu/E3mSduz54pren4mpCHc9m
-/S2+VjCZAgMBAAECggEAASC9qQbGnL7XuExRDOIn/m4bWx92ehjo0lCTibhpY3LW
-umbSbpfbhmmuSj3CjW9VZsaM3hBTgSjoTX72lbY/eIUXD7c0memUK5pV4XcEIrQw
-AZlPIye6ckx4I7ZGnKasO8FoAel9dd7DXw36AuBK3LBzJwtzkEFsBc0e3/wixqmG
-UJBbbt/+5ya7CxyjuePaQhKtkLD5R6DpvN2XnCYq5nHJNJdvSVg1pOzsTHYIf+Ee
-2Rz42fGsfFKqeEQCcBFRZaGb/ELeP4c6UZdktZAvmHb1p1fursVZc6X9JXmiJ2OJ
-Kv2H2tMKuysP8L0fXFOMgkH2SVt6rcdHkO6xhlhWsQKBgQDqR8rAJeEE5BFoXA8T
-VVW6CLMlW51x4ey7PEGOaYh39dTG2Q+GZQBZ9G+SZk3f5Y85UCACSyc//4qaz/c3
-0nWsegZ+JPyymmuc79wzIAFFvXB7pL6wyn0Ed1P620kOZTtA8iBcXrsuxL+KP7iu
-MXfWmU1QiZpbndILtyDnY+70uwKBgQDSyCljWkydQCaPU+fiAXLxP8CvcJTSSNQD
-mVUlwJ+OpHnU+Alsi1rBavMgUtLlYbFqzH7NmYrLC8Yadq3ZOwLt0VEK0r8qstAL
-7QCDUD2WNuQjpZupRnXuMUl3iXB96i2gb+VQKGuUAJvVWjdIbYa4+Gu+sBMfcDcX
-dBihDLuEuwKBgAgX4tEwfc2Fc3R/eaXZVNTQaB/qQk4k1+C//CPHUYeTXn5gEUE7
-S//PiesszZPmgkQgmHp7zidP1KH0fT3Yb2g97ut8q54f54fMYXcCrAiUusYKsuu4
-kwkMdkI8QRHWPW3I74VBYIYFFfjYqrCZ1OH8+cbGeiagFRmCggh8U0zxAoGAVW3u
-6Ge22Z0gg8LcHsu7jG/sZq7Ygool8/d3fT+e669Z+ak2GJo6hF4WgClRdMqtn72W
-PzpV+ImjFyK2v26dd0n48MwN0v56N/ss1Av3iiRhPtlmR6tZLNspDZvUzhPVvkrb
-xCs9vtSoVEamVWKe0eVNthGjDoDqs0TInq2MavUCgYB6REavSJs/CLkSS7iimjxZ
-G7g5YQi9/p1lXLOEUDiwEmvRr0XTwzzxUsIc535IXhh/ZUYpthenW+qBBzn85pEC
-TowIqciHu5redqlQ8rITA8/AOY98vaDIhppDg1rfpnHHaZHFbXD/keYAEbhBtbvf
-a0QMqKUcs8+YTy5R5K6qtw==
------END PRIVATE KEY-----";
-
         let manager = TokenManager::new_asymmetric(
-            pem,
+            TEST_RSA_PRIVATE_KEY_PEM,
             Some("issuer".to_string()),
             Some("my-kid-123".to_string()),
         )
@@ -452,6 +457,53 @@ a0QMqKUcs8+YTy5R5K6qtw==
             jsonwebtoken::decode::<Claims>(&token, &decoding_key, &validation).unwrap();
         assert_eq!(token_data.claims.sub, "user123");
         assert_eq!(token_data.header.kid.as_deref(), Some("my-kid-123"));
+    }
+
+    /// Regression test for the asymmetric decoding key being derived from the
+    /// private half instead of the public one.
+    ///
+    /// `test_token_manager_asymmetric_issuance` above verifies via the
+    /// published JWK, which exercises `Jwk::to_decoding_key` rather than the
+    /// manager's own `decoding_key` — so it stays green either way. This one
+    /// goes through `validate_token`, which is the path `/reissue` and
+    /// `/userinfo` actually take.
+    #[test]
+    fn test_asymmetric_manager_validates_its_own_tokens() {
+        let manager = TokenManager::new_asymmetric(
+            TEST_RSA_PRIVATE_KEY_PEM,
+            Some("issuer".to_string()),
+            Some("my-kid-123".to_string()),
+        )
+        .unwrap();
+
+        let identity = Identity {
+            provider_id: "mock".to_string(),
+            external_id: "user123".to_string(),
+            email: None,
+            username: None,
+            attributes: HashMap::new(),
+        };
+
+        let token = manager
+            .issue_user_token(identity, 3600, None, None)
+            .unwrap();
+
+        let claims = manager.validate_token(&token, None).unwrap();
+        assert_eq!(claims.sub, "user123");
+        assert_eq!(claims.iss, Some("issuer".to_string()));
+
+        // Same round trip for the attestation shape `/reissue` presents.
+        let attestation = manager
+            .issue_custom_token(
+                "device-1".to_string(),
+                60,
+                "webank-attest+jws",
+                HashMap::new(),
+            )
+            .unwrap();
+
+        let attest_claims = manager.validate_token(&attestation, None).unwrap();
+        assert_eq!(attest_claims.sub, "device-1");
     }
 
     #[test]


### PR DESCRIPTION
Closes #180.

## Problem

`TokenManager::new_asymmetric` builds its **decoding** key from the **private** key PEM:

```rust
// crates/authkestra-engine/src/token/mod.rs:62-65 (main, v0.3.3)
let encoding_key = EncodingKey::from_rsa_pem(private_key_pem)?;
let decoding_key = DecodingKey::from_rsa_pem(private_key_pem)?;   // <-- private key
```

`DecodingKey::from_rsa_pem` expects a **public** key PEM. The part I had not pinned down when filing the issue, and which the fix turns on: given a private key it **does not error** — it constructs happily and then fails every signature check at verify time with `InvalidSignature`. So the failure surfaces far from its cause, as a rejection rather than a key-configuration error.

Net effect: an asymmetric `TokenManager` cannot verify the tokens it just signed. Every `validate_token` call on it fails, for every token, always — not just expired or malformed ones.

| Call site | Consequence |
| --- | --- |
| `authkestra-op` `handle_reissue_start` (`handlers/enrolment.rs:170`) | validates the presented attestation before minting a new one — `/reissue` can never succeed, for any device, at any time |
| `authkestra-op` `handlers/userinfo.rs:46` | `/userinfo` rejects every access token |
| `authkestra-op` `handlers/token.rs:1006` | token exchange rejects every `subject_token` |
| `authkestra-axum` `helpers/api.rs:502`, `authkestra-actix` `lib.rs:189` | bearer-token extraction fails for any OP running RS256 |

Verification against the published **JWKS** is unaffected — that path goes through `Jwk::to_decoding_key`, which uses the public `n`/`e` correctly. An external verifier (`authkestra-devsig`, say) sees nothing wrong, which is what let this sit.

There is no PEM shape that avoids it: PKCS#8 and PKCS#1 private keys both fail, and a *public* key PEM is rejected one line earlier by `EncodingKey::from_rsa_pem`. An operator cannot configure their way out.

### Why the existing tests were green

Two independent reasons, and they compound:

1. `test_token_manager_asymmetric_issuance` is the only asymmetric test in the engine, and by design it verifies through the published JWK — its own comment says *"Decode directly via jsonwebtoken to prove independent verification"*. It never touches `manager.validate_token`, so it exercises exactly the path that was already correct.
2. Every `authkestra-op` handler test builds its manager with `TokenManager::new(b"super_secret…", None)` — HS256 (`handlers/enrolment.rs:472`). The symmetric constructor derives both halves from the same secret, so it is immune. The reissue/userinfo tests that *do* call `validate_token` are all on that symmetric path.

So the asymmetric branch — the one an OP actually runs in production, since publishing a JWKS is the whole point — had no `validate_token` coverage anywhere in the workspace.

## Fix

1. **Derive the decoding key from the public half**, via the JWK the function already builds a few lines below for `/jwks`:

   ```rust
   let decoding_key = jwk.to_decoding_key()?;
   ```

   This required only moving the `decoding_key` binding down past the JWK construction — no new imports, no new dependency, and no second parse of the PEM. The private key is already parsed into an `rsa::RsaPrivateKey` there to compute `n`/`e`.

2. **Reuse `Jwk::to_decoding_key` rather than re-deriving `n`/`e` locally.** It is the crate's existing idiom for this (`token/jwk.rs`), it already returns `Result<_, AuthError>` so `?` applies directly, and routing through it makes the manager's verifier and the published JWKS structurally the same key — they cannot drift, because they are computed from one value.

3. **A regression test that goes through `validate_token`**, `test_asymmetric_manager_validates_its_own_tokens`. It round-trips an `issue_user_token`, and then an `issue_custom_token` in the `webank-attest+jws` shape `/reissue` presents, since that is the concrete path in the issue. Its doc comment records why the neighbouring asymmetric test does not cover this, so the gap does not get reintroduced.

4. **Hoisted the test RSA key to a `TEST_RSA_PRIVATE_KEY_PEM` const** in the `#[cfg(test)]` module rather than pasting a second 27-line PEM literal. Confined to the test module; the existing test is otherwise untouched. Happy to inline it again if you would rather keep the tests fully self-contained.

## Why not the alternatives

- **`rsa::RsaPublicKey::from(&rsa_key)` → `to_public_key_pem()` → `DecodingKey::from_rsa_pem`.** Correct, and closer to a literal reading of "use the public PEM". Rejected: it adds a `pkcs8::EncodePublicKey` import and a PEM encode/decode round trip purely to arrive at the same modulus and exponent the function already has in hand as `n`/`e`. More moving parts for no benefit.
- **`DecodingKey::from_rsa_components(&n, &e)` inline.** Identical result — it is literally what `Jwk::to_decoding_key` calls. I went through the `Jwk` so there is one place in the crate that turns RSA components into a verifier, instead of two that must agree.
- **Making `new_asymmetric` take the public PEM as a second argument.** A cleaner contract in the abstract, but it is a breaking signature change to fix a bug that needs no API change, and it would let a caller pass a mismatched pair — the current shape makes that unrepresentable.
- **Fixing this in `authkestra-op` instead**, e.g. by having handlers verify against the JWKS. Wrong layer: the defect is in the engine constructor, and every consumer of `new_asymmetric` inherits it.

## Consumer-visible impact

**No API change.** Signature, return type, and error type of `new_asymmetric` are unchanged. Nothing else in the workspace changes.

**No behaviour regression is possible for code that works today**, because on the asymmetric path `validate_token` currently cannot succeed at all — there is no passing case to break. Callers move from "always `Err(Token("InvalidSignature"))`" to "verifies correctly".

**Tokens already issued stay valid.** Signing is untouched; only verification changes, and it changes to the key those tokens were always meant to be checked against. The published JWKS is byte-identical.

**Worth knowing if you have worked around this:** anyone who had routed around `validate_token` on an asymmetric manager (verifying via `public_jwk().to_decoding_key()` by hand, as our host binary does) will find the direct call now works and can drop the workaround. Nothing forces them to.

One consequence to flag: error *timing* shifts slightly. `to_decoding_key` can now fail inside `new_asymmetric`, so a malformed key would surface at construction. In practice it cannot trigger — the JWK is built from an already-parsed `RsaPrivateKey` with `kty: "RSA"` and both components present, so all three of its error branches are unreachable. It is a `?` for honesty, not a real path.

## Open question for you

The engine bug is fixed and tested, but the *coverage* gap in point 2 above is a design call I did not want to make unilaterally: `authkestra-op`'s handler tests are symmetric-only, so no test in the workspace exercises `/reissue`, `/userinfo`, or token exchange against an RS256 manager. Adding an asymmetric variant of `test_tokens()` and running some of the enrolment tests over both would have caught this at the handler level rather than the constructor level — but it touches a fair number of tests and is a larger change than this issue asked for. Happy to do it in a follow-up PR if you think it is worth the churn, or to leave it.

## Verification

Workspace, on this branch (`docker compose up -d` first — note the suite is testcontainers-based and spins up its own ephemeral containers, so the compose stack is not strictly required):

```console
$ cargo fmt --all -- --check                                            # exit 0
$ cargo clippy --workspace --all-targets --all-features -- -D warnings  # exit 0
$ cargo test --workspace --all-features                                 # exit 0, 198 passed / 0 failed
$ cargo test --workspace --no-run                                       # exit 0 (default features)
$ cargo llvm-cov --workspace --all-features --fail-under-lines 60       # exit 0, 64.60% lines
```

That last one is the `coverage` job in `.github/workflows/ci.yml`; the four above it are the `fmt`, `lint`, and `test` jobs (CI's clippy omits `--all-targets`, so this run is a superset of it).

Like-for-like count under the same `--all-features` flags: **197 passed on `main`, 198 on this branch — exactly one test added.**

### The test is load-bearing

Same test, with only the one-line fix reverted (test body byte-identical):

```console
$ cargo test -p authkestra-engine --all-features token::tests::test_asymmetric_manager_validates_its_own_tokens

running 1 test
test token::tests::test_asymmetric_manager_validates_its_own_tokens ... FAILED

failures:

---- token::tests::test_asymmetric_manager_validates_its_own_tokens stdout ----

thread 'token::tests::test_asymmetric_manager_validates_its_own_tokens' panicked at crates/authkestra-engine/src/token/mod.rs:487:59:
called `Result::unwrap()` on an `Err` value: Token("InvalidSignature")

failures:
    token::tests::test_asymmetric_manager_validates_its_own_tokens

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 41 filtered out; finished in 0.05s
```

And on that same reverted build, the pre-existing asymmetric test is still green — this is the "why it was missed" claim above, demonstrated rather than asserted:

```console
$ cargo test -p authkestra-engine --lib --all-features token::tests::test_token_manager_asymmetric_issuance

running 1 test
test token::tests::test_token_manager_asymmetric_issuance ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 41 filtered out; finished in 0.04s
```

With the fix in place:

```console
$ cargo test -p authkestra-engine --lib --all-features token::tests::

running 13 tests
test token::tests::test_claims_serialization ... ok
test token::tests::test_issue_client_token_wrapper_still_has_empty_extra ... ok
test token::tests::test_issue_client_token_with_extra_round_trips_custom_claims ... ok
test token::tests::test_issue_custom_token_sets_typ_and_no_aud ... ok
test token::tests::test_issue_id_token ... ok
test token::tests::test_issue_id_token_with_extra_explicit_nonce_wins_over_extra_nonce ... ok
test token::tests::test_issue_id_token_with_extra_round_trips_custom_claims ... ok
test token::tests::test_issue_user_token_with_extra_round_trips_custom_claims ... ok
test token::tests::test_issue_user_token_wrapper_still_has_empty_extra ... ok
test token::tests::test_token_manager_asymmetric_issuance ... ok
test token::tests::test_token_manager_audience_validation ... ok
test token::tests::test_token_manager_issuance ... ok
test token::tests::test_asymmetric_manager_validates_its_own_tokens ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 29 filtered out; finished in 0.09s
```

Toolchain: `rustc 1.95.0` / `cargo 1.95.0`, macOS aarch64.

## Reviewer focus

- **The reordering is the load-bearing part.** `decoding_key` had to move below the JWK construction; `encoding_key` deliberately stays first so a public-key PEM is still rejected up front with the same error as before.
- **`jwk.to_decoding_key()?` widens `new_asymmetric`'s failure surface on paper** (see Consumer-visible impact). If you would rather it stay infallible, `DecodingKey::from_rsa_components(&n, &e)` inline plus a `.map_err` reads the same and keeps the error set where it was — say the word and I will switch it.
- **The `TEST_RSA_PRIVATE_KEY_PEM` hoist** is cosmetic and separable; it only exists to avoid a duplicated 27-line PEM literal.

---
AI assistance: drafted with Claude, reviewed and verified by me — every console block above is real output from this branch, not reconstructed.
