### PR TITLE
docs: rewrite core guides and provider documentation for authkestra-engine (#193)

### DIFF
--- a/website/src/content/docs/advanced/op-server.md
+++ b/website/src/content/docs/advanced/op-server.md
@@ -15,10 +15,10 @@ Because OP Servers are an advanced use case, the OP logic is not included in the
 
 ```toml
 [dependencies]
-authkestra-op = "0.3.0"
-authkestra-axum = { version = "0.3", features = ["op"] }
+authkestra-op = "0.4.0"
+authkestra-axum = { version = "0.4", features = ["op"] }
 # Or if using Actix:
-# authkestra-actix = { version = "0.3", features = ["op"] }
+# authkestra-actix = { version = "0.4", features = ["op"] }
 ```
 
 ## The OpStore Interface
@@ -47,70 +47,55 @@ let op_store = CompositeOpStore::new(
 );
 ```
 
-:::tip[Implementing Custom Stores]
-**Implementing Custom Stores:** If you build your own combined store type (e.g. `struct MyCustomStore { ... }`), you must explicitly implement the `OpStore` trait for it (`impl OpStore for MyCustomStore {}`). This is a minor breaking change from `0.2.3` where a blanket implementation was provided, which was removed to allow for overriding the `handle_custom_grant` method.
+:::tip[Overriding Refresh Token Logic]
+The `OpStore` interface allows overriding `handle_refresh_token` for custom refresh token rotation or revocation policies. When the `openid` scope is requested during the refresh flow, Authkestra automatically issues an updated `id_token` alongside the new access token.
 :::
 
 Check the [op_server.rs](https://github.com/marcjazz/authkestra/tree/main/crates/authkestra/examples/op_server.rs) example in the repository for full database wiring code.
 
 ## Supported Grant Types
 
-Authkestra's OP server is fully featured and natively supports the following OAuth 2.0 / OIDC grant types. When registering clients (via your `ClientStore`), you assign them a list of `GrantType` enum variants they are permitted to use:
+Authkestra's OP server natively supports the following OAuth 2.0 / OIDC grant types:
 
-1. **Authorization Code** (`GrantType::AuthorizationCode`): The standard interactive OIDC login flow. Used by web applications and mobile apps to securely acquire tokens after user authentication.
-2. **Client Credentials** (`GrantType::ClientCredentials`): Server-to-server machine authentication. Used when a backend service needs to access an API on its own behalf.
-3. **Refresh Token** (`GrantType::RefreshToken`): Allows clients to exchange a long-lived refresh token for a new short-lived access token without requiring user interaction.
-4. **Device Code** (`GrantType::DeviceCode`): The OAuth 2.0 Device Authorization Grant (RFC 8628). Used for input-constrained devices like Smart TVs or CLI tools where the user authenticates on a secondary device (e.g., their smartphone).
-5. **Token Exchange** (`GrantType::TokenExchange`): The OAuth 2.0 Token Exchange grant (RFC 8693). Allows a resource server to impersonate or delegate permissions by exchanging an incoming access token for a new token targeting a downstream service.
+1. **Authorization Code** (`GrantType::AuthorizationCode`): The standard interactive OIDC login flow.
+2. **Client Credentials** (`GrantType::ClientCredentials`): Server-to-server machine authentication.
+3. **Refresh Token** (`GrantType::RefreshToken`): Allows clients to exchange a refresh token for new tokens (with automatic `id_token` issuance when `openid` scope is active).
+4. **Device Code** (`GrantType::DeviceCode`): The OAuth 2.0 Device Authorization Grant (RFC 8628).
+5. **Token Exchange** (`GrantType::TokenExchange`): The OAuth 2.0 Token Exchange grant (RFC 8693).
 
 ## Supported Algorithms & Scopes
 
-It is important to distinguish between what the Authkestra framework *can* do and what you, the developer, *choose* to enable via your OP configuration.
-
 ### Signing Algorithms
 
-Authkestra uses the underlying `jsonwebtoken` crate, which provides robust support for modern cryptographic signing algorithms (including `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `EdDSA`, etc.). 
+Authkestra uses `jsonwebtoken` and `sha2`/`ed25519-dalek` to provide robust support for modern cryptographic signing algorithms:
+- `RS256`, `RS384`, `RS512` (RSA)
+- `ES256`, `ES384` (ECDSA)
+- `EdDSA` / `Ed25519` (Octet Key Pair)
 
-However, when configuring your OP server, **you must choose an asymmetric algorithm** (like `RS256`). Authkestra intentionally rejects symmetric algorithms (like `HS256`) for OpenID Providers. This is a strict security requirement: Resource Servers and Relying Parties must be able to verify your tokens using public keys exposed at your `/jwks` endpoint without ever knowing your private signing secret.
+When configuring your OP server, **you must choose an asymmetric algorithm** (such as `RS256` or `EdDSA`). Authkestra intentionally rejects symmetric algorithms (`HS256`) for OP servers so Resource Servers can verify tokens via the public `/jwks` endpoint.
 
 ### Scopes
 
-Authkestra is entirely **scope-agnostic**. The framework does not hardcode what scopes mean. 
-
-If you want to be OpenID Connect compliant, you simply add `"openid"`, `"profile"`, and `"email"` to your configuration. But you are completely free to invent custom scopes for your own APIs (e.g., `"billing:read"`, `"admin:write"`, `"devices:provision"`).
-
-The relationship works like this:
-1. **Global Capability**: You define all possible scopes your server understands in `OpConfig.scopes_supported`.
-2. **Client Restriction**: When creating a `ClientRegistration` in your database, you give that client a subset of those scopes.
-3. **User Delegation**: When a user logs in, the `/authorize` flow ensures the requested scopes do not exceed what the client is permitted to ask for.
+Authkestra is entirely **scope-agnostic**. To be OpenID Connect compliant, include `"openid"`, `"profile"`, and `"email"` in `OpConfig.scopes_supported`.
 
 ## Building the OP State
 
