### PR TITLE
fix(engine): derive asymmetric decoding key from public components, not the private PEM

### DIFF
--- a/crates/authkestra-engine/src/token/mod.rs
+++ b/crates/authkestra-engine/src/token/mod.rs
@@ -61,8 +61,6 @@ impl TokenManager {
     ) -> Result<Self, AuthError> {
         let encoding_key = EncodingKey::from_rsa_pem(private_key_pem)
             .map_err(|e| AuthError::Token(e.to_string()))?;
-        let decoding_key = DecodingKey::from_rsa_pem(private_key_pem)
-            .map_err(|e| AuthError::Token(e.to_string()))?;
 
         let pem_str = std::str::from_utf8(private_key_pem)
             .map_err(|_| AuthError::Token("Invalid PEM UTF-8".into()))?;
@@ -78,6 +76,17 @@ impl TokenManager {
 
         let n = URL_SAFE_NO_PAD.encode(rsa_key.n().to_bytes_be());
         let e = URL_SAFE_NO_PAD.encode(rsa_key.e().to_bytes_be());
+
+        // The decoding key MUST be derived from the public half (`n`, `e`),
+        // never from the private key PEM: `DecodingKey::from_rsa_pem`
+        // expects a PUBLIC key PEM, and handing it a private key silently
+        // produces a key that cannot verify what `encoding_key` above just
+        // signed (jsonwebtoken#180 upstream in this crate's terms — see
+        // https://github.com/marcjazz/authkestra/issues/180). `n`/`e` are
+        // already computed for the JWK a few lines below, so this reuses
+        // them rather than re-deriving anything.
+        let decoding_key = DecodingKey::from_rsa_components(&n, &e)
+            .map_err(|e| AuthError::Token(e.to_string()))?;
 
         let kid_val = kid.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
@@ -452,6 +461,74 @@ a0QMqKUcs8+YTy5R5K6qtw==
             jsonwebtoken::decode::<Claims>(&token, &decoding_key, &validation).unwrap();
         assert_eq!(token_data.claims.sub, "user123");
         assert_eq!(token_data.header.kid.as_deref(), Some("my-kid-123"));
+    }
+
+    /// Regression test for #180: an asymmetric `TokenManager` must be able
+    /// to verify the tokens it just signed, via its OWN `validate_token`
+    /// (not by round-tripping through the published JWK, which is the path
+    /// `test_token_manager_asymmetric_issuance` above exercises and which
+    /// stayed green throughout #180 — it is a genuinely independent
+    /// verifier, unaffected by `decoding_key` being built from the wrong
+    /// key half). Before the fix, `decoding_key` was built with
+    /// `DecodingKey::from_rsa_pem(private_key_pem)` — a PRIVATE key handed
+    /// to an API that expects a PUBLIC one — so every call here failed with
+    /// `InvalidRsaKey`/`InvalidSignature` regardless of `exp`. This is
+    /// exactly the path `handle_reissue_start` (`authkestra-op`) and
+    /// `handle_userinfo` call.
+    #[test]
+    fn asymmetric_manager_can_verify_the_tokens_it_just_signed() {
+        let pem = b"-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDA5hJIcQ+2rxMz
+VM8ZH5WAmguCr0xmNDAdy0IzzsUeFLG7BebB7izOkU36J4t8t5tUaQwrBMnx2Fvt
+VqJjbdE242UDpvWF/8m9zJ2HR5298cbwT5cGMKLB0HWzDMahugs+Bbh2lCgwyLZk
+Tr3Diwxp5SwFew/Wb+Ke9cNG9Hu5IFH3BCuJ839d9hfqisIeYrBPfb52xxckM37R
+7zSGu/eDP/HZAeLkQuptZJW4A3u7xni14u4qyqXDqsHsYFNgJaxMSAwWgBRY6HNu
+TnvBArTXCiVfL+F73B2L6mdYr64g+QS9nK9v97MlJu/E3mSduz54pren4mpCHc9m
+/S2+VjCZAgMBAAECggEAASC9qQbGnL7XuExRDOIn/m4bWx92ehjo0lCTibhpY3LW
+umbSbpfbhmmuSj3CjW9VZsaM3hBTgSjoTX72lbY/eIUXD7c0memUK5pV4XcEIrQw
+AZlPIye6ckx4I7ZGnKasO8FoAel9dd7DXw36AuBK3LBzJwtzkEFsBc0e3/wixqmG
+UJBbbt/+5ya7CxyjuePaQhKtkLD5R6DpvN2XnCYq5nHJNJdvSVg1pOzsTHYIf+Ee
+2Rz42fGsfFKqeEQCcBFRZaGb/ELeP4c6UZdktZAvmHb1p1fursVZc6X9JXmiJ2OJ
+Kv2H2tMKuysP8L0fXFOMgkH2SVt6rcdHkO6xhlhWsQKBgQDqR8rAJeEE5BFoXA8T
+VVW6CLMlW51x4ey7PEGOaYh39dTG2Q+GZQBZ9G+SZk3f5Y85UCACSyc//4qaz/c3
+0nWsegZ+JPyymmuc79wzIAFFvXB7pL6wyn0Ed1P620kOZTtA8iBcXrsuxL+KP7iu
+MXfWmU1QiZpbndILtyDnY+70uwKBgQDSyCljWkydQCaPU+fiAXLxP8CvcJTSSNQD
+mVUlwJ+OpHnU+Alsi1rBavMgUtLlYbFqzH7NmYrLC8Yadq3ZOwLt0VEK0r8qstAL
+7QCDUD2WNuQjpZupRnXuMUl3iXB96i2gb+VQKGuUAJvVWjdIbYa4+Gu+sBMfcDcX
+dBihDLuEuwKBgAgX4tEwfc2Fc3R/eaXZVNTQaB/qQk4k1+C//CPHUYeTXn5gEUE7
+S//PiesszZPmgkQgmHp7zidP1KH0fT3Yb2g97ut8q54f54fMYXcCrAiUusYKsuu4
+kwkMdkI8QRHWPW3I74VBYIYFFfjYqrCZ1OH8+cbGeiagFRmCggh8U0zxAoGAVW3u
+6Ge22Z0gg8LcHsu7jG/sZq7Ygool8/d3fT+e669Z+ak2GJo6hF4WgClRdMqtn72W
+PzpV+ImjFyK2v26dd0n48MwN0v56N/ss1Av3iiRhPtlmR6tZLNspDZvUzhPVvkrb
+xCs9vtSoVEamVWKe0eVNthGjDoDqs0TInq2MavUCgYB6REavSJs/CLkSS7iimjxZ
+G7g5YQi9/p1lXLOEUDiwEmvRr0XTwzzxUsIc535IXhh/ZUYpthenW+qBBzn85pEC
+TowIqciHu5redqlQ8rITA8/AOY98vaDIhppDg1rfpnHHaZHFbXD/keYAEbhBtbvf
+a0QMqKUcs8+YTy5R5K6qtw==
+-----END PRIVATE KEY-----";
+
+        let manager = TokenManager::new_asymmetric(
+            pem,
+            Some("issuer".to_string()),
+            Some("kid-1".to_string()),
+        )
+        .unwrap();
+
+        let identity = Identity {
+            provider_id: "mock".to_string(),
+            external_id: "user123".to_string(),
+            email: None,
+            username: None,
+            attributes: HashMap::new(),
+        };
+
+        let token = manager
+            .issue_user_token(identity, 3600, None, None)
+            .unwrap();
+
+        let claims = manager
+            .validate_token(&token, None)
+            .expect("the manager must be able to verify a token it just signed");
+        assert_eq!(claims.sub, "user123");
     }
 
     #[test]


### PR DESCRIPTION
Closes #180.

## Problem

`TokenManager::new_asymmetric` builds its **decoding** key from the **private** key PEM:

```rust
// crates/authkestra-engine/src/token/mod.rs (main, before this PR)
let encoding_key = EncodingKey::from_rsa_pem(private_key_pem)?;
let decoding_key = DecodingKey::from_rsa_pem(private_key_pem)?;   // <-- private key
```

`DecodingKey::from_rsa_pem` expects a **public** key PEM. Given a private key it does not produce a usable verifier, so a `TokenManager` constructed this way cannot verify the tokens it just signed — every `validate_token` call fails, unconditionally, regardless of `exp`.

Concretely this breaks:
- **`/reissue`** — `handle_reissue_start` (`authkestra-op`) validates the presented attestation before issuing a new challenge, so silent re-issue can never succeed for any device, at any time.
- **`/userinfo`**.

Verification against the published **JWKS** is unaffected (that path uses the public key material correctly), so an external verifier — e.g. `authkestra-devsig` — sees nothing wrong. That's why this stayed unnoticed: the symptom is "re-issue keeps refusing", which reads exactly like correct rejection of an expired attestation rather than a key bug.

## Fix

Derive the decoding key from the public half instead of re-parsing the private PEM. `new_asymmetric` already parses the RSA private key into an `rsa::RsaPrivateKey` and computes base64url `n`/`e` a few lines below (to build the public JWK) — this reuses those same values via `DecodingKey::from_rsa_components(&n, &e)` rather than deriving anything new. No new dependency, no change to the public API.

## Tests

Added `asymmetric_manager_can_verify_the_tokens_it_just_signed`, which calls `TokenManager::validate_token` directly — the manager's **own** verification path, not a second manager/JWK built independently (the existing `test_token_manager_asymmetric_issuance` test round-trips through the *published* JWK, which is exactly the path that stayed green throughout this bug and is why it went unnoticed).

Confirmed the new test is a real regression guard, not a tautology:
- Against `main` (private-PEM decoding key): fails with `Token("InvalidSignature")`.
- Against this branch: passes.

## Verification evidence

```
cargo test -p authkestra-engine --features webauthn,totp,sql-sqlite --lib
# 28 passed; 0 failed

cargo clippy -p authkestra-engine --features webauthn,totp,sql-sqlite --lib -- -D warnings
# clean

cargo fmt -p authkestra-engine -- --check
# clean
```

One pre-existing, unrelated item noted during verification: `cargo test -p authkestra-engine` without `--features webauthn` fails to compile (`crates/authkestra-engine/src/tests.rs` references `AuthInput::WebAuthnAuthentication`, which is gated behind the non-default `webauthn` feature). Confirmed present on `main` before this change too (`git stash` + `cargo test -p authkestra-engine --no-run`) — not introduced or touched by this PR, calling it out only so it isn't attributed here.

## AI Usage Declaration

Drafting, understanding code, proposing the fix, generating code, generating tests, reviewing the diff — this PR was produced end-to-end by an AI agent (Claude), acting on the maintainer's (@stephane-segning, also this repo's owner) explicit standing instruction to file issues/PRs upstream. The commands and results under "Verification evidence" above were actually executed by the agent, including the before/after regression check — that's machine verification, real and reproducible, not merely asserted. It is not, however, human review: @stephane-segning has not personally read this diff yet. Flagging that honestly rather than claiming a review that hasn't happened — he reviews and merges, per his own usual process.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>