### PR TITLE
fix(release): group all crates in version_group to prevent version mismatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,14 +45,14 @@ exclude = [
 authkestra-engine = { version = "0.3.4", path = "crates/authkestra-engine", default-features = false }
 authkestra-providers = { version = "0.3.4", path = "crates/authkestra-providers", default-features = false }
 authkestra-axum = { version = "0.3.4", path = "crates/authkestra-axum", default-features = false }
-authkestra-macros = { version = "0.3.0", path = "crates/authkestra-macros", default-features = false }
+authkestra-macros = { version = "0.3.4", path = "crates/authkestra-macros", default-features = false }
 authkestra-oidc = { version = "0.3.4", path = "crates/authkestra-oidc", default-features = false }
 authkestra-actix = { version = "0.3.4", path = "crates/authkestra-actix", default-features = false }
 authkestra-resource = { version = "0.3.4", path = "crates/authkestra-resource", default-features = false }
 authkestra = { version = "0.3.4", path = "crates/authkestra", default-features = false }
 
 authkestra-op = { version = "0.3.4", path = "crates/authkestra-op", default-features = false }
-authkestra-devsig = { version = "0.3.2", path = "crates/authkestra-devsig", default-features = false }
+authkestra-devsig = { version = "0.3.4", path = "crates/authkestra-devsig", default-features = false }
 rand = "0.9.2"
 url = "2.5"
 sha2 = "0.10"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,3 +1,47 @@
 [workspace]
 publish_no_verify = true
 release_commits = "^(feat|fix|perf|refactor|revert)"
+
+# All crates share `version.workspace = true`, so they must be bumped as a
+# single unit. Without this, release-plz may try to bump authkestra-engine to
+# 0.4.0 (breaking API) while leaving authkestra-devsig at 0.3.x, causing
+# `cargo update` to fail because `^0.3.x` doesn't match `0.4.0`.
+[[package]]
+name = "authkestra-engine"
+version_group = "authkestra"
+
+[[package]]
+name = "authkestra-providers"
+version_group = "authkestra"
+
+[[package]]
+name = "authkestra-axum"
+version_group = "authkestra"
+
+[[package]]
+name = "authkestra-macros"
+version_group = "authkestra"
+
+[[package]]
+name = "authkestra-oidc"
+version_group = "authkestra"
+
+[[package]]
+name = "authkestra-actix"
+version_group = "authkestra"
+
+[[package]]
+name = "authkestra-resource"
+version_group = "authkestra"
+
+[[package]]
+name = "authkestra"
+version_group = "authkestra"
+
+[[package]]
+name = "authkestra-op"
+version_group = "authkestra"
+
+[[package]]
+name = "authkestra-devsig"
+version_group = "authkestra"


### PR DESCRIPTION
## Problem

The release-plz pipeline is still failing after #196. The root cause is structural:

All crates use `version.workspace = true` (shared version `0.3.4`), but release-plz tries to bump crates to **different** versions independently:
- `authkestra-engine` → `0.4.0` (breaking API changes detected by cargo-semver-checks)
- `authkestra-devsig` → stays at `0.3.4` (no matching commits)

Since all crates share the workspace version, when release-plz copies the workspace to a temp dir and bumps engine to `0.4.0`, **all** crates (including devsig) become `0.4.0`. But the `[workspace.dependencies]` requirement for `authkestra-devsig` is still `^0.3.4`, which doesn't match `0.4.0` → `cargo update` fails.

## Fix

Added `version_group = "authkestra"` to every crate in `release-plz.toml`. This tells release-plz to always bump all crates together as a single unit, so when any crate triggers a version bump, all crates get the same new version and the workspace dependency requirements stay consistent.