-The behavior of your OpenID Provider is entirely driven by `OpConfig`. When building the state, you must configure this struct to declare what your server supports.
+The behavior of your OpenID Provider is driven by `OpConfig`:
 
 ```rust
 use authkestra_op::config::OpConfig;
 use authkestra_op::Op;
 
 let config = OpConfig {
-    // The canonical base URL of your OP Server. Used in JWT `iss` claims.
     issuer: "http://localhost:3000".to_string(),
-    
-    // The scopes this server grants (must include "openid" for OIDC)
     scopes_supported: vec!["openid".to_string(), "profile".to_string(), "email".to_string()],
-    
-    // The authorization flows supported. "code" enables the Authorization Code flow.
     response_types_supported: vec!["code".to_string()],
-    
-    // The token endpoints supported. 
-    grant_types_supported: vec!["authorization_code".to_string()],
-    
-    // Cryptographic signing algorithm for issued ID tokens
-    id_token_signing_alg: "RS256".to_string(),
+    grant_types_supported: vec!["authorization_code".to_string(), "refresh_token".to_string()],
+    id_token_signing_alg: "EdDSA".to_string(), // Supports RS256, ES256, EdDSA, etc.
 };
 
 let op = Op::builder()
-    .engine(auth_engine) // Assumes an Engine with SessionStore and TokenManager
+    .engine(auth_engine)
     .config(config)
     .store(op_store)
     .build();
@@ -118,171 +103,21 @@ let op = Op::builder()
 
 ## Custom Grant Types
 
-Beyond the built-in grant types, Authkestra allows you to implement custom extension grants (e.g. for custom legacy flows, SSO tokens from third parties, etc).
-
-To support a custom grant type:
-
-1. Add it to your client's authorized grants using the `Custom(String)` variant:
-   ```rust
-   use authkestra_op::client::GrantType;
-
-   client.grant_types = vec![GrantType::Custom("urn:my:custom:grant".to_string())];
-   ```
-2. Implement your own `OpStore` and override the `handle_custom_grant` method. By default, `handle_custom_grant` returns an `unsupported_grant_type` error, meaning it is safely backwards compatible for users leveraging `CompositeOpStore`.
-   ```rust
-   use authkestra_op::store::OpStore;
-   use authkestra_op::handlers::token::{TokenRequest, TokenResponse, TokenErrorResponse};
-
-   #[async_trait::async_trait]
-   impl OpStore for MyCustomOpStore {
-       // ... other store methods ...
-
-       async fn handle_custom_grant(
-           &self,
-           grant_type: &str,
-           req: TokenRequest,
-           client_id: String,
-           client: authkestra_op::client::ClientRegistration,
-           config: &authkestra_op::config::OpConfig,
-           tokens: &authkestra_engine::token::TokenManager,
-       ) -> Result<TokenResponse, TokenErrorResponse> {
-           if grant_type == "urn:my:custom:grant" {
-               // Perform custom validation here...
-               
-               // Issue the token!
-               let access_token = tokens.issue_client_token(&client_id, 3600, None, None).unwrap();
-               return Ok(TokenResponse {
-                   access_token,
-                   token_type: "Bearer".to_string(),
-                   expires_in: 3600,
-                   refresh_token: None,
-                   id_token: None,
-                   scope: None,
-               });
-           }
-           
-           Err(TokenErrorResponse {
-               error: "unsupported_grant_type".to_string(),
-               error_description: "Unsupported custom grant".to_string(),
-           })
-       }
-   }
-   ```
-
-Authkestra's token endpoint automatically intercepts any unknown grant type, checks if the client is authorized to use `GrantType::Custom(grant_type_string)`, and if so, safely forwards it to your `handle_custom_grant` implementation.
-
-## Custom Claims
-
-When building a full Identity Provider, you often need to attach domain-specific data to your tokens (e.g., `role`, `project_id`, or `billing_tier`). This aligns with custom claim mappers found in enterprise systems like Keycloak or Auth0.
-
-Authkestra's core `TokenManager` natively supports injecting custom claims via the `*_with_extra` suite of methods. You simply provide a `HashMap<String, serde_json::Value>` containing your extra claims when minting tokens:
-
-```rust
-use std::collections::HashMap;
-use serde_json::json;
-
-let mut extra_claims = HashMap::new();
-extra_claims.insert("org_id".to_string(), json!("org-123"));
-extra_claims.insert("role".to_string(), json!("admin"));
-
-// Issue an ID Token with standard claims AND your custom claims appended
-let id_token = token_manager.issue_id_token_with_extra(
-    identity,
-    "client-1",
-    Some("nonce123".to_string()),
-    3600,
-    extra_claims
-)?;
-```
-
-*(Note: When calling `issue_id_token_with_extra`, an explicit `nonce` argument will always take precedence over a `"nonce"` key provided in the `extra_claims` map).*
-
-## Device/Service Attestation Issuance
-
-Beyond issuing OIDC tokens to a browser-based Relying Party, `authkestra-op` can also act as the **Issuer** in a device-bound-signature authentication scheme: it mints short-lived **attestations** — JWS tokens carrying a `cnf.jkt` claim (the SHA-256 thumbprint of a JWK) bound to a public key that a device or backend service generated locally and never shares. An attestation alone proves nothing; a verifier must additionally see a per-request signature made with the corresponding private key. This is the Issuer-side counterpart to `authkestra-devsig`'s request verification (see the mdBook chapter on adapters for that side).
-
-Attestations are deliberately **short-lived** rather than the long-lived, hard-to-revoke tokens common to plain bearer auth: a compromised or revoked device's exposure window is bounded by `attestation_ttl_secs`, not by however long a refresh token happens to live. Renewal is silent — the caller re-proves possession of the same key well before expiry (recommended at `attestation_reissue_after_secs`), so there is no user-facing re-login and no second factor required beyond continuity of the key itself.
-
-The ceremony is three HTTP calls (see the updated endpoint list below):
-
-1. The caller generates an asymmetric keypair locally (EC P-256, ideally hardware-backed — Secure Enclave / StrongBox / Keystore) and calls `POST /enrol` with its public JWK and a second-factor proof (SMS/TOTP for a device; an out-of-band admin approval or bootstrap secret for a service principal). The OP verifies the factor and returns a single-use challenge.
-2. The caller signs the challenge with its private key and calls `POST /enrol/complete`. The OP verifies the signature, computes `cnf.jkt` from the *enrolled* key (never from client input), and mints the attestation.
-3. Before the attestation expires, the caller silently re-proves possession via `POST /reissue`, which itself returns a fresh challenge to complete through the same `/enrol/complete` endpoint — no second factor needed, since continuity of the key stands in for it.
-
-Configure the ceremony with `AttestationConfig`, and implement a `SecondFactorVerifier` (mandatory) plus, optionally, an `AttestationStatusProvider` that can refuse re-issuance for a revoked principal or refresh its attributes:
-
-```rust
-use async_trait::async_trait;
-use authkestra_op::attestation::{
-    AttestationConfig, PrincipalType, SecondFactorProof, SecondFactorVerifier,
-};
-use authkestra_op::OpError;
-
-let attestation_config = AttestationConfig {
-    attestation_ttl_secs: 86_400,           // 24h attestation lifetime
-    attestation_reissue_after_secs: 43_200, // recommend silent renewal at 12h
-    challenge_ttl_secs: 300,                // 5 minutes to complete a challenge
-};
-
-struct SmsOrBootstrapVerifier;
-
-#[async_trait]
-impl SecondFactorVerifier for SmsOrBootstrapVerifier {
-    async fn verify(
-        &self,
-        subject: &str,
-        principal_type: PrincipalType,
-        proof: &SecondFactorProof,
-    ) -> Result<(), OpError> {
-        // Verify `proof.value` against whatever second factor fits
-        // `principal_type` — an SMS/TOTP code for a device, or an
-        // out-of-band approval / one-time bootstrap secret for a service.
-        // `authkestra-op` treats `proof` as opaque and never interprets it
-        // itself.
-        todo!()
-    }
-}
-```
-
-The three routes are wired through a router split from the standard OIDC surface, so an application that only wants plain OIDC never has to supply attestation-specific dependencies just to keep compiling:
-
-```rust
-use authkestra_axum::op::{OpExt, OpState};
-use axum::Router;
-
-let app = Router::new()
-    .merge(op.op_axum_router())              // /authorize, /token, /userinfo, ...
-    .merge(op.op_axum_attestation_router())  // /enrol, /enrol/complete, /reissue
-    .with_state(OpState(op));
-```
-
-Actix wires the same three routes via `OpExt::op_actix_scope()`, resolving `EnrolmentChallengeStore`, `SecondFactorVerifier`, `TokenManager`, and `AttestationConfig` from `app_data` the same way the rest of the OP server's dependencies are resolved.
-
-See [`crates/authkestra/examples/axum_op_server_attestation.rs`](https://github.com/marcjazz/authkestra/tree/main/crates/authkestra/examples/axum_op_server_attestation.rs) and [`crates/authkestra/examples/actix_op_server_attestation.rs`](https://github.com/marcjazz/authkestra/tree/main/crates/authkestra/examples/actix_op_server_attestation.rs) in the repository for a runnable, end-to-end walkthrough of enrolment and re-issuance (no external services required — the challenge store is an in-memory `MemoryStore`), or the step-by-step [Device Attestation guide](/guides/device-attestation/) for a narrated version of the same flow.
+Beyond built-in grant types, Authkestra allows extension grants by adding `GrantType::Custom("urn:my:grant".into())` to client registrations and overriding `handle_custom_grant` on your `OpStore`.
 
 ## Wiring the OP Endpoints
 
-Once your stores and config are built, you wire the server routes using `op_axum_router()` (or `op_actix_router()`).
+Wire server routes using `op_axum_router()` or `op_actix_router()`:
 
 ```rust
 use authkestra_axum::op::{OpExt, OpState};
 use axum::Router;
 
