### PR TITLE
chore: require a tag on HEAD before any crate can be published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,47 @@ on:
     types: [created]
 
 jobs:
+  # Gate for the whole publish chain (foundation -> core -> advanced ->
+  # frameworks -> root are linked by `needs:`, so gating the first gates all).
+  #
+  # Of the three triggers above, only `push: tags: v*` guarantees a tag.
+  # `workflow_dispatch` and `release: created` can both run against an
+  # arbitrary, untagged commit — so a crate could be published from a state
+  # nobody can later point at. That is not hypothetical: this repository's
+  # own history has published versions whose source is not reachable from any
+  # tag here (see RELEASE.md). A published version that cannot be traced back
+  # to a commit cannot be audited, diffed, or reproduced by anyone consuming
+  # it — including a `=`-exact pin in another service.
+  verify-tag:
+    name: Verify HEAD is tagged
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # Tags are not fetched by default, and `git describe` without them
+          # would report "no tag" for every commit — failing open in the
+          # loudest possible way, but for the wrong reason.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Require an exact tag on HEAD
+        run: |
+          set -euo pipefail
+          if ! tag="$(git describe --exact-match --tags HEAD 2>/dev/null)"; then
+            echo "::error::HEAD ($(git rev-parse --short HEAD)) carries no tag; refusing to publish."
+            echo ""
+            echo "Every published version must be reachable from a tag, so that"
+            echo "anyone consuming it can find the exact source. Tag the release"
+            echo "commit and re-run, or trigger this workflow by pushing the tag."
+            exit 1
+          fi
+          echo "HEAD is tagged: ${tag}"
+
   publish-foundation:
     name: Publish foundation / ${{ matrix.crate }}
     runs-on: ubuntu-latest
