### PR TITLE
feat: Implement Redis stores and update token exchange logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,7 @@ dependencies = [
  "p256",
  "rand 0.9.5",
  "rand_core 0.6.4",
+ "redis",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/authkestra-engine/src/token/mod.rs
+++ b/crates/authkestra-engine/src/token/mod.rs
@@ -4,12 +4,28 @@ use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum Audience {
+    Single(String),
+    Multi(Vec<String>),
+}
+
+impl Audience {
+    pub fn contains(&self, aud: &str) -> bool {
+        match self {
+            Audience::Single(s) => s == aud,
+            Audience::Multi(vec) => vec.iter().any(|s| s == aud),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Claims {
     // Standard OIDC claims
     pub iss: Option<String>,
     pub sub: String,
-    pub aud: Option<String>,
+    pub aud: Option<Audience>,
     pub exp: usize,
     pub iat: usize,
     pub nbf: Option<usize>,
@@ -208,7 +224,7 @@ impl TokenManager {
         let claims = Claims {
             iss: self.issuer.clone(),
             sub: identity.external_id.clone(),
-            aud,
+            aud: aud.map(Audience::Single),
             exp: expiration,
             iat: now,
             nbf: Some(now),
@@ -261,7 +277,7 @@ impl TokenManager {
         let mut claims = Claims {
             iss: self.issuer.clone(),
             sub: identity.external_id.clone(),
-            aud: Some(client_id.to_string()),
+            aud: Some(Audience::Single(client_id.to_string())),
             exp: expiration,
             iat: now,
             nbf: Some(now),
@@ -313,7 +329,7 @@ impl TokenManager {
         let claims = Claims {
             iss: self.issuer.clone(),
             sub: client_id.to_string(),
-            aud,
+            aud: aud.map(Audience::Single),
             exp: expiration,
             iat: now,
             nbf: Some(now),
@@ -450,7 +466,7 @@ MC4CAQAwBQYDK2VwBCIEIPlsnSfvh53rJ+Tlbo8e7cgq2mIkWQ1NCM5paVeinUh8
         let claims = Claims {
             iss: Some("issuer".to_string()),
             sub: "user123".to_string(),
-            aud: Some("audience".to_string()),
+            aud: Some(Audience::Single("audience".to_string())),
             exp: 1000,
             iat: 500,
             nbf: Some(500),
@@ -597,7 +613,7 @@ MC4CAQAwBQYDK2VwBCIEIPlsnSfvh53rJ+Tlbo8e7cgq2mIkWQ1NCM5paVeinUh8
 
         assert_eq!(claims.iss, Some("issuer".to_string()));
         assert_eq!(claims.sub, "user123");
-        assert_eq!(claims.aud, Some("client-1".to_string()));
+        assert_eq!(claims.aud, Some(Audience::Single("client-1".to_string())));
         assert_eq!(claims.extra.get("nonce").unwrap(), "nonce123");
     }
     #[test]
@@ -618,7 +634,7 @@ MC4CAQAwBQYDK2VwBCIEIPlsnSfvh53rJ+Tlbo8e7cgq2mIkWQ1NCM5paVeinUh8
 
         // Validate with correct audience
         let claims = manager.validate_token(&token, Some("client-1")).unwrap();
-        assert_eq!(claims.aud, Some("client-1".to_string()));
+        assert_eq!(claims.aud, Some(Audience::Single("client-1".to_string())));
 
         // Validate with incorrect audience (should fail)
         let err = manager

--- a/crates/authkestra-op/Cargo.toml
+++ b/crates/authkestra-op/Cargo.toml
@@ -27,6 +27,7 @@ url = { workspace = true }
 sha2 = { workspace = true }
 argon2 = "0.5.3"
 sqlx = { version = "0.8", optional = true, features = ["runtime-tokio", "json", "chrono"] }
+redis = { version = "0.27", features = ["tokio-comp"], optional = true }
 
 [features]
 default = ["rustls-aws-lc-rs"]
@@ -35,6 +36,7 @@ sqlx = ["dep:sqlx"]
 sqlx-postgres = ["sqlx", "sqlx/postgres"]
 sqlx-sqlite = ["sqlx", "sqlx/sqlite"]
 sqlx-mysql = ["sqlx", "sqlx/mysql"]
+redis = ["dep:redis"]
 
 # TLS backend, forwarded to authkestra-engine. See its documentation for the
 # `rustls-no-provider` contract.
@@ -50,7 +52,7 @@ rustls-no-provider = [
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
 testcontainers = "0.27.3"
-testcontainers-modules = { version = "0.15.0", features = ["postgres", "mysql"] }
+testcontainers-modules = { version = "0.15.0", features = ["postgres", "mysql", "redis"] }
 # Test-only: generating real EC P-256 keypairs and signing enrolment
 # challenges with them, to exercise the attestation ceremony end-to-end
 # rather than mocking the crypto away. Already present in the dependency

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -173,7 +173,9 @@ pub async fn handle_token(
             handle_device_code(req, client_id, client, config, op_store, tokens).await
         }
         "urn:ietf:params:oauth:grant-type:token-exchange" => {
-            handle_token_exchange(req, client_id, client, config, tokens).await
+            op_store
+                .handle_token_exchange(req, client_id, client, config, tokens)
+                .await
         }
         _ => {
             if !client.allows_grant_type(&crate::client::GrantType::Custom(req.grant_type.clone()))
@@ -968,7 +970,8 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
     })
 }
 
-async fn handle_token_exchange(
+/// Default implementation for the token exchange grant type.
+pub async fn default_handle_token_exchange(
     req: TokenRequest,
     client_id: String,
     client: crate::client::ClientRegistration,
@@ -1019,12 +1022,15 @@ async fn handle_token_exchange(
         .requested_token_type
         .as_deref()
         .unwrap_or("urn:ietf:params:oauth:token-type:access_token");
-    if requested_token_type != "urn:ietf:params:oauth:token-type:access_token" {
+    if requested_token_type != "urn:ietf:params:oauth:token-type:access_token"
+        && requested_token_type != "urn:ietf:params:oauth:token-type:id_token"
+    {
         tracing::warn!(requested_token_type = %requested_token_type, "Unsupported requested_token_type");
         return Err(TokenErrorResponse {
             error: "invalid_request".to_string(),
-            error_description: "Unsupported requested_token_type. Only access_token is supported."
-                .to_string(),
+            error_description:
+                "Unsupported requested_token_type. Only access_token and id_token are supported."
+                    .to_string(),
         });
     }
 
@@ -1050,9 +1056,12 @@ async fn handle_token_exchange(
         }
     };
 
-    // Audience Binding: either the subject token was issued TO this client (azp or aud = client_id)
-    // or this client is in the intended audience.
-    let is_intended_aud = claims.aud.as_deref() == Some(client_id.as_str());
+    // Audience Binding: the subject token must have been issued to this client
+    // (the client_id must be present in the `aud` array/string).
+    let is_intended_aud = claims
+        .aud
+        .as_ref()
+        .is_some_and(|a| a.contains(client_id.as_str()));
     if !is_intended_aud {
         tracing::warn!(
             client_id = %client_id,
@@ -1126,17 +1135,39 @@ async fn handle_token_exchange(
     };
 
     let expires_in = config.access_token_ttl_secs;
-    let access_token =
-        match tokens.issue_user_token(identity, expires_in, final_scope_str.clone(), new_aud) {
-            Ok(t) => t,
+    let access_token = match tokens.issue_user_token(
+        identity.clone(),
+        expires_in,
+        final_scope_str.clone(),
+        new_aud,
+    ) {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!(error = ?e, "Failed to issue access token during exchange");
+            return Err(TokenErrorResponse {
+                error: "server_error".to_string(),
+                error_description: "Failed to generate token".to_string(),
+            });
+        }
+    };
+
+    let mut id_token = None;
+    if requested_token_type == "urn:ietf:params:oauth:token-type:id_token" || final_scope_str.as_ref().is_some_and(|s| s.contains("openid")) {
+        match tokens.issue_id_token(identity, &client_id, None, expires_in) {
+            Ok(t) => id_token = Some(t),
             Err(e) => {
-                tracing::error!(error = ?e, "Failed to issue access token during exchange");
-                return Err(TokenErrorResponse {
-                    error: "server_error".to_string(),
-                    error_description: "Failed to generate token".to_string(),
-                });
+                tracing::error!(error = ?e, "Failed to issue id token during exchange");
+                // Don't fail the entire grant if only the id_token fails, unless
+                // id_token was explicitly the only thing requested.
+                if requested_token_type == "urn:ietf:params:oauth:token-type:id_token" {
+                    return Err(TokenErrorResponse {
+                        error: "server_error".to_string(),
+                        error_description: "Failed to generate id_token".to_string(),
+                    });
+                }
             }
-        };
+        }
+    }
 
     tracing::info!(
         client_id = %client_id,
@@ -1147,7 +1178,7 @@ async fn handle_token_exchange(
         access_token,
         token_type: "Bearer".to_string(),
         expires_in,
-        id_token: None,
+        id_token,
         refresh_token: None,
         scope: final_scope_str,
     })
@@ -2594,7 +2625,10 @@ mod tests {
         let claim = tokens
             .validate_token(&res.unwrap().access_token, None)
             .unwrap();
-        assert_eq!(claim.aud.unwrap(), "serviceA");
+        assert_eq!(
+            claim.aud.unwrap(),
+            authkestra_engine::token::Audience::Single("serviceA".to_string())
+        );
     }
 
     #[tokio::test]
@@ -2691,7 +2725,10 @@ mod tests {
             .validate_token(&res.unwrap().access_token, None)
             .unwrap();
         // default aud should be config.issuer
-        assert_eq!(claim.aud.unwrap(), "https://auth.example.com");
+        assert_eq!(
+            claim.aud.unwrap(),
+            authkestra_engine::token::Audience::Single("https://auth.example.com".to_string())
+        );
     }
 
     #[tokio::test]

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -1152,7 +1152,11 @@ pub async fn default_handle_token_exchange(
     };
 
     let mut id_token = None;
-    if requested_token_type == "urn:ietf:params:oauth:token-type:id_token" || final_scope_str.as_ref().is_some_and(|s| s.contains("openid")) {
+    if requested_token_type == "urn:ietf:params:oauth:token-type:id_token"
+        || final_scope_str
+            .as_ref()
+            .is_some_and(|s| s.contains("openid"))
+    {
         match tokens.issue_id_token(identity, &client_id, None, expires_in) {
             Ok(t) => id_token = Some(t),
             Err(e) => {

--- a/crates/authkestra-op/src/lib.rs
+++ b/crates/authkestra-op/src/lib.rs
@@ -61,6 +61,10 @@ pub use store::OpStore;
 /// Native SQL implementations using sqlx.
 pub mod sqlx_store;
 
+#[cfg(feature = "redis")]
+/// Redis-backed implementations.
+pub mod redis_store;
+
 /// Provider-level configuration (issuer URL, supported scopes/response
 /// types).
 pub mod config;

--- a/crates/authkestra-op/src/redis_store.rs
+++ b/crates/authkestra-op/src/redis_store.rs
@@ -1,0 +1,67 @@
+use crate::client_assertion::ClientAssertionStore;
+use crate::error::OpError;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+/// A Redis-backed store for client assertions to prevent replay attacks.
+#[derive(Clone)]
+pub struct RedisClientAssertionStore {
+    client: redis::Client,
+    prefix: String,
+}
+
+impl RedisClientAssertionStore {
+    /// Creates a new RedisClientAssertionStore from a redis URL and a key prefix.
+    pub fn new(redis_url: &str, prefix: String) -> Result<Self, OpError> {
+        let client = redis::Client::open(redis_url).map_err(|e| {
+            tracing::error!("Failed to open redis client: {e}");
+            OpError::Storage
+        })?;
+        Ok(Self { client, prefix })
+    }
+
+    /// Creates a new RedisClientAssertionStore from an existing redis client and a key prefix.
+    pub fn with_client(client: redis::Client, prefix: String) -> Self {
+        Self { client, prefix }
+    }
+
+    fn key(&self, jti: &str) -> String {
+        format!("{prefix}:{jti}", prefix = self.prefix)
+    }
+}
+
+#[async_trait]
+impl ClientAssertionStore for RedisClientAssertionStore {
+    async fn record_jti(&self, jti: &str, expires_at: DateTime<Utc>) -> Result<bool, OpError> {
+        let mut conn = self
+            .client
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "Redis connection error");
+                OpError::Storage
+            })?;
+
+        let now = Utc::now();
+        if expires_at <= now {
+            return Ok(false);
+        }
+        let ttl_secs = (expires_at - now).num_seconds().max(1) as u64;
+
+        let res: Option<String> = redis::cmd("SET")
+            .arg(self.key(jti))
+            .arg("1")
+            .arg("NX")
+            .arg("EX")
+            .arg(ttl_secs)
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "Redis SET NX error");
+                OpError::Storage
+            })?;
+
+        // If res is Some("OK"), it means SET NX succeeded (the JTI is new).
+        Ok(res.is_some())
+    }
+}

--- a/crates/authkestra-op/src/store.rs
+++ b/crates/authkestra-op/src/store.rs
@@ -87,6 +87,26 @@ pub trait OpStore:
         )
         .await
     }
+
+    /// Extensibility seam for the `urn:ietf:params:oauth:grant-type:token-exchange` grant.
+    ///
+    /// Analogous to `handle_refresh_token`, this allows an `OpStore` implementor
+    /// to override default behavior — for example, to inject custom claims via
+    /// `TokenManager::issue_user_token_with_extra`, or to enforce specific constraints.
+    async fn handle_token_exchange(
+        &self,
+        req: crate::handlers::token::TokenRequest,
+        client_id: String,
+        client: crate::client::ClientRegistration,
+        config: &crate::config::OpConfig,
+        tokens: &authkestra_engine::token::TokenManager,
+    ) -> Result<crate::handlers::token::TokenResponse, crate::handlers::token::TokenErrorResponse>
+    {
+        crate::handlers::token::default_handle_token_exchange(
+            req, client_id, client, config, tokens,
+        )
+        .await
+    }
 }
 
 /// A helper struct that implements `OpStore` by delegating to 5 individual stores.


### PR DESCRIPTION
Closes #185, #206, #205, and #204. Implements RedisClientAssertionStore, updates handle_token_exchange logic, supports id_token, and fixes audience verification.