-// `op_axum_router()` automatically wires standard OIDC server endpoints!
 let app = Router::new().merge(op.op_axum_router()).with_state(OpState(op));
 ```
 
-### What Endpoints are Exposed?
-
-Unlike a standard OAuth client router, `op_axum_router()` exposes the endpoints that *other* applications will call to authenticate against you:
-
-1. **`GET /.well-known/openid-configuration`**: The OIDC Discovery endpoint. Relying Parties fetch this to discover your supported scopes and keys.
-2. **`GET /jwks`**: Exposes the public keys used to sign your JWTs so Resource Servers can validate them.
-3. **`GET /authorize`**: The endpoint users are redirected to when they want to log in.
-4. **`POST /token`**: The endpoint clients call to exchange an authorization code or refresh token for a new Access/ID Token.
-
-If you also merge `op_axum_attestation_router()` (or wire `op_actix_scope()`), three more endpoints are exposed for the device/service attestation ceremony described above:
-
-5. **`POST /enrol`**: Validates the caller's public key and second factor, and issues a single-use proof-of-possession challenge.
-6. **`POST /enrol/complete`**: Consumes the challenge, verifies the signature was produced by the enrolled key, and mints the attestation.
-7. **`POST /reissue`**: Silently renews a near-expiry attestation by re-proving possession of the same key.
+Exposed endpoints:
+1. **`GET /.well-known/openid-configuration`**: OIDC Discovery endpoint.
+2. **`GET /jwks`**: Public key set (supports RSA, ECDSA, and Ed25519 / OKP keys).
+3. **`GET /authorize`**: Authorization endpoint.
+4. **`POST /token`**: Token exchange endpoint (code, refresh token, client credentials, etc.).

--- a/website/src/content/docs/advanced/resource-server.mdx
+++ b/website/src/content/docs/advanced/resource-server.mdx
@@ -8,9 +8,9 @@ Authkestra isn't just for logging users in; you can also use it to build an **OA
 
 ## What is a Resource Server?
 
-According to [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-1.1), a Resource Server is the server hosting the protected resources, capable of accepting and responding to protected resource requests using access tokens.
+According to [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-1.1), a Resource Server is the server hosting protected resources, capable of accepting and responding to protected resource requests using access tokens.
 
-To securely validate an external JWT, the Resource Server must verify the cryptographic signature using the external provider's public keys (JWKS, defined in [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517)).
+To securely validate an external JWT, the Resource Server verifies the cryptographic signature using the external provider's public keys (JWKS, defined in [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517)).
 
 ## Prerequisites
 
@@ -18,10 +18,19 @@ Like the OP Server, the Resource Server is an advanced component and is not incl
 
 ```toml
 [dependencies]