+    needs: verify-tag
     environment: ${{ github.event.inputs.deploy_environment || 'prod' }}
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,76 @@
+# Releasing
+
+## This repository is a fork
+
+`stephane-segning/authkestra` is a **fork of [`marcjazz/authkestra`](https://github.com/marcjazz/authkestra)**.
+
+That matters more than it usually would, because **`marcjazz` is the sole crates.io owner** of the
+published `authkestra*` crates. This fork does not publish them and cannot: it has no ownership of
+those names on the registry.
+
+Verify either fact yourself:
+
+```sh
+gh api repos/stephane-segning/authkestra --jq '{fork: .fork, parent: .parent.full_name}'
+curl -s https://crates.io/api/v1/crates/authkestra-op/owner_user | jq '.users[].login'
+```
+
+## Where the source of a published version lives
+
+Upstream carries a per-crate tag for every published version — `authkestra-op-v0.3.4` and so on.
+To audit what a given version actually contains:
+
+```sh
+# what exists on the registry, with publish timestamps and yank status
+curl -s https://index.crates.io/au/th/authkestra-op | jq -c '{vers, yanked}'
+
+# the matching tag upstream
+git ls-remote --tags https://github.com/marcjazz/authkestra | grep 'authkestra-op-v0.3.4'
+```
+
+**Known gap — this fork's own tags lag upstream.** Its highest tag is `0.2.1` and its `Cargo.toml`
+sits at an unreleased `0.2.4`. Anyone auditing a `=0.3.x` pin must look at `marcjazz/authkestra`,
+not here. No tags have been created in this fork for 0.3.x versions, deliberately: those commits are
+not reachable from this fork's history, so a tag placed here would point at something that is not
+what was published. **A tag that looks authoritative and is wrong is worse than a missing one.**
+
+## Downstream consumers
+
+`vpay` pins `authkestra-op = "=0.3.4"`; `vsms` pins `=0.3.3`. Both therefore depend, at exact
+versions, on crates owned by a third party. **Nobody on this side can patch, yank, or ship a fix for
+them independently.** Before authkestra becomes load-bearing for more services, resolve that one of
+three ways:
+
+1. obtain crates.io co-ownership from `marcjazz`;
+2. formalise the upstream relationship and contribute there rather than maintaining a divergent
+   fork; or
+3. fork-and-rename under an org you control, and own the names outright.
+
+This is a relationship decision, not only a technical one — but it should be a deliberate one.
+
+## Cutting a release (whoever holds publish rights)
+
+`.github/workflows/publish.yml` publishes the workspace in dependency order:
+foundation → core → advanced → frameworks → root, chained with `needs:`.
+
+**Every publish requires a tag on `HEAD`.** The `verify-tag` job gates the whole chain and fails the
+run when `git describe --exact-match --tags HEAD` finds nothing. Of the workflow's three triggers,
+only `push: tags: v*` guarantees this; `workflow_dispatch` and `release: created` can otherwise run
+against an arbitrary untagged commit, which is exactly how a version becomes untraceable.
+
+So:
+
+1. Bump versions and merge.
+2. Tag the release commit and push the tag — that alone triggers the workflow.
+3. If you instead dispatch manually, make sure the ref you dispatch against is tagged, or the run
+   fails at the gate before touching the registry.
+
+### After releasing, verify
+
+```sh
+git ls-remote --tags origin | grep "$VERSION"
+curl -s https://index.crates.io/au/th/authkestra-op | jq -c 'select(.vers=="'"$VERSION"'")'
+```
+
+Both should return a row. If the registry has a version the tag list does not, that is the defect
+this document exists to prevent — fix it before cutting the next release.


### PR DESCRIPTION
## Summary

Adds a `verify-tag` gate to `publish.yml` so no crate can be published from an untagged commit, and a `RELEASE.md` recording how to audit a published version — including a finding that changes the diagnosis.

## Intent

`publish.yml` has three triggers and **only `push: tags: v*` guarantees a tag**. `workflow_dispatch` and `release: created` can both run against an arbitrary untagged commit, so a crate could be published from a state nobody can later point at.

That is not hypothetical. crates.io carries `authkestra-op` 0.3.0–0.3.4; this repository's highest tag is `0.2.1` and `Cargo.toml` sits at an unreleased `0.2.4`.

### The finding that changed the fix

This work started from "the source of the published 0.3.x versions is untraceable." **That was wrong, and the correction matters more than the original task.**

**This repository is a fork of [`marcjazz/authkestra`](https://github.com/marcjazz/authkestra)**, and **`marcjazz` is the sole crates.io owner** of the published `authkestra*` crates:

```
$ gh api repos/stephane-segning/authkestra --jq '{fork: .fork, parent: .parent.full_name}'
{"fork":true,"parent":"marcjazz/authkestra"}

$ curl -s https://crates.io/api/v1/crates/authkestra-op/owner_user | jq '.users[].login'
"marcjazz"

$ git ls-remote --tags https://github.com/marcjazz/authkestra | grep 'op-v0\.3\.'
962edc66…  refs/tags/authkestra-op-v0.3.1
19caa9f7…  refs/tags/authkestra-op-v0.3.2
9126d23b…  refs/tags/authkestra-op-v0.3.3
9c469213…  refs/tags/authkestra-op-v0.3.4
```

So the source was never missing — it is fully tagged upstream. The original check (`git ls-remote --tags` vs the crates.io index) was sound; it was pointed at the wrong repository. `Cargo.toml`'s `repository` field already points at `marcjazz/authkestra`, which is correct metadata rather than staleness.

**No tags were created here for 0.3.x, deliberately.** Those commits are not reachable from this fork's history, so a tag placed here would point at something that is not what was published. A tag that looks authoritative while being wrong is worse than a missing one.

## Scope

- `.github/workflows/publish.yml` — new `verify-tag` job; `publish-foundation` gains `needs: verify-tag`. The five publish jobs form a linear `needs:` chain (foundation → core → advanced → frameworks → root), so gating the first gates all of them. Checkout uses `fetch-depth: 0` + `fetch-tags: true`, since tags are not fetched by default and their absence would otherwise fail the gate for the wrong reason.
- `RELEASE.md` — new. How to verify any published version against the registry and the upstream tag; the known gap that this fork's tags lag upstream; and the ownership consequence below.

## Verification

- [x] **`publish.yml` parses**, and the wiring is what I intended:

```
jobs: ['verify-tag', 'publish-foundation', 'publish-core', 'publish-advanced', 'publish-frameworks', 'publish-root']
publish-foundation needs: verify-tag
verify-tag steps: 2
YAML parses OK
```

- [x] **The guard was dry-run both ways**, not just written:

```
$ git describe --exact-match --tags HEAD   # current main
would FAIL (correct): HEAD 8fdd837 carries no tag

$ git describe --exact-match --tags 0.1.0
guard would PASS on tag 0.1.0
```

  Current `main` being untagged is precisely the hole this closes.

- [x] Every claim about the fork and crates.io ownership is real command output, quoted above.
- [x] No Rust source changed, so `cargo check`/`fmt`/`clippy` were not run — this is a workflow and documentation change only.

## Risk Assessment

**Low, and it fails safe.** The gate can only *prevent* a publish, never cause one. The realistic failure mode is a legitimate release being blocked because the release commit was not tagged — which is the intended behaviour, and the error message says exactly what to do.

Anyone relying on `workflow_dispatch` against an untagged ref will now be blocked. That is the point.

## Reviewer Focus

1. **The ownership question is the real one, and this PR does not solve it.** `vpay` pins `authkestra-op = "=0.3.4"` and `vsms` pins `=0.3.3` — exact versions of crates owned by a third party. Nobody on this side can patch, yank, or ship a fix for them independently. Before authkestra becomes load-bearing for more services, that wants resolving: crates.io co-ownership from `marcjazz`, a formalised upstream relationship instead of a divergent fork, or fork-and-rename under an org you control. `RELEASE.md` states this plainly rather than leaving it implicit.
2. **The guard requires only *a* tag, not a version-matching tag.** Upstream uses per-crate tags (`authkestra-op-v0.3.4`) while this fork used workspace-wide ones (`v0.2.4`), so a strict version-match check would need a convention decision first. Happy to tighten it once that is settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
