### PR TITLE
fix(engine,op): accept array-shaped aud claims in token exchange

### DIFF
--- a/crates/authkestra-engine/src/token/mod.rs
+++ b/crates/authkestra-engine/src/token/mod.rs
@@ -4,12 +4,53 @@ use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// The `aud` (audience) claim, per RFC 7519 §4.1.3: either a single
+/// case-sensitive string, or a JSON array of such strings.
+///
+/// `#[serde(untagged)]` tries variants in declaration order on
+/// deserialization, so a bare JSON string matches [`Audience::Single`]
+/// first, and only a JSON array falls through to [`Audience::Multiple`].
+/// Serialization is not affected by declaration order — each variant
+/// serializes as its own shape — so a token minted with a single audience
+/// still serializes as a bare string, not a one-element array, matching
+/// every token this crate has ever issued.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum Audience {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl Audience {
+    /// True if `value` is present in this audience, whichever shape it was
+    /// deserialized from. This is the "matches ANY" membership test that
+    /// replaces exact-string-equality comparisons against `aud`.
+    pub fn contains(&self, value: &str) -> bool {
+        match self {
+            Audience::Single(s) => s == value,
+            Audience::Multiple(values) => values.iter().any(|s| s == value),
+        }
+    }
+}
+
+impl From<String> for Audience {
+    fn from(value: String) -> Self {
+        Audience::Single(value)
+    }
+}
+
+impl From<&str> for Audience {
+    fn from(value: &str) -> Self {
+        Audience::Single(value.to_string())
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Claims {
     // Standard OIDC claims
     pub iss: Option<String>,
     pub sub: String,
-    pub aud: Option<String>,
+    pub aud: Option<Audience>,
     pub exp: usize,
     pub iat: usize,
     pub nbf: Option<usize>,
@@ -208,7 +249,7 @@ impl TokenManager {
         let claims = Claims {
             iss: self.issuer.clone(),
             sub: identity.external_id.clone(),
-            aud,
+            aud: aud.map(Audience::from),
             exp: expiration,
             iat: now,
             nbf: Some(now),
@@ -261,7 +302,7 @@ impl TokenManager {
         let mut claims = Claims {
             iss: self.issuer.clone(),
             sub: identity.external_id.clone(),
-            aud: Some(client_id.to_string()),
+            aud: Some(Audience::from(client_id)),
             exp: expiration,
             iat: now,
             nbf: Some(now),
@@ -313,7 +354,7 @@ impl TokenManager {
         let claims = Claims {
             iss: self.issuer.clone(),
             sub: client_id.to_string(),
-            aud,
+            aud: aud.map(Audience::from),
             exp: expiration,
             iat: now,
             nbf: Some(now),
@@ -450,7 +491,7 @@ MC4CAQAwBQYDK2VwBCIEIPlsnSfvh53rJ+Tlbo8e7cgq2mIkWQ1NCM5paVeinUh8
         let claims = Claims {
             iss: Some("issuer".to_string()),
             sub: "user123".to_string(),
-            aud: Some("audience".to_string()),
+            aud: Some(Audience::from("audience")),
             exp: 1000,
             iat: 500,
             nbf: Some(500),
@@ -597,7 +638,7 @@ MC4CAQAwBQYDK2VwBCIEIPlsnSfvh53rJ+Tlbo8e7cgq2mIkWQ1NCM5paVeinUh8
 
         assert_eq!(claims.iss, Some("issuer".to_string()));
         assert_eq!(claims.sub, "user123");
-        assert_eq!(claims.aud, Some("client-1".to_string()));
+        assert_eq!(claims.aud, Some(Audience::from("client-1")));
         assert_eq!(claims.extra.get("nonce").unwrap(), "nonce123");
     }
     #[test]
@@ -618,7 +659,7 @@ MC4CAQAwBQYDK2VwBCIEIPlsnSfvh53rJ+Tlbo8e7cgq2mIkWQ1NCM5paVeinUh8
 
         // Validate with correct audience
         let claims = manager.validate_token(&token, Some("client-1")).unwrap();
-        assert_eq!(claims.aud, Some("client-1".to_string()));
+        assert_eq!(claims.aud, Some(Audience::from("client-1")));
 
         // Validate with incorrect audience (should fail)
         let err = manager
@@ -1055,6 +1096,86 @@ MC4CAQAwBQYDK2VwBCIEIPlsnSfvh53rJ+Tlbo8e7cgq2mIkWQ1NCM5paVeinUh8
             err.to_string().contains("InvalidSignature") || err.to_string().contains("Json"),
             "unexpected error for tampered token: {err}"
         );
+    }
+
+    /// #206 repro: a stock Keycloak realm with two `oidc-audience-mapper`
+    /// entries mints `"aud"` as a JSON array (RFC 7519 §4.1.3 allows this).
+    /// `validate_token` calls `jsonwebtoken::decode::<Claims>`, which
+    /// deserializes the payload into `Claims` before any of
+    /// `jsonwebtoken`'s own validation runs — so this fails at
+    /// deserialization, not at a validation check, and `expected_aud: None`
+    /// (which turns `Validation::validate_aud` off) makes no difference.
+    #[test]
+    fn test_validate_token_accepts_array_aud() {
+        let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
+
+        let raw_claims = serde_json::json!({
+            "iss": "issuer",
+            "sub": "user123",
+            "aud": ["client-1", "client-2"],
+            "exp": (chrono::Utc::now().timestamp() as usize) + 3600,
+            "iat": chrono::Utc::now().timestamp() as usize,
+        });
+        let token = jsonwebtoken::encode(
+            &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256),
+            &raw_claims,
+            &jsonwebtoken::EncodingKey::from_secret(b"secret"),
+        )
+        .unwrap();
+
+        let claims = manager
+            .validate_token(&token, None)
+            .expect("multi-audience subject token must deserialize");
+        let aud = claims.aud.expect("aud claim must be present");
+        assert!(aud.contains("client-1"));
+        assert!(aud.contains("client-2"));
+        assert!(!aud.contains("client-3"));
+    }
+
+    /// Companion to `test_validate_token_accepts_array_aud`: a subject token
+    /// with a plain string `aud` (the shape every token this crate has ever
+    /// issued) must keep working exactly as before the `Audience` enum was
+    /// introduced.
+    #[test]
+    fn test_validate_token_still_accepts_string_aud() {
+        let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
+        let identity = Identity {
+            provider_id: "mock".to_string(),
+            external_id: "user123".to_string(),
+            email: None,
+            username: None,
+            attributes: HashMap::new(),
+        };
+
+        let token = manager
+            .issue_id_token(identity, "client-1", None, 3600)
+            .unwrap();
+
+        let claims = manager.validate_token(&token, None).unwrap();
+        let aud = claims.aud.expect("aud claim must be present");
+        assert!(aud.contains("client-1"));
+        assert!(!aud.contains("client-2"));
+    }
+
+    /// Serialization symmetry guarantee: a single audience must still
+    /// serialize as a bare JSON string, not a one-element array, so every
+    /// token this crate has ever issued (and any consumer relying on that
+    /// shape) is unaffected by `Audience` gaining array support.
+    #[test]
+    fn test_audience_single_round_trips_as_bare_string() {
+        let single = Audience::Single("client-1".to_string());
+        let serialized = serde_json::to_string(&single).unwrap();
+        assert_eq!(serialized, "\"client-1\"");
+
+        let deserialized: Audience = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, single);
+
+        let multiple = Audience::Multiple(vec!["client-1".to_string(), "client-2".to_string()]);
+        let serialized_multi = serde_json::to_string(&multiple).unwrap();
+        assert_eq!(serialized_multi, "[\"client-1\",\"client-2\"]");
+
+        let deserialized_multi: Audience = serde_json::from_str(&serialized_multi).unwrap();
+        assert_eq!(deserialized_multi, multiple);
     }
 }
 pub mod jwk;

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -1050,9 +1050,15 @@ async fn handle_token_exchange(
         }
     };
 
-    // Audience Binding: either the subject token was issued TO this client (azp or aud = client_id)
-    // or this client is in the intended audience.
-    let is_intended_aud = claims.aud.as_deref() == Some(client_id.as_str());
+    // Audience Binding: this client must be a member of the subject token's
+    // `aud` claim, which per RFC 7519 §4.1.3 may be a single string or an
+    // array of strings (e.g. a Keycloak realm with multiple
+    // `oidc-audience-mapper` entries). `azp` is not read here — this crate's
+    // `Claims` has no such field, and there is no dedicated `azp` check.
+    let is_intended_aud = claims
+        .aud
+        .as_ref()
+        .is_some_and(|aud| aud.contains(&client_id));
     if !is_intended_aud {
         tracing::warn!(
             client_id = %client_id,
@@ -1206,6 +1212,39 @@ mod tests {
         tokens
             .issue_user_token(test_identity(), 3600, scope, Some(client_id.to_string()))
             .unwrap()
+    }
+
+    /// Like `issue_subject_token`, but mints a subject token whose `aud`
+    /// claim is a JSON array (RFC 7519 §4.1.3), the shape a stock Keycloak
+    /// realm with multiple `oidc-audience-mapper` entries produces. Built by
+    /// hand with `jsonwebtoken::encode` because `TokenManager`'s issuance
+    /// methods only ever emit a single-string `aud`. The signing secret
+    /// below must match `test_tokens()`'s so `TokenManager::validate_token`
+    /// can verify the result.
+    fn issue_subject_token_multi_aud(audiences: &[&str], scope: Option<String>) -> String {
+        let now = chrono::Utc::now().timestamp() as usize;
+        let raw_claims = serde_json::json!({
+            "sub": "user123",
+            "aud": audiences,
+            "exp": now + 3600,
+            "iat": now,
+            "scope": scope,
+            "identity": {
+                "provider_id": "test",
+                "external_id": "user123",
+                "email": null,
+                "username": "user123",
+                "attributes": {}
+            }
+        });
+        jsonwebtoken::encode(
+            &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256),
+            &raw_claims,
+            &jsonwebtoken::EncodingKey::from_secret(
+                b"super_secret_key_that_is_long_enough_for_hmac",
+            ),
+        )
+        .unwrap()
     }
 
     // --- Pre-existing restored tests ---
@@ -2269,6 +2308,105 @@ mod tests {
         assert_eq!(res.unwrap_err().error, "invalid_grant");
     }
 
+    /// #206: a subject token whose `aud` is a JSON array must exchange
+    /// successfully when the requesting client_id is *any one* of the
+    /// listed audiences, not just when it's the sole audience.
+    #[tokio::test]
+    async fn test_tx_multi_audience_subject_token_allowed() {
+        let tokens = test_tokens();
+        let subject_token = issue_subject_token_multi_aud(&["client1", "client2"], None);
+        let req = default_tx_req(&subject_token);
+
+        let clients = authkestra_engine::store::memory::MemoryStore::<
+            crate::client::ClientRegistration,
+        >::new();
+        clients
+            .set(
+                "client1",
+                ClientRegistration {
+                    client_id: "client1".to_string(),
+                    client_secret_hash: None,
+                    redirect_uris: vec![],
+                    grant_types: vec![GrantType::TokenExchange],
+                    scopes: vec![],
+                    require_pkce: false,
+                    allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
+                },
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let res = handle_token(
+            req,
+            None,
+            &test_config(true),
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            ),
+            ),
+            &tokens
+        )
+        .await;
+        assert!(
+            res.is_ok(),
+            "client1 is a member of the array aud, exchange should succeed: {res:?}"
+        );
+    }
+
+    /// #206 companion: when the requesting client_id is absent from the
+    /// subject token's array `aud`, exchange must still be rejected —
+    /// membership, not mere array-shape acceptance, is the check.
+    #[tokio::test]
+    async fn test_tx_multi_audience_subject_token_disallowed() {
+        let tokens = test_tokens();
+        let subject_token = issue_subject_token_multi_aud(&["client2", "client3"], None);
+        let req = default_tx_req(&subject_token);
+
+        let clients = authkestra_engine::store::memory::MemoryStore::<
+            crate::client::ClientRegistration,
+        >::new();
+        clients
+            .set(
+                "client1",
+                ClientRegistration {
+                    client_id: "client1".to_string(),
+                    client_secret_hash: None,
+                    redirect_uris: vec![],
+                    grant_types: vec![GrantType::TokenExchange],
+                    scopes: vec![],
+                    require_pkce: false,
+                    allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
+                },
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let res = handle_token(
+            req,
+            None,
+            &test_config(true),
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            ),
+            ),
+            &tokens
+        )
+        .await;
+        assert_eq!(res.unwrap_err().error, "invalid_grant");
+    }
+
     #[tokio::test]
     async fn test_tx_scope_escalation_narrow() {
         let tokens = test_tokens();
@@ -2594,7 +2732,7 @@ mod tests {
         let claim = tokens
             .validate_token(&res.unwrap().access_token, None)
             .unwrap();
-        assert_eq!(claim.aud.unwrap(), "serviceA");
+        assert!(claim.aud.unwrap().contains("serviceA"));
     }
 
     #[tokio::test]
@@ -2691,7 +2829,7 @@ mod tests {
             .validate_token(&res.unwrap().access_token, None)
             .unwrap();
         // default aud should be config.issuer
-        assert_eq!(claim.aud.unwrap(), "https://auth.example.com");
+        assert!(claim.aud.unwrap().contains("https://auth.example.com"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #206: a subject token whose `aud` claim is a JSON array (RFC 7519 §4.1.3 allows this) fails token-exchange, because `authkestra_engine::token::Claims.aud` is typed `Option<String>`.

## The mechanism, precisely

`handle_token_exchange` calls `tokens.validate_token(subject_token_str, None)`, which passes `expected_aud: None` into `TokenManager::validate_token` — that already sets `validation.validate_aud = false` (`engine/src/token/mod.rs`), so `jsonwebtoken`'s own audience machinery is off for this path. The only audience check that path ever reaches is the manual one further down in `handle_token_exchange`.

But it never gets there for an array `aud`. `jsonwebtoken::decode<T>` (v11.0.0) does, in order:

```rust
let decoded_claims = DecodedJwtPartClaims::from_jwt_part_claims(claims)?;
let claims = decoded_claims.deserialize()?;      // <- deserializes into T = Claims, HERE
validate(decoded_claims.deserialize()?, validation)?;  // <- separate deserialize, into jsonwebtoken's own ClaimsForValidation
```

Line 2 deserializes the payload into our `Claims` type and is evaluated *before* `validate()` on line 3 is ever called. With `aud: Option<String>`, a JSON array `aud` fails right there with a serde type error — so this is a deserialization failure, not a validation-setting issue, and turning `validate_aud` off (as this path already does) makes no difference.

I confirmed this by minting a token with `"aud": ["client-1", "client-2"]` and calling `validate_token`: pre-fix it returns `Token("JSON error: invalid type: sequence, expected a string at line 1 column 7")`. The same repro exercised through the full exchange handler returns `TokenErrorResponse { error: "invalid_grant", error_description: "subject_token is invalid" }` — a legitimate multi-audience subject token is rejected before the audience-binding check ever runs.

Interesting side note: `jsonwebtoken`'s own internal validation type (`ClaimsForValidation`, deserialized separately on line 3 above) already has its own `Audience::{Single, Multiple}` enum for exactly this ambiguity — it's only our `Claims` that picked a single-string-only shape.

## The fix

- Add `authkestra_engine::token::Audience`, `#[serde(untagged)] enum { Single(String), Multiple(Vec<String>) }`, with a `contains(&self, value: &str) -> bool` membership helper. Deserialization tries `Single` first (declaration order), so a bare JSON string still hits it; only an array falls through to `Multiple`.
- `Claims.aud` becomes `Option<Audience>`. Every `issue_*_token*` call site still accepts `Option<String>`/`&str` for the audience it's minting (unchanged signatures) and converts via `Audience::from` at construction — so this crate still only ever *issues* a single-string `aud`, it just now also *accepts* an array on the way in.
- `handle_token_exchange`'s audience-binding check changes from `claims.aud.as_deref() == Some(client_id.as_str())` to `claims.aud.as_ref().is_some_and(|aud| aud.contains(&client_id))` — an ANY-of-N membership test instead of exact equality.
- Fixed the comment above that check ("either the subject token was issued TO this client (azp or aud = client_id) or this client is in the intended audience") — it referenced `azp`, but `Claims` has no `azp` field and nothing reads one. I did not implement `azp` handling; I only made the comment match what the code actually does. Whether `azp` *should* be checked too, per the RFC, seemed like a separate design question worth leaving to you rather than bundling into a bug fix — happy to open a follow-up issue if you'd like it tracked.

**Serialization symmetry**: a single audience still serializes as a bare JSON string, not a one-element array (`untagged` serializes each variant by its own shape, independent of declaration order — only deserialization is order-sensitive) — covered by `test_audience_single_round_trips_as_bare_string`.

**On the representation**: I went with a dedicated `Audience` enum (mirroring `jsonwebtoken`'s own internal one) rather than, say, always storing `Vec<String>` internally, specifically to preserve that serialization symmetry without extra `#[serde(serialize_with = ...)]` machinery. If you'd rather have a different shape (a newtype over `Vec<String>` with custom (de)serialization, or something else entirely), I'm not attached to this one — happy to adjust.

## Downstream motivation

`lightbridge-authz` (ADORSYS-GIS) is adopting `authkestra-op` as its OIDC issuance surface for exactly this token-exchange flow. Its Keycloak realm has two `oidc-audience-mapper` entries, so every subject token it hands to `authkestra-op` for exchange carries a two-element `aud` array — no configuration on the consumer side can make these tokens fit the current single-string `Claims.aud`.

## Test evidence

All four new/changed tests are designed to fail for the *predicted* reason pre-fix, not just to pass post-fix.

**`authkestra-engine`**, before the fix (unmodified `Claims.aud: Option<String>`):
```
$ cargo test -p authkestra-engine --all-features test_validate_token_accepts_array_aud -- --nocapture
thread 'token::tests::test_validate_token_accepts_array_aud' panicked at crates/authkestra-engine/src/token/mod.rs:1087:14:
multi-audience subject token must deserialize: Token("JSON error: invalid type: sequence, expected a string at line 1 column 7")
test result: FAILED. 0 passed; 1 failed
```
— a serde type error, exactly the predicted mechanism, not a compile error or something incidental.

**`authkestra-op`**, before the fix, a standalone version of the new exchange-level test (built against pristine `main`, calling only public APIs, so it compiles unmodified):
```
$ cargo test -p authkestra-op --all-features test_tx_multi_audience_subject_token_allowed -- --nocapture
thread 'handlers::token::tests::test_tx_multi_audience_subject_token_allowed' panicked at crates/authkestra-op/src/handlers/token.rs:2340:9:
client1 is a member of the array aud, exchange should succeed: Err(TokenErrorResponse { error: "invalid_grant", error_description: "subject_token is invalid" })
test result: FAILED. 0 passed; 1 failed
```
— confirms the deserialization failure surfaces end-to-end as a hard exchange rejection for a legitimate multi-audience token, before this fix.

After the fix, full suites for both touched crates:
```
$ cargo test -p authkestra-engine --all-features
test result: ok. 52 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
   (includes test_validate_token_accepts_array_aud, test_validate_token_still_accepts_string_aud,
    test_audience_single_round_trips_as_bare_string)

$ cargo test -p authkestra-op --all-features
test result: ok. 118 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
   (includes test_tx_multi_audience_subject_token_allowed, test_tx_multi_audience_subject_token_disallowed,
    and every pre-existing test_tx_* / test_token_manager_* test unchanged in outcome)
```

Lints:
```
$ cargo fmt --all -- --check
(clean)

$ cargo clippy --workspace --all-features -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) — no warnings
```

`cargo test --workspace --all-features` is green except for one pre-existing, unrelated failure: `authkestra::tests::examples_e2e::test_all_oauth_examples_sequentially` fails with `AddrInUse` on port 3000 in this environment — confirmed a local Docker process already listens on that port here (`lsof -i :3000`), and that test doesn't touch `Claims`/`aud`/token-exchange at all. Not something this change introduced.

## AI Usage Declaration

I (an AI agent, prompted by a human maintainer of a downstream consumer) drafted this fix, including verifying the `jsonwebtoken` v11.0.0 decode/validate ordering directly against its source before writing the mechanism description above, reproducing the pre-fix failure for the predicted reason before applying any change, and running the full test/lint suite for the touched crates afterward. All command output quoted above is real, from this run. A human reviewed the diff before it was pushed. Happy to adjust the representation or split this differently if you'd prefer — treat this as a proposal, not a final answer.