-authkestra-resource = "0.3.0"
-authkestra-axum = { version = "0.3", features = ["resource"] }
+authkestra-resource = "0.4.0"
+authkestra-axum = { version = "0.4", features = ["resource"] }
 # Or if using Actix:
-# authkestra-actix = { version = "0.3", features = ["resource"] }
+# authkestra-actix = { version = "0.4", features = ["resource"] }
+```
+
+### TLS Backend Selection
+
+Outbound HTTP requests for JWKS discovery require a TLS backend. Authkestra enables `rustls-aws-lc-rs` by default. If your project uses a different TLS implementation (such as `ring`), you can select `rustls-no-provider` and install your own `rustls::CryptoProvider`:
+
+```toml
+[dependencies]
+authkestra-resource = { version = "0.4.0", default-features = false, features = ["rustls-no-provider"] }
 ```
 
 ## Building with Authkestra Guard
@@ -30,7 +39,7 @@ Authkestra provides the `authkestra-resource` crate, which features a `Guard` an
 
 ### 1. Configure the Strategy
 
-First, we set up the `ValidationConfig` and point it to the issuer's JWKS URL. The strategy will automatically fetch and cache the public keys in the background to eliminate per-request latency.
+First, set up `ValidationConfig` and point it to the issuer's JWKS URL. The strategy automatically fetches and caches public keys in the background.
 
 ```rust
 use authkestra_resource::{jwt::JwtStrategy, jwt::ValidationConfig, Guard};
@@ -46,12 +55,13 @@ let validation_config = ValidationConfig::builder()
 let jwt_strategy = JwtStrategy::<UserIdentity>::new(validation_config);
 ```
 
-### Advanced JWT Validation
+### Advanced Cryptography & JWT Validation
 
-The `ValidationConfig::builder()` supports several advanced validation rules to enforce strict security policies:
+The `ValidationConfig::builder()` supports advanced validation rules and cryptographic key types:
 
-- **Multi-Audience Support**: If your API serves multiple distinct clients, you can configure it to accept tokens minted for any of those audiences by chaining `.audiences(["client_a", "client_b"])`. (You can still use `.audience("single_client")` for backward compatibility).
-- **Strict Key IDs (`kid`)**: By default, if a JWT is missing the `kid` (Key ID) header, Authkestra will gracefully fall back to the first available key in the JWKS. To strictly reject malformed tokens that lack a `kid`, chain `.require_kid(true)`.
+- **Supported Signing Algorithms**: Supports `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, and `EdDSA` (`Ed25519` OKP keys).
+- **Multi-Audience Support**: To accept tokens minted for any of multiple distinct client IDs, chain `.audiences(["client_a", "client_b"])`.
+- **Strict Key IDs (`kid`)**: To strictly reject malformed tokens that lack a `kid` header instead of falling back to the first JWKS key, chain `.require_kid(true)`.
 
 ```rust
 let advanced_config = ValidationConfig::builder()
@@ -63,9 +73,7 @@ let advanced_config = ValidationConfig::builder()
 
 ### 2. Flexible Strategy Chaining
 
-A core feature of Authkestra is **Flexible Chaining**. What if you want to support *multiple* types of authentication on the same endpoint? For instance, accepting an OIDC JWT *or* a custom API key? 
-
-The `Guard` builder allows you to chain multiple strategies together. The request will pass if *any* of the chained strategies successfully validate it.
+The `Guard` builder allows you to chain multiple strategies together. A request passes if *any* of the chained strategies successfully validate it (e.g., accepting an OIDC JWT *or* an API key).
 
 <Tabs>
 <TabItem label="Axum" icon="seti:rust">
@@ -88,7 +96,7 @@ struct AppState {
 
 ### 3. Protect Endpoints
 
-Now you can use the `Auth` extractor in your handlers. If the incoming request satisfies any of the chained strategies in your Guard, it is deserialized into your `UserIdentity` struct!
+Now use the `Auth` extractor in your handlers. If the incoming request satisfies any strategy in your Guard, it is deserialized into your `UserIdentity` struct:
 
 ```rust
 use authkestra_axum::Auth;
