### PR TITLE
fix: align workspace dependencies to unblock release-plz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,14 +45,14 @@ exclude = [
 authkestra-engine = { version = "0.3.4", path = "crates/authkestra-engine", default-features = false }
 authkestra-providers = { version = "0.3.4", path = "crates/authkestra-providers", default-features = false }
 authkestra-axum = { version = "0.3.4", path = "crates/authkestra-axum", default-features = false }
-authkestra-macros = { version = "0.3.0", path = "crates/authkestra-macros", default-features = false }
+authkestra-macros = { version = "0.3.4", path = "crates/authkestra-macros", default-features = false }
 authkestra-oidc = { version = "0.3.4", path = "crates/authkestra-oidc", default-features = false }
 authkestra-actix = { version = "0.3.4", path = "crates/authkestra-actix", default-features = false }
 authkestra-resource = { version = "0.3.4", path = "crates/authkestra-resource", default-features = false }
 authkestra = { version = "0.3.4", path = "crates/authkestra", default-features = false }
 
 authkestra-op = { version = "0.3.4", path = "crates/authkestra-op", default-features = false }
-authkestra-devsig = { version = "0.3.2", path = "crates/authkestra-devsig", default-features = false }
+authkestra-devsig = { version = "0.3.4", path = "crates/authkestra-devsig", default-features = false }
 rand = "0.9.2"
 url = "2.5"
 sha2 = "0.10"


### PR DESCRIPTION
This PR fixes the release-plz pipeline failure caused by mismatched versions in workspace.dependencies.