### PR TITLE
fix(workspace): use broad version ranges for sibling workspace deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,17 +42,23 @@ exclude = [
 # features of a sibling off. Cargo ignores `default-features = false` on an
 # inherited dependency unless the workspace entry sets it too, which is what
 # lets the TLS-backend choice below reach every crate in the graph.
-authkestra-engine = { version = "0.3.4", path = "crates/authkestra-engine", default-features = false }
-authkestra-providers = { version = "0.3.4", path = "crates/authkestra-providers", default-features = false }
-authkestra-axum = { version = "0.3.4", path = "crates/authkestra-axum", default-features = false }
-authkestra-macros = { version = "0.3.4", path = "crates/authkestra-macros", default-features = false }
-authkestra-oidc = { version = "0.3.4", path = "crates/authkestra-oidc", default-features = false }
-authkestra-actix = { version = "0.3.4", path = "crates/authkestra-actix", default-features = false }
-authkestra-resource = { version = "0.3.4", path = "crates/authkestra-resource", default-features = false }
-authkestra = { version = "0.3.4", path = "crates/authkestra", default-features = false }
+#
+# IMPORTANT: The version constraints below intentionally use a broad range
+# (>=0.3, <2) rather than an exact pin. release-plz bumps [workspace.package]
+# version but does NOT update these strings; an exact pin like "0.3.4" would
+# cause `cargo update` to fail with "candidate versions found which didn't
+# match: 0.4.0" as soon as any crate gets a major/minor bump.
+authkestra-engine = { version = ">=0.3, <2", path = "crates/authkestra-engine", default-features = false }
+authkestra-providers = { version = ">=0.3, <2", path = "crates/authkestra-providers", default-features = false }
+authkestra-axum = { version = ">=0.3, <2", path = "crates/authkestra-axum", default-features = false }
+authkestra-macros = { version = ">=0.3, <2", path = "crates/authkestra-macros", default-features = false }
+authkestra-oidc = { version = ">=0.3, <2", path = "crates/authkestra-oidc", default-features = false }
+authkestra-actix = { version = ">=0.3, <2", path = "crates/authkestra-actix", default-features = false }
+authkestra-resource = { version = ">=0.3, <2", path = "crates/authkestra-resource", default-features = false }
+authkestra = { version = ">=0.3, <2", path = "crates/authkestra", default-features = false }
 
-authkestra-op = { version = "0.3.4", path = "crates/authkestra-op", default-features = false }
-authkestra-devsig = { version = "0.3.4", path = "crates/authkestra-devsig", default-features = false }
+authkestra-op = { version = ">=0.3, <2", path = "crates/authkestra-op", default-features = false }
+authkestra-devsig = { version = ">=0.3, <2", path = "crates/authkestra-devsig", default-features = false }
 rand = "0.9.2"
 url = "2.5"
 sha2 = "0.10"


### PR DESCRIPTION
## Problem

release-plz bumps `[workspace.package].version` (e.g. `0.3.4` → `0.4.0`) but does **NOT** update the explicit `version = "..."` strings in `[workspace.dependencies]` for sibling crates. This causes `cargo update` to fail in the temp workspace with:

```
error: failed to select a version for the requirement `authkestra-devsig = "^0.3.4"`
candidate versions found which didn't match: 0.4.0
```

Previous attempts (#196, #197) failed because:
- #196 just realigned the pinned versions to `0.3.4`, which shifted the error from `^0.3.2` to `^0.3.4` (same problem)
- #197 added `version_group` to `release-plz.toml`, but `version_group` only controls which version number is assigned — it does **not** update `[workspace.dependencies]` version strings

## Root Cause

All crates use `version.workspace = true`, so when release-plz bumps `[workspace.package].version` to `0.4.0`, all crates in the temp workspace become `0.4.0`. But the `[workspace.dependencies]` version constraint for `authkestra-devsig` (and others) stays at `"0.3.4"`, which doesn't match `0.4.0` → cargo resolution fails.

## Fix

Replace all exact version pins in `[workspace.dependencies]` for sibling crates with `">=0.3, <2"`. Since these are **path dependencies**, Cargo always resolves them by path inside the workspace — the `version` field is only used by crates.io for compatibility checking during publish. This broad range satisfies both the current `0.3.4` and any future `0.4.0` / `0.5.0` / `1.x` bump without needing to be manually updated.