@@ -122,7 +130,7 @@ struct AppState {
 
 ### 3. Protect Endpoints
 
-Now you can use the `Auth` extractor in your handlers. If the incoming request satisfies any of the chained strategies in your Guard, it is deserialized into your `UserIdentity` struct!
+Now use the `Auth` extractor in your handlers:
 
 ```rust
 use authkestra_actix::Auth;

--- a/website/src/content/docs/guides/framework-integration.mdx
+++ b/website/src/content/docs/guides/framework-integration.mdx
@@ -8,7 +8,7 @@ Authkestra provides first-class support for both the `axum` and `actix-web` web 
 
 ## Prerequisites
 
-Ensure you have enabled the correct web framework feature on the `authkestra` crate in your `Cargo.toml`. Also, since session management is stateful, make sure the `session` feature is enabled.
+Ensure you have enabled the correct web framework feature on the `authkestra` crate in your `Cargo.toml`.
 
 <Tabs>
   <TabItem label="Axum" icon="seti:rust">
@@ -31,13 +31,13 @@ authkestra = { version = "0.3", features = ["actix", "session"] }
 
 ## The `AuthSession` Extractor
 
-The primary way to interact with an authenticated user in a handler is via the `AuthSession` extractor. It automatically validates the session and injects the user's identity.
+The primary way to interact with an authenticated user in a handler when using sessions is via the `AuthSession` extractor. It automatically validates the session from cookies and injects the user's identity.
 
 <Tabs>
   <TabItem label="Axum" icon="seti:rust">
 
 ```rust
-use authkestra_axum::{AuthSession, AxumError};
+use authkestra::axum::{AuthSession, AxumError};
 use axum::response::{IntoResponse, Json};
 use serde_json::json;
 
@@ -57,7 +57,7 @@ pub async fn my_handler(
   <TabItem label="Actix-web" icon="seti:rust">
 
 ```rust
-use authkestra_actix::{AuthSession, ActixError};
+use authkestra::actix::{AuthSession, ActixError};
 use actix_web::{get, HttpResponse, Responder};
 
 #[get("/api/user")]
@@ -78,27 +78,88 @@ async fn get_user(session: Result<AuthSession, ActixError>) -> impl Responder {
   </TabItem>
 </Tabs>
 
-## Router Setup
+## The `AuthToken` Extractor
 
-To wire up the endpoints, you use `axum_router()` or `actix_router()` on the built Engine.
+For stateless JWT authentication, Authkestra provides the `AuthToken` extractor which reads and validates the `Authorization: Bearer <token>` header.
 
 <Tabs>
   <TabItem label="Axum" icon="seti:rust">
 
 ```rust
-use authkestra_axum::AxumExt;
+use authkestra::axum::{AuthToken, AxumError};
+use axum::response::{IntoResponse, Json};
+use serde_json::json;
+
+pub async fn token_protected_handler(
+    token: Result<AuthToken, AxumError>
+) -> impl IntoResponse {
+    match token {
+        Ok(AuthToken(claims)) => Json(json!({
+            "message": "Valid Token!",
+            "sub": claims.sub,
+        })),
+        Err(_) => Json(json!({ "error": "Invalid or missing token" }))
+    }
+}
+```
+  </TabItem>
+  <TabItem label="Actix-web" icon="seti:rust">
+
+```rust
+use authkestra::actix::{AuthToken, ActixError};
+use actix_web::{get, HttpResponse, Responder};
+
+#[get("/api/protected")]
+async fn get_protected(token: Result<AuthToken, ActixError>) -> impl Responder {
+    match token {
+        Ok(AuthToken(claims)) => HttpResponse::Ok().json(
+            serde_json::json!({
+                "message": "Valid Token!",
+                "sub": claims.sub,
+            })
+        ),
+        Err(_) => HttpResponse::Unauthorized().json(
+            serde_json::json!({ "error": "Invalid token" })
+        ),
+    }
+}
+```
+  </TabItem>
+</Tabs>
+
+## Router Setup
+
+To wire up standard authentication endpoints automatically, use `axum_router()` / `axum_router_stateless()` for Axum, or `actix_router()` / `actix_router_stateless()` for Actix-web on the built `Engine`.
+
+<Tabs>
+  <TabItem label="Axum" icon="seti:rust">
+
+```rust
+use authkestra::axum::{AxumExt, AxumState};
+use authkestra::core::AkWebAppEngine;
+use axum::Router;
+use tower_cookies::CookieManagerLayer;
+
+#[derive(Clone, AxumState)]
+struct AppState {
+    #[authkestra(engine)]
+    auth: AkWebAppEngine,
+}
+
+let state = AppState { auth: auth_engine.clone() };
 
 let app = Router::new()
     .merge(auth_engine.axum_router())
     .layer(CookieManagerLayer::new())
-    .with_state(AppState { auth: auth_engine });
+    .with_state(state);
 ```
 
   </TabItem>
   <TabItem label="Actix-web" icon="seti:rust">
 
 ```rust
-use authkestra_actix::ActixExt;
+use actix_web::{web, App, HttpServer};
+use authkestra::actix::ActixExt;
 
 HttpServer::new(move || {
     App::new()

--- a/website/src/content/docs/guides/quickstart.mdx
+++ b/website/src/content/docs/guides/quickstart.mdx
@@ -17,6 +17,8 @@ Add the `authkestra` facade crate to your `Cargo.toml`. The facade re-exports al
 ```toml
 [dependencies]
 authkestra = { version = "0.3", features = ["axum", "github"] }
+tower-cookies = "0.10"
+tokio = { version = "1", features = ["full"] }
 ```
 
   </TabItem>
@@ -25,6 +27,7 @@ authkestra = { version = "0.3", features = ["axum", "github"] }
 ```toml
 [dependencies]
 authkestra = { version = "0.3", features = ["actix", "github"] }
+actix-web = "4"
 ```
 
   </TabItem>
@@ -32,19 +35,19 @@ authkestra = { version = "0.3", features = ["actix", "github"] }
 
 ## Setting Up the Engine
 
-The core logic of Authkestra is identical regardless of which web framework you choose. First, we will initialize the Identity Provider (GitHub) and then construct the `Engine` using the Typestate Builder Pattern.
+The core logic of Authkestra is identical regardless of which web framework you choose. First, initialize the Identity Provider (`GithubProvider`) and construct the `Engine` using the Typestate Builder Pattern (`Authkestra::builder()`).
 
 ```rust
 use authkestra::Authkestra;
-use authkestra_providers::github::GithubProvider;
-use authkestra_engine::store::memory::MemoryStore;
+use authkestra::providers::github::GithubProvider;
+use authkestra::store::memory::MemoryStore;
 use std::sync::Arc;
 
 // 1. Initialize the GitHub Provider
 let github_provider = GithubProvider::new(
     "YOUR_CLIENT_ID".to_string(), 
     "YOUR_CLIENT_SECRET".to_string(), 
-    "http://localhost:3000/auth/github/callback".to_string()
+    "http://localhost:3000/auth/callback/github".to_string()
 );
 
 // 2. Setup the Session Store
@@ -59,18 +62,20 @@ let auth_engine = Authkestra::builder()
 
 ## Wiring the Router
 
-Once the engine is built, it's time to integrate it into your web framework's routing layer. Authkestra provides specialized adapters (`authkestra-axum` and `authkestra-actix`) that automatically map the standard authentication endpoints for you.
+Once the engine is built, integrate it into your web framework's routing layer. Authkestra provides specialized adapters (`authkestra-axum` and `authkestra-actix`) that automatically map standard authentication endpoints.
 
 <Tabs>
   <TabItem label="Axum" icon="seti:rust">
 
 ```rust
-use authkestra::axum::AxumExt;
-use axum::Router;
-use tower_cookies::CookieManagerLayer;
-use authkestra::core::engine::Engine;
+use authkestra::axum::{AxumExt, AxumState};
 use authkestra::core::AkWebAppEngine;
-use authkestra::axum::AxumState;
+use authkestra::providers::github::GithubProvider;
+use authkestra::store::memory::MemoryStore;
+use authkestra::Authkestra;
+use axum::Router;
+use std::sync::Arc;
+use tower_cookies::CookieManagerLayer;
 
 #[derive(Clone, AxumState)]
 struct AppState {
@@ -80,11 +85,19 @@ struct AppState {
 
 #[tokio::main]
 async fn main() {
-    let auth_engine = /* setup engine as above */ Authkestra::builder().build();
+    let auth_engine = Authkestra::builder()
+        .provider(GithubProvider::new(
+            "YOUR_CLIENT_ID".to_string(),
+            "YOUR_CLIENT_SECRET".to_string(),
+            "http://localhost:3000/auth/callback/github".to_string(),
+        ))
+        .session_store(Arc::new(MemoryStore::default()))
+        .build();
+
     let state = AppState { auth: auth_engine.clone() };
 
     let app = Router::new()
-        // `axum_router()` automatically wires standard login endpoints!
+        // `axum_router()` automatically wires `/auth/login/{provider}` and `/auth/callback/{provider}`
         .merge(auth_engine.axum_router())
         .layer(CookieManagerLayer::new())
         .with_state(state);
@@ -98,18 +111,28 @@ async fn main() {
   <TabItem label="Actix-web" icon="seti:rust">
 
 ```rust
+use actix_web::{web, App, HttpServer};
 use authkestra::actix::ActixExt;
-use actix_web::{App, HttpServer, web};
-use authkestra::core::engine::Engine;
+use authkestra::providers::github::GithubProvider;
+use authkestra::store::memory::MemoryStore;
+use authkestra::Authkestra;
+use std::sync::Arc;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let auth_engine = /* setup engine as above */ Authkestra::builder().build();
+    let auth_engine = Authkestra::builder()
+        .provider(GithubProvider::new(
+            "YOUR_CLIENT_ID".to_string(),
+            "YOUR_CLIENT_SECRET".to_string(),
+            "http://localhost:3000/auth/callback/github".to_string(),
+        ))
+        .session_store(Arc::new(MemoryStore::default()))
+        .build();
 
     HttpServer::new(move || {
         App::new()
             .app_data(web::Data::new(auth_engine.clone()))
-            // `actix_router()` automatically wires standard login endpoints!
+            // `actix_router()` automatically wires `/auth/login/{provider}` and `/auth/callback/{provider}`
             .configure(|cfg| auth_engine.actix_router(cfg))
     })
     .bind("0.0.0.0:3000")?
@@ -121,4 +144,4 @@ async fn main() -> std::io::Result<()> {
   </TabItem>
 </Tabs>
 
-With just these few lines of code, your application is now fully equipped to handle stateless OAuth logins, validate standard OIDC responses, and issue secure sessions!
+With just these few lines of code, your application is now fully equipped to handle OAuth logins, validate responses, and issue secure sessions!

--- a/website/src/content/docs/providers/oauth2.mdx
+++ b/website/src/content/docs/providers/oauth2.mdx
@@ -4,17 +4,17 @@ description: Configuring Stateless OAuth with Authkestra.
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-By default, OAuth2 logins often result in a server-side session being created. However, Authkestra allows you to build a strictly **stateless** flow where the authentication results in a JWT (JSON Web Token).
+By default, OAuth2 logins can create a server-side session. However, Authkestra allows you to build a strictly **stateless** flow where authentication results in a signed JWT (JSON Web Token).
 
-"Stateless" means that the entire flow can be completed *without* using a session store. 
+"Stateless" means that the entire flow can be completed *without* using a session store.
 
 ## The OAuth2 Standard
 
-Authkestra strictly implements the [OAuth 2.0 Authorization Framework (RFC 6749)](https://datatracker.ietf.org/doc/html/rfc6749) and [PKCE (RFC 7636)](https://datatracker.ietf.org/doc/html/rfc7636). We didn't invent these protocols; we just provide a memory-safe, idiomatic Rust engine to execute them.
+Authkestra strictly implements the [OAuth 2.0 Authorization Framework (RFC 6749)](https://datatracker.ietf.org/doc/html/rfc6749) and [PKCE (RFC 7636)](https://datatracker.ietf.org/doc/html/rfc7636). We provide a memory-safe, idiomatic Rust engine to execute them.
 
 ## Prerequisites
 
-If you are using multiple OAuth providers (e.g., GitHub and Google), you must enable their respective feature flags:
+If you are using multiple OAuth providers (e.g., GitHub and Google), enable their respective feature flags:
 
 ```toml
 [dependencies]
@@ -23,55 +23,59 @@ authkestra = { version = "0.3", features = ["github", "google"] }
 
 ## Stateless Engine Configuration
 
-Notice how we completely omit `.session_store()` and use `.jwt_secret()` instead. You can also chain multiple providers back-to-back:
+Notice how we completely omit `.session_store()` and use `.jwt_secret()` instead. You can chain multiple providers directly:
 
 ```rust
-use authkestra::flow::{Engine, OAuth2Flow};
-use authkestra_providers::github::GithubProvider;
-use authkestra_providers::google::GoogleProvider;
+use authkestra::Authkestra;
+use authkestra::providers::github::GithubProvider;
+use authkestra::providers::google::GoogleProvider;
 
 // Initialize Authkestra in stateless mode supporting multiple providers
 let auth_engine = Authkestra::builder()
-    .provider(OAuth2Flow::new(GithubProvider::new(...)))
-    .provider(OAuth2Flow::new(GoogleProvider::new(...)))
+    .provider(GithubProvider::new(
+        "GITHUB_CLIENT_ID".into(),
+        "GITHUB_CLIENT_SECRET".into(),
+        "http://localhost:3000/auth/callback/github".into(),
+    ))
+    .provider(GoogleProvider::new(
+        "GOOGLE_CLIENT_ID".into(),
+        "GOOGLE_CLIENT_SECRET".into(),
+        "http://localhost:3000/auth/callback/google".into(),
+    ))
     .jwt_secret(b"your-256-bit-secret-key-at-least-32-bytes-long")
     .build();
 ```
 
 ## Wiring the Routes
 
-Because we are not using sessions, we **cannot** use the default `auth_engine.axum_router()`. 
-
-You can wire the endpoints automatically by using the stateless counterpart: `auth_engine.axum_router_stateless()` (or `auth_engine.actix_scope_stateless()` for Actix).
+Because we are not using sessions, we use the stateless router counterpart: `auth_engine.axum_router_stateless()` for Axum or `auth_engine.actix_router_stateless()` for Actix-web.
 
 <Tabs>
 <TabItem label="Axum">
 ```rust
+use authkestra::axum::AxumStatelessExt;
+
 let app = axum::Router::new().merge(auth_engine.axum_router_stateless());
 ```
 </TabItem>
 <TabItem label="Actix Web">
 ```rust
-let app = actix_web::App::new().service(auth_engine.actix_scope_stateless());
+use authkestra::actix::ActixStatelessExt;
+
+let app = actix_web::App::new().configure(|cfg| auth_engine.actix_router_stateless(cfg));
 ```
 </TabItem>
 </Tabs>
 
-### Wiring Routes Manually
+### Wiring Handlers Manually
 
-If you need absolute control over the HTTP response, you can bypass the automatic router. Instead, you manually define your `/auth/:provider` and `/auth/callback/:provider` routes.
-
-Here is a step-by-step breakdown of how the manual handlers work:
-
-### 1. The Login Handler
-
-The login handler intercepts the user's request and delegates to Authkestra's `axum_login_handler` or `actix_login_handler` helper. This helper securely generates the PKCE challenges and cookies before redirecting to the provider.
+If you need absolute control over the HTTP response, you can bypass the automatic router and handle requests manually using Authkestra's helpers in `authkestra-axum` or `authkestra-actix`.
 
 <Tabs>
 <TabItem label="Axum">
 ```rust
 use axum::{extract::{Path, State, Query}, response::IntoResponse};
-use authkestra_axum::helpers;
+use authkestra::axum::helpers;
 
 async fn login_handler(
     Path(provider): Path<String>,
@@ -79,8 +83,6 @@ async fn login_handler(
     Query(params): Query<helpers::OAuthLoginParams>,
     cookies: tower_cookies::Cookies,
 ) -> impl IntoResponse {
-    // We pass the framework extractors directly into the helper.
-    // The helper handles generating the state, nonce, and the 302 Redirect.
     helpers::axum_login_handler::<AppState, _, _>(Path(provider), State(state), Query(params), cookies).await
 }
 ```
@@ -88,7 +90,7 @@ async fn login_handler(
 <TabItem label="Actix Web">
 ```rust
 use actix_web::{web, Responder};
-use authkestra_actix::helpers;
+use authkestra::actix::helpers;
 
 async fn login_handler(
     path: web::Path<String>,
@@ -101,63 +103,4 @@ async fn login_handler(
 </TabItem>
 </Tabs>
 
-### 2. The Callback Handler
-
-The callback handler is where the stateless magic happens. Instead of relying on a session store, we use `handle_oauth_callback_jwt_erased`.
-
-<Tabs>
-<TabItem label="Axum">
-```rust
-async fn callback_handler(
-    Path(provider): Path<String>,
-    State(state): State<AppState>,
-    Query(params): Query<helpers::OAuthCallbackParams>,
-    cookies: tower_cookies::Cookies,
-) -> Result<impl IntoResponse, AxumError> {
-    
-    // Extract the token manager (injected via .jwt_secret() earlier)
-    let token_manager = <Result<Arc<TokenManager>, AxumError>>::from_ref(&state)?;
-    
-    // Resolve which provider (e.g. github vs google) was requested
-    let flow = state.auth.providers.get(&provider).unwrap();
-
-    // The helper exchanges the code for tokens and issues a custom JWT
-    helpers::handle_oauth_callback_jwt_erased(
-        flow.as_ref(), 
-        cookies, 
-        params, 
-        token_manager, 
-        3600, // Token TTL in seconds
-        state.auth.session_config
-    ).await
-}
-```
-</TabItem>
-<TabItem label="Actix Web">
-```rust
-async fn callback_handler(
-    req: actix_web::HttpRequest,
-    path: web::Path<String>,
-    authkestra: web::Data<Engine<AppState, ()>>,
-    params: web::Query<helpers::OAuthCallbackParams>,
-) -> actix_web::Result<impl Responder> {
-    
-    let provider = path.into_inner();
-    let flow = authkestra.providers.get(&provider).unwrap();
-
-    let response = helpers::handle_oauth_callback_jwt_erased(
-        flow.as_ref(),
-        &req,
-        params.into_inner(),
-        authkestra.session_store.get_manager(),
-        3600,
-        authkestra.session_config.clone(),
-    ).await?;
-
-    Ok(response)
-}
-```
-</TabItem>
-</Tabs>
-
-By manually exposing these handlers, you gain absolute control over the HTTP response. You can append headers, write to custom databases, or return the JWT inside a JSON body.
+By manually exposing these handlers, you gain full control over the HTTP response. You can append headers, record analytics, or return the JWT inside a custom JSON body.

--- a/website/src/content/docs/providers/oidc.md
+++ b/website/src/content/docs/providers/oidc.md
@@ -3,11 +3,11 @@ title: OIDC Client
 description: Using the generic OpenID Connect client with Authkestra.
 ---
 
-Authkestra provides a generic OpenID Connect (OIDC) client that can automatically discover endpoints and keys from any OIDC-compliant provider.
+Authkestra provides a generic OpenID Connect (OIDC) client that automatically discovers endpoints and keys from any OIDC-compliant provider and background-caches discovery documents.
 
 ## Prerequisites
 
-To use the OIDC client, you must enable the `oidc` feature on the `authkestra` crate.
+To use the OIDC client, enable the `oidc` feature on the `authkestra` crate.
 
 ```toml
 [dependencies]
@@ -16,18 +16,31 @@ authkestra = { version = "0.3", features = ["oidc"] }
 
 ## Configuring the OIDC Provider
 
-You can instantiate the `OidcProvider` directly by pointing it to the issuer URL. The client will automatically fetch the `/.well-known/openid-configuration` to determine the authorization and token endpoints.
+Instantiate `OidcProvider` directly by pointing it to the issuer URL. The client automatically fetches and caches `/.well-known/openid-configuration` to discover authorization and token endpoints.
 
 ```rust
-use authkestra_oidc::OidcProvider;
+use authkestra::Authkestra;
+use authkestra::oidc::OidcProvider;
+use authkestra::store::memory::MemoryStore;
+use std::sync::Arc;
 
-// This performs discovery automatically!
-let provider = OidcProvider::discover(
-    "CLIENT_ID".to_string(),
-    "CLIENT_SECRET".to_string(),
-    "http://localhost:3000/auth/callback/my-oidc".to_string(),
-    "https://accounts.google.com".to_string(), // The issuer URL
-).await.unwrap();
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Perform discovery automatically
+    let oidc_provider = OidcProvider::discover(
+        "CLIENT_ID".to_string(),
+        "CLIENT_SECRET".to_string(),
+        "http://localhost:3000/auth/callback/oidc".to_string(),
+        "https://accounts.google.com".to_string(), // Issuer URL
+    ).await?;
+
+    let auth_engine = Authkestra::builder()
+        .provider(oidc_provider)
+        .session_store(Arc::new(MemoryStore::default()))
+        .build();
+
+    Ok(())
+}
 ```
 
-*(Note: If you are building a Resource Server that needs to validate incoming JWTs against an external OIDC provider, refer to the **Resource Server** page for information on OIDC Discovery caching).*
+*(Note: If you are building a Resource Server that needs to validate incoming JWTs against an external OIDC provider, refer to the **Resource Server** guide for information on OIDC Discovery caching and JWKS validation).*


### PR DESCRIPTION
Closes #193

### Summary of Changes
- Updated  to use  /  and the unified RFC-001 engine types ().
- Updated  for Axum () and Actix () using the new extractors and router extensions.
- Updated  and  to document the unified plugin model directly on .
- Verified Astro/Starlight documentation site build via  ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "/home/marco". in .