### PR TITLE
fix(release): remove release_commits to fix version_group synchronization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,23 +42,17 @@ exclude = [
 # features of a sibling off. Cargo ignores `default-features = false` on an
 # inherited dependency unless the workspace entry sets it too, which is what
 # lets the TLS-backend choice below reach every crate in the graph.
-#
-# IMPORTANT: The version constraints below intentionally use a broad range
-# (>=0.3, <2) rather than an exact pin. release-plz bumps [workspace.package]
-# version but does NOT update these strings; an exact pin like "0.3.4" would
-# cause `cargo update` to fail with "candidate versions found which didn't
-# match: 0.4.0" as soon as any crate gets a major/minor bump.
-authkestra-engine = { version = ">=0.3, <2", path = "crates/authkestra-engine", default-features = false }
-authkestra-providers = { version = ">=0.3, <2", path = "crates/authkestra-providers", default-features = false }
-authkestra-axum = { version = ">=0.3, <2", path = "crates/authkestra-axum", default-features = false }
-authkestra-macros = { version = ">=0.3, <2", path = "crates/authkestra-macros", default-features = false }
-authkestra-oidc = { version = ">=0.3, <2", path = "crates/authkestra-oidc", default-features = false }
-authkestra-actix = { version = ">=0.3, <2", path = "crates/authkestra-actix", default-features = false }
-authkestra-resource = { version = ">=0.3, <2", path = "crates/authkestra-resource", default-features = false }
-authkestra = { version = ">=0.3, <2", path = "crates/authkestra", default-features = false }
+authkestra-engine = { version = "0.3.4", path = "crates/authkestra-engine", default-features = false }
+authkestra-providers = { version = "0.3.4", path = "crates/authkestra-providers", default-features = false }
+authkestra-axum = { version = "0.3.4", path = "crates/authkestra-axum", default-features = false }
+authkestra-macros = { version = "0.3.4", path = "crates/authkestra-macros", default-features = false }
+authkestra-oidc = { version = "0.3.4", path = "crates/authkestra-oidc", default-features = false }
+authkestra-actix = { version = "0.3.4", path = "crates/authkestra-actix", default-features = false }
+authkestra-resource = { version = "0.3.4", path = "crates/authkestra-resource", default-features = false }
+authkestra = { version = "0.3.4", path = "crates/authkestra", default-features = false }
 
-authkestra-op = { version = ">=0.3, <2", path = "crates/authkestra-op", default-features = false }
-authkestra-devsig = { version = ">=0.3, <2", path = "crates/authkestra-devsig", default-features = false }
+authkestra-op = { version = "0.3.4", path = "crates/authkestra-op", default-features = false }
+authkestra-devsig = { version = "0.3.4", path = "crates/authkestra-devsig", default-features = false }
 rand = "0.9.2"
 url = "2.5"
 sha2 = "0.10"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,6 @@
 [workspace]
 publish_no_verify = true
-release_commits = "^(feat|fix|perf|refactor|revert)"
+release_always = true
 
 # All crates share `version.workspace = true`, so they must be bumped as a
 # single unit. Without this, release-plz may try to bump authkestra-engine to


### PR DESCRIPTION
## Problem Analysis & Solution

### Root Cause
1. **Attempt 1 & 2**:  had  configured at the workspace level. When  analyzed the workspace, crates without matching commits (like ) were filtered out **before**  was processed (known issue #2891 in ).
2. Because  was filtered out,  did not include it in the  bump or update its entry in .
3. However,  uses . When  was bumped to , 's package version automatically became  in Cargo, while  still specified .
4. **Attempt 3**: Using version operators () caused  to crash with .

### The Fix
1. Removed  filter and enabled  in . This ensures  can properly synchronize all crates in the workspace together.
2. Reverted  version constraints to clean version strings (), allowing  to successfully update them to  during the release PR generation.