### PR TITLE
op: make refresh_token overridable via OpStore, issue id_token on openid scope

### DIFF
--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -159,7 +159,15 @@ pub async fn handle_token(
             handle_client_credentials(req, client_id, client, config, tokens).await
         }
         "refresh_token" => {
-            handle_refresh_token(req, client_id, client, config, op_store, tokens).await
+            // Routed through the `OpStore` seam (mirrors `handle_custom_grant`)
+            // so an integrator can substitute its own refresh handling —
+            // e.g. to re-mint an `id_token` or apply a custom rotation
+            // policy — without forking this crate. The default
+            // implementation reproduces the built-in behavior below via
+            // `default_handle_refresh_token`.
+            op_store
+                .handle_refresh_token(req, client_id, client, config, tokens)
+                .await
         }
         "urn:ietf:params:oauth:grant-type:device_code" => {
             handle_device_code(req, client_id, client, config, op_store, tokens).await
@@ -819,12 +827,18 @@ async fn handle_client_credentials(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn handle_refresh_token(
+/// The built-in `refresh_token` grant handling.
+///
+/// This is the default body for [`crate::store::OpStore::handle_refresh_token`]
+/// — split out as a free function so the trait's default method can call it
+/// without duplicating the logic, while `handle_token` reaches it exclusively
+/// through the trait method (so an override actually takes effect).
+pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
     req: TokenRequest,
     client_id: String,
     client: ClientRegistration,
     config: &OpConfig,
-    op_store: &dyn OpStore,
+    op_store: &S,
     tokens: &TokenManager,
 ) -> Result<TokenResponse, TokenErrorResponse> {
     if !client.allows_grant_type(&GrantType::RefreshToken) {
@@ -1682,6 +1696,391 @@ mod tests {
         .await;
         assert!(res.is_ok());
         assert!(res.unwrap().refresh_token.is_some());
+    }
+
+    // --- OpStore::handle_refresh_token override seam (issue #189) ---
+
+    /// A minimal `OpStore` wrapper that delegates every method to an inner
+    /// `OpStore` except `handle_refresh_token`, which it overrides with a
+    /// canned response. Proves the override actually reaches the dispatch
+    /// site in `handle_token`, not just that the trait compiles.
+    struct OverridingRefreshStore<Inner> {
+        inner: Inner,
+    }
+
+    #[async_trait::async_trait]
+    impl<Inner: OpStore> crate::client::ClientStore for OverridingRefreshStore<Inner> {
+        async fn find_client(
+            &self,
+            client_id: &str,
+        ) -> Result<Option<ClientRegistration>, OpError> {
+            self.inner.find_client(client_id).await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<Inner: OpStore> crate::code::AuthorizationCodeStore for OverridingRefreshStore<Inner> {
+        async fn store_code(&self, code: AuthorizationCode) -> Result<(), OpError> {
+            self.inner.store_code(code).await
+        }
+
+        async fn consume_code(&self, code: &str) -> Result<Option<AuthorizationCode>, OpError> {
+            self.inner.consume_code(code).await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<Inner: OpStore> RefreshTokenStore for OverridingRefreshStore<Inner> {
+        async fn store_token(&self, token: RefreshToken) -> Result<(), OpError> {
+            self.inner.store_token(token).await
+        }
+
+        async fn get_token(&self, token: &str) -> Result<Option<RefreshToken>, OpError> {
+            self.inner.get_token(token).await
+        }
+
+        async fn revoke_token(&self, token: &str) -> Result<(), OpError> {
+            self.inner.revoke_token(token).await
+        }
+
+        async fn consume_token(&self, token: &str) -> Result<Option<RefreshToken>, OpError> {
+            self.inner.consume_token(token).await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<Inner: OpStore> crate::device::DeviceCodeStore for OverridingRefreshStore<Inner> {
+        async fn store_device_code(
+            &self,
+            session: crate::device::DeviceCodeSession,
+        ) -> Result<(), OpError> {
+            self.inner.store_device_code(session).await
+        }
+
+        async fn get_device_code(
+            &self,
+            device_code: &str,
+        ) -> Result<Option<crate::device::DeviceCodeSession>, OpError> {
+            self.inner.get_device_code(device_code).await
+        }
+
+        async fn get_by_user_code(
+            &self,
+            user_code: &str,
+        ) -> Result<Option<crate::device::DeviceCodeSession>, OpError> {
+            self.inner.get_by_user_code(user_code).await
+        }
+
+        async fn update_device_code(
+            &self,
+            session: crate::device::DeviceCodeSession,
+        ) -> Result<(), OpError> {
+            self.inner.update_device_code(session).await
+        }
+
+        async fn delete_device_code(&self, device_code: &str) -> Result<(), OpError> {
+            self.inner.delete_device_code(device_code).await
+        }
+
+        async fn consume_device_code(
+            &self,
+            device_code: &str,
+        ) -> Result<Option<crate::device::DeviceCodeSession>, OpError> {
+            self.inner.consume_device_code(device_code).await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<Inner: OpStore> OpStore for OverridingRefreshStore<Inner> {
+        async fn handle_refresh_token(
+            &self,
+            _req: TokenRequest,
+            _client_id: String,
+            _client: ClientRegistration,
+            _config: &OpConfig,
+            _tokens: &TokenManager,
+        ) -> Result<TokenResponse, TokenErrorResponse> {
+            Ok(TokenResponse {
+                access_token: "overridden-access-token".to_string(),
+                token_type: "Bearer".to_string(),
+                expires_in: 42,
+                id_token: Some("overridden-id-token".to_string()),
+                refresh_token: Some("overridden-refresh-token".to_string()),
+                scope: Some("overridden-scope".to_string()),
+            })
+        }
+    }
+
+    fn refresh_test_client() -> ClientRegistration {
+        ClientRegistration {
+            client_id: "client1".to_string(),
+            client_secret_hash: None,
+            redirect_uris: vec![],
+            grant_types: vec![GrantType::RefreshToken],
+            scopes: vec![],
+            require_pkce: false,
+            allowed_audiences: vec![],
+            token_endpoint_auth_method: None,
+            jwks: None,
+        }
+    }
+
+    fn refresh_test_req(refresh_token: &str) -> TokenRequest {
+        TokenRequest {
+            grant_type: "refresh_token".to_string(),
+            code: None,
+            redirect_uri: None,
+            client_id: Some("client1".to_string()),
+            client_secret: None,
+            code_verifier: None,
+            scope: None,
+            refresh_token: Some(refresh_token.to_string()),
+            subject_token: None,
+            subject_token_type: None,
+            device_code: None,
+            actor_token: None,
+            actor_token_type: None,
+            requested_token_type: None,
+            audience: None,
+            client_assertion: None,
+            client_assertion_type: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_refresh_token_is_overridable_by_op_store() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<ClientRegistration>::new();
+        clients
+            .set(
+                "client1",
+                refresh_test_client(),
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let store =
+            OverridingRefreshStore {
+                inner:
+                    crate::store::CompositeOpStore::new(
+                        clients,
+                        authkestra_engine::store::memory::MemoryStore::<AuthorizationCode>::new(),
+                        authkestra_engine::store::memory::MemoryStore::<RefreshToken>::new(),
+                        authkestra_engine::store::memory::MemoryStore::<
+                            crate::device::DeviceCodeSession,
+                        >::new(),
+                    ),
+            };
+
+        // Deliberately a token no store has ever issued: if dispatch fell
+        // through to the built-in handler instead of the override, this
+        // would fail closed with `invalid_grant`, not succeed.
+        let req = refresh_test_req("no-such-token");
+
+        let res = handle_token(req, None, &test_config(false), &store, &test_tokens()).await;
+
+        let resp =
+            res.expect("the override should have been invoked instead of the built-in handler");
+        assert_eq!(resp.access_token, "overridden-access-token");
+        assert_eq!(resp.id_token.as_deref(), Some("overridden-id-token"));
+        assert_eq!(
+            resp.refresh_token.as_deref(),
+            Some("overridden-refresh-token")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_refresh_token_default_behavior_is_unchanged_without_override() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<ClientRegistration>::new();
+        clients
+            .set(
+                "client1",
+                refresh_test_client(),
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let refresh =
+            authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new();
+        refresh
+            .store_token(RefreshToken {
+                token: "rt-default".to_string(),
+                client_id: "client1".to_string(),
+                identity: test_identity(),
+                // Non-openid scope: the built-in handler's `id_token: None`
+                // is a fixed point here regardless of whether a later change
+                // teaches it to issue one for the `openid` scope.
+                scope: "profile".to_string(),
+                expires_at: Utc::now() + Duration::days(1),
+            })
+            .await
+            .unwrap();
+
+        // A store that does NOT override `handle_refresh_token` — this is
+        // the compatibility guarantee: it must behave identically to before
+        // the trait method existed.
+        let res = handle_token(
+            refresh_test_req("rt-default"),
+            None,
+            &test_config(false),
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                authkestra_engine::store::memory::MemoryStore::<AuthorizationCode>::new(),
+                refresh.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(),
+            ),
+            &test_tokens(),
+        )
+        .await;
+
+        let resp = res.unwrap();
+        assert_eq!(resp.scope.as_deref(), Some("profile"));
+        assert_eq!(resp.id_token, None);
+        assert_ne!(resp.refresh_token.as_deref(), Some("rt-default"));
+        // The old refresh token was consumed (single-use rotation).
+        assert!(refresh.get_token("rt-default").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_refresh_token_rejects_unknown_token() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<ClientRegistration>::new();
+        clients
+            .set(
+                "client1",
+                refresh_test_client(),
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let res = handle_token(
+            refresh_test_req("does-not-exist"),
+            None,
+            &test_config(false),
+            &crate::store::CompositeOpStore::new(
+                clients,
+                authkestra_engine::store::memory::MemoryStore::<AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(),
+            ),
+            &test_tokens(),
+        )
+        .await;
+
+        assert_eq!(res.unwrap_err().error, "invalid_grant");
+    }
+
+    #[tokio::test]
+    async fn test_refresh_token_rejects_expired_token() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<ClientRegistration>::new();
+        clients
+            .set(
+                "client1",
+                refresh_test_client(),
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let refresh =
+            authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new();
+        // `store_token` derives the underlying KV TTL from `expires_at`, so
+        // an already-past `expires_at` would get evicted at the storage
+        // layer before the handler's own expiry check ever runs. Write
+        // through `set` directly with a real TTL so the token is still
+        // present, and the handler's `Utc::now() > expires_at` check
+        // (`handlers/token.rs`, `default_handle_refresh_token`) is what
+        // rejects it.
+        refresh
+            .set(
+                "rt-expired",
+                RefreshToken {
+                    token: "rt-expired".to_string(),
+                    client_id: "client1".to_string(),
+                    identity: test_identity(),
+                    scope: "profile".to_string(),
+                    expires_at: Utc::now() - Duration::minutes(1),
+                },
+                std::time::Duration::from_secs(60),
+            )
+            .await
+            .unwrap();
+
+        let res = handle_token(
+            refresh_test_req("rt-expired"),
+            None,
+            &test_config(false),
+            &crate::store::CompositeOpStore::new(
+                clients,
+                authkestra_engine::store::memory::MemoryStore::<AuthorizationCode>::new(),
+                refresh,
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(),
+            ),
+            &test_tokens(),
+        )
+        .await;
+
+        let err = res.unwrap_err();
+        assert_eq!(err.error, "invalid_grant");
+        assert_eq!(err.error_description, "Refresh token expired");
+    }
+
+    #[tokio::test]
+    async fn test_refresh_token_rejects_replay_of_a_rotated_token() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<ClientRegistration>::new();
+        clients
+            .set(
+                "client1",
+                refresh_test_client(),
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let refresh =
+            authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new();
+        refresh
+            .store_token(RefreshToken {
+                token: "rt-once".to_string(),
+                client_id: "client1".to_string(),
+                identity: test_identity(),
+                scope: "profile".to_string(),
+                expires_at: Utc::now() + Duration::days(1),
+            })
+            .await
+            .unwrap();
+
+        let store = crate::store::CompositeOpStore::new(
+            clients,
+            authkestra_engine::store::memory::MemoryStore::<AuthorizationCode>::new(),
+            refresh,
+            authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            ),
+        );
+        let tokens = test_tokens();
+
+        let first = handle_token(
+            refresh_test_req("rt-once"),
+            None,
+            &test_config(false),
+            &store,
+            &tokens,
+        )
+        .await;
+        assert!(first.is_ok());
+
+        // Replaying the now-rotated token must fail, not succeed a second
+        // time.
+        let second = handle_token(
+            refresh_test_req("rt-once"),
+            None,
+            &test_config(false),
+            &store,
+            &tokens,
+        )
+        .await;
+        assert_eq!(second.unwrap_err().error, "invalid_grant");
     }
 
     // --- Token Exchange DoD Tests ---

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -931,6 +931,28 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
         }
     };
 
+    // Per OIDC Core §12.2, an id_token MAY be re-minted on refresh; a client
+    // that never requested `openid` gets none, mirroring how
+    // `handle_authorization_code` gates `issue_id_token` on the same scope
+    // check. Refresh tokens don't carry a `nonce` (only auth codes do,
+    // reflecting the original `/authorize` request) — Core §12.2 lists
+    // `nonce` as OPTIONAL on a refreshed id_token, so omitting it is
+    // conformant, not a shortcut.
+    let id_token = if old_rt.scope.contains("openid") {
+        match tokens.issue_id_token(old_rt.identity.clone(), &client_id, None, expires_in) {
+            Ok(t) => Some(t),
+            Err(e) => {
+                tracing::error!(error = ?e, "Failed to issue id token");
+                return Err(TokenErrorResponse {
+                    error: "server_error".to_string(),
+                    error_description: "Failed to generate ID token".to_string(),
+                });
+            }
+        }
+    } else {
+        None
+    };
+
     tracing::info!(
         client_id = %client_id,
         "Successfully refreshed tokens"
@@ -940,7 +962,7 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
         access_token,
         token_type: "Bearer".to_string(),
         expires_in,
-        id_token: None, // usually id_token is not issued on refresh unless openid scope is present, simplify for now
+        id_token,
         refresh_token: Some(new_refresh_val),
         scope: scope_opt,
     })
@@ -2081,6 +2103,100 @@ mod tests {
         )
         .await;
         assert_eq!(second.unwrap_err().error, "invalid_grant");
+    }
+
+    #[tokio::test]
+    async fn test_refresh_token_issues_id_token_when_openid_scope_present() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<ClientRegistration>::new();
+        clients
+            .set(
+                "client1",
+                refresh_test_client(),
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let refresh =
+            authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new();
+        refresh
+            .store_token(RefreshToken {
+                token: "rt-openid".to_string(),
+                client_id: "client1".to_string(),
+                identity: test_identity(),
+                scope: "openid profile".to_string(),
+                expires_at: Utc::now() + Duration::days(1),
+            })
+            .await
+            .unwrap();
+
+        let res = handle_token(
+            refresh_test_req("rt-openid"),
+            None,
+            &test_config(false),
+            &crate::store::CompositeOpStore::new(
+                clients,
+                authkestra_engine::store::memory::MemoryStore::<AuthorizationCode>::new(),
+                refresh,
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            ),
+            ),
+            &test_tokens(),
+        )
+        .await;
+
+        let resp = res.unwrap();
+        assert!(
+            resp.id_token.is_some(),
+            "openid scope should get a refreshed id_token"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_refresh_token_omits_id_token_without_openid_scope() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<ClientRegistration>::new();
+        clients
+            .set(
+                "client1",
+                refresh_test_client(),
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let refresh =
+            authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new();
+        refresh
+            .store_token(RefreshToken {
+                token: "rt-no-openid".to_string(),
+                client_id: "client1".to_string(),
+                identity: test_identity(),
+                scope: "profile".to_string(),
+                expires_at: Utc::now() + Duration::days(1),
+            })
+            .await
+            .unwrap();
+
+        let res = handle_token(
+            refresh_test_req("rt-no-openid"),
+            None,
+            &test_config(false),
+            &crate::store::CompositeOpStore::new(
+                clients,
+                authkestra_engine::store::memory::MemoryStore::<AuthorizationCode>::new(),
+                refresh,
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            ),
+            ),
+            &test_tokens(),
+        )
+        .await;
+
+        let resp = res.unwrap();
+        assert_eq!(
+            resp.id_token, None,
+            "no openid scope should mean no id_token, same as before this feature existed"
+        );
     }
 
     // --- Token Exchange DoD Tests ---

--- a/crates/authkestra-op/src/store.rs
+++ b/crates/authkestra-op/src/store.rs
@@ -66,11 +66,13 @@ pub trait OpStore:
     /// re-minting an `id_token`, or a non-default rotation policy — without
     /// forking the crate.
     ///
-    /// **The default reproduces today's built-in behavior exactly** —
-    /// consume-and-rotate the refresh token and re-mint an access token
-    /// (see `default_handle_refresh_token`). Any `OpStore` that does not
-    /// override this method behaves identically to before this method
-    /// existed.
+    /// The default (see `default_handle_refresh_token`) consumes and
+    /// rotates the refresh token, re-mints an access token, and — mirroring
+    /// `handle_authorization_code` — re-mints an `id_token` too when the
+    /// stored scope includes `openid` (OIDC Core §12.2 makes this optional;
+    /// this crate now exercises that option instead of always omitting it).
+    /// Any `OpStore` that does not override this method gets that behavior
+    /// automatically; nothing about the trait or dispatch changes for it.
     async fn handle_refresh_token(
         &self,
         req: crate::handlers::token::TokenRequest,

--- a/crates/authkestra-op/src/store.rs
+++ b/crates/authkestra-op/src/store.rs
@@ -55,6 +55,36 @@ pub trait OpStore:
             error_description: "Unsupported grant type".to_string(),
         })
     }
+
+    /// Handle a `refresh_token` grant request during token exchange.
+    ///
+    /// A defaulted method, same reasoning as `handle_custom_grant`: the
+    /// built-in dispatch in `handlers::token::handle_token` used to match the
+    /// literal string `"refresh_token"` and call straight into the built-in
+    /// handler, with no seam an `OpStore` implementor could intercept. That
+    /// made it impossible to substitute custom refresh behavior — e.g.
+    /// re-minting an `id_token`, or a non-default rotation policy — without
+    /// forking the crate.
+    ///
+    /// **The default reproduces today's built-in behavior exactly** —
+    /// consume-and-rotate the refresh token and re-mint an access token
+    /// (see `default_handle_refresh_token`). Any `OpStore` that does not
+    /// override this method behaves identically to before this method
+    /// existed.
+    async fn handle_refresh_token(
+        &self,
+        req: crate::handlers::token::TokenRequest,
+        client_id: String,
+        client: crate::client::ClientRegistration,
+        config: &crate::config::OpConfig,
+        tokens: &authkestra_engine::token::TokenManager,
+    ) -> Result<crate::handlers::token::TokenResponse, crate::handlers::token::TokenErrorResponse>
+    {
+        crate::handlers::token::default_handle_refresh_token(
+            req, client_id, client, config, self, tokens,
+        )
+        .await
+    }
 }
 
 /// A helper struct that implements `OpStore` by delegating to 5 individual stores.


### PR DESCRIPTION
## Summary

Fixes #189: the `refresh_token` grant had no override seam, and the built-in handler never issued an `id_token`.

**Commit 1 — `feat(op): make the refresh_token grant overridable via OpStore`**
`handle_token` matched the literal string `"refresh_token"` and called straight into the built-in handler, ahead of the `handle_custom_grant` fallback. No `OpStore` implementor could intercept it. Adds `OpStore::handle_refresh_token`, a defaulted trait method that mirrors the existing `handle_custom_grant` seam exactly. `handle_token` now dispatches through `op_store.handle_refresh_token(...)` instead of calling the built-in function directly; the built-in logic moves into `default_handle_refresh_token` (a `pub(crate)` free function, generic over `S: OpStore + ?Sized`) and becomes the trait method's default body.

**Commit 2 — `fix(op): issue an id_token on refresh_token grant when openid scope is present`**
The built-in handler always returned `id_token: None`, with a comment saying so was a simplification. Mirrors `handle_authorization_code`: re-mints an `id_token` via `tokens.issue_id_token` when the refresh token's stored scope contains `openid`, `None` otherwise (unchanged). No `nonce` is reflected — refresh tokens don't carry one, and OIDC Core §12.2 lists `nonce` as optional on a refreshed `id_token`, so this is spec-conformant, not a shortcut.

## Design chosen and why

Went with the **defaulted-trait-method** direction from the issue (mirroring `handle_custom_grant`), not routing custom-grant dispatch ahead of the built-in match. Reasons:
- It's additive: existing `OpStore` implementations keep compiling and keep behaving identically without touching a line, because the default reproduces today's exact logic.
- It's discoverable at the same call site as `handle_custom_grant`, the pattern this codebase already uses for exactly this kind of extension point.
- Routing custom-grant dispatch first would silently change grant-type precedence for every existing integrator that happens to register a client for `urn:...:custom` grants that collide with `refresh_token` handling in some way, or would require every `OpStore` to explicitly re-implement today's refresh logic just to keep it working — worse ergonomics and a real (if narrow) compatibility risk. The defaulted method has neither problem.

## Compatibility story

- Every existing `OpStore` implementation (anything not overriding `handle_refresh_token`) keeps compiling with zero changes and gets identical behavior — proven by `test_refresh_token_default_behavior_is_unchanged_without_override`, which asserts the exact response shape (rotated refresh token, no `id_token` for a non-`openid` scope) rather than just returning `Ok`.
- `test_refresh_token_is_overridable_by_op_store` proves the seam is real: it passes a refresh token that was never issued by any store, so the built-in handler would reject it with `invalid_grant` — the override returning `Ok` proves dispatch actually reached the trait method.
- The `openid`-scope `id_token` change (commit 2) is the one behavior change to the built-in default itself, and it's scope-gated: only refresh tokens whose stored scope already includes `openid` are affected, and the new override seam from commit 1 makes it optional to adopt (or opt out of) regardless.

## Included the `openid` id_token change

Yes — it's small (one `if`/`match` mirroring existing code in `handle_authorization_code`), it's well-tested both ways, and it's the actual root cause the issue's second half calls out. Left as its own commit so it's easy to revert independently of the override seam if the maintainer prefers to defer it.

## Test evidence

`cargo test -p authkestra-op --lib handlers::token` (final state, both commits applied):

```
test handlers::token::tests::test_refresh_token_is_overridable_by_op_store ... ok
test handlers::token::tests::test_refresh_token_default_behavior_is_unchanged_without_override ... ok
test handlers::token::tests::test_refresh_token_rejects_unknown_token ... ok
test handlers::token::tests::test_refresh_token_rejects_expired_token ... ok
test handlers::token::tests::test_refresh_token_rejects_replay_of_a_rotated_token ... ok
test handlers::token::tests::test_refresh_token_issues_id_token_when_openid_scope_present ... ok
test handlers::token::tests::test_refresh_token_omits_id_token_without_openid_scope ... ok
test handlers::token::tests::test_refresh_token ... ok
...
test result: ok. 44 passed; 0 failed; 0 ignored; 0 measured; 66 filtered out; finished in 0.80s
```

Full workspace, matching CI's `cargo test --workspace --all-features` (ran with `--exclude authkestra`; see note below):

```
running 116 tests (authkestra-op, unit + sqlx/testcontainers integration)
test result: ok. 116 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 9.99s
```
All other workspace crates: 0 failures across the run.

```
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy --workspace --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.57s
(no warnings)
```

**Note on `--exclude authkestra`:** `crates/authkestra/tests/examples_e2e.rs` hardcodes binding an example server to port 3000, which was already occupied by an unrelated local Docker service on the machine this ran on. Confirmed this is pre-existing and unrelated to this change by running the identical test against a clean, unmodified `origin/main` checkout in a separate worktree — same `AddrInUse` failure there too.

## Verification

- [x] `cargo test --workspace --all-features` (effectively; `authkestra`'s example-server e2e test excluded for the environmental reason above, confirmed pre-existing against unmodified `origin/main`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New tests cover: override seam actually invoked, non-overriding default unchanged, invalid/expired/replayed-token rejection, `openid` scope both ways

## AI Usage Declaration

This PR was authored by an AI coding agent (Claude) at the repo owner's explicit request, working in an isolated git worktree (`/tmp/authkestra-refresh`) to avoid colliding with a second, concurrent agent working on issues #187/#188 in the same repo. The agent read the issue, the linked source, `CONTRIBUTING.md`, and `release-plz.toml` before making changes; wrote the tests; and ran the full verification suite shown above. A human (the repo maintainer) reviews this PR before merge — the agent has explicit instructions never to self-merge.

- [x] AI-authored, human-reviewed before merge
- [x] All new logic covered by tests written and run by the agent, not just asserted
- [x] Source-of-truth: https://github.com/marcjazz/authkestra/issues/189

Closes #189
