### PR TITLE
feat(op): add RedisClientAssertionStore backed by redis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,7 @@ dependencies = [
  "p256",
  "rand 0.9.5",
  "rand_core 0.6.4",
+ "redis",
  "serde",
  "serde_json",
  "sha2",
@@ -751,6 +752,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
 ]
 
 [[package]]
@@ -1553,6 +1563,12 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferroid"
@@ -3239,8 +3255,10 @@ checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "backon",
  "bytes",
  "combine",
+ "futures",
  "futures-util",
  "itertools 0.13.0",
  "itoa",

--- a/crates/authkestra-op/Cargo.toml
+++ b/crates/authkestra-op/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
+redis = { version = "0.27", optional = true, features = ["tokio-comp"] }
 authkestra-engine = { workspace = true, default-features = false, features = ["token", "memory"] }
 authkestra-resource = { workspace = true, default-features = false }
 serde = { version = "1.0", features = ["derive"] }
@@ -29,6 +30,7 @@ argon2 = "0.5.3"
 sqlx = { version = "0.8", optional = true, features = ["runtime-tokio", "json", "chrono"] }
 
 [features]
+redis = ["dep:redis"]
 default = ["rustls-aws-lc-rs"]
 
 sqlx = ["dep:sqlx"]

--- a/crates/authkestra-op/Cargo.toml
+++ b/crates/authkestra-op/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 readme.workspace = true
 
 [dependencies]
-redis = { version = "0.27", optional = true, features = ["tokio-comp"] }
+redis = { version = "0.27", optional = true, features = ["tokio-comp", "connection-manager"] }
 authkestra-engine = { workspace = true, default-features = false, features = ["token", "memory"] }
 authkestra-resource = { workspace = true, default-features = false }
 serde = { version = "1.0", features = ["derive"] }
@@ -52,7 +52,7 @@ rustls-no-provider = [
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
 testcontainers = "0.27.3"
-testcontainers-modules = { version = "0.15.0", features = ["postgres", "mysql"] }
+testcontainers-modules = { version = "0.15.0", features = ["postgres", "mysql", "redis"] }
 # Test-only: generating real EC P-256 keypairs and signing enrolment
 # challenges with them, to exercise the attestation ceremony end-to-end
 # rather than mocking the crypto away. Already present in the dependency

--- a/crates/authkestra-op/src/lib.rs
+++ b/crates/authkestra-op/src/lib.rs
@@ -57,6 +57,10 @@ pub mod refresh;
 pub mod store;
 pub use store::OpStore;
 
+#[cfg(feature = "redis")]
+/// Redis-backed implementations.
+pub mod redis_store;
+
 #[cfg(feature = "sqlx")]
 /// Native SQL implementations using sqlx.
 pub mod sqlx_store;

--- a/crates/authkestra-op/src/redis_store.rs
+++ b/crates/authkestra-op/src/redis_store.rs
@@ -2,27 +2,37 @@ use crate::client_assertion::ClientAssertionStore;
 use crate::error::OpError;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use redis::aio::ConnectionManager;
 
 /// A Redis-backed store for client assertions to prevent replay attacks.
 #[derive(Clone)]
 pub struct RedisClientAssertionStore {
-    client: redis::Client,
+    conn: ConnectionManager,
     prefix: String,
 }
 
 impl RedisClientAssertionStore {
     /// Creates a new RedisClientAssertionStore from a redis URL and a key prefix.
-    pub fn new(redis_url: &str, prefix: String) -> Result<Self, OpError> {
+    pub async fn new(redis_url: &str, prefix: String) -> Result<Self, OpError> {
         let client = redis::Client::open(redis_url).map_err(|e| {
-            tracing::error!("Failed to open redis client: {e}");
+            tracing::error!(error = %e, "Failed to open redis client");
             OpError::Storage
         })?;
-        Ok(Self { client, prefix })
+        Self::with_client(client, prefix).await
     }
 
     /// Creates a new RedisClientAssertionStore from an existing redis client and a key prefix.
-    pub fn with_client(client: redis::Client, prefix: String) -> Self {
-        Self { client, prefix }
+    pub async fn with_client(client: redis::Client, prefix: String) -> Result<Self, OpError> {
+        let conn = client.get_connection_manager().await.map_err(|e| {
+            tracing::error!(error = %e, "Failed to create Redis connection manager");
+            OpError::Storage
+        })?;
+        Ok(Self::with_connection_manager(conn, prefix))
+    }
+
+    /// Creates a new RedisClientAssertionStore from a pre-configured `ConnectionManager`.
+    pub fn with_connection_manager(conn: ConnectionManager, prefix: String) -> Self {
+        Self { conn, prefix }
     }
 
     fn key(&self, jti: &str) -> String {
@@ -33,21 +43,14 @@ impl RedisClientAssertionStore {
 #[async_trait]
 impl ClientAssertionStore for RedisClientAssertionStore {
     async fn record_jti(&self, jti: &str, expires_at: DateTime<Utc>) -> Result<bool, OpError> {
-        let mut conn = self
-            .client
-            .get_multiplexed_async_connection()
-            .await
-            .map_err(|e| {
-                tracing::error!(error = %e, "Redis connection error");
-                OpError::Storage
-            })?;
-
         let now = Utc::now();
         if expires_at <= now {
+            tracing::debug!(jti = %jti, "Assertion is already expired; refusing without querying Redis");
             return Ok(false);
         }
         let ttl_secs = (expires_at - now).num_seconds().max(1) as u64;
 
+        let mut conn = self.conn.clone();
         let res: Option<String> = redis::cmd("SET")
             .arg(self.key(jti))
             .arg("1")
@@ -63,5 +66,48 @@ impl ClientAssertionStore for RedisClientAssertionStore {
 
         // If res is Some("OK"), it means SET NX succeeded (the JTI is new).
         Ok(res.is_some())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::redis::REDIS_PORT;
+
+    #[tokio::test]
+    async fn test_redis_client_assertion_store_replay_protection() {
+        let node = testcontainers_modules::redis::Redis::default()
+            .start()
+            .await
+            .unwrap();
+        let host_port = node.get_host_port_ipv4(REDIS_PORT).await.unwrap();
+        let redis_url = format!("redis://127.0.0.1:{host_port}");
+
+        let store = RedisClientAssertionStore::new(&redis_url, "test_jti".to_string())
+            .await
+            .unwrap();
+
+        let exp = Utc::now() + chrono::Duration::seconds(60);
+
+        // 1. First record_jti succeeds (returns true)
+        let first = store.record_jti("unique-jti-1", exp).await.unwrap();
+        assert!(first, "First presentation of JTI must succeed");
+
+        // 2. Second record_jti before expiration fails (returns false - replay prevented)
+        let second = store.record_jti("unique-jti-1", exp).await.unwrap();
+        assert!(!second, "Replay of same JTI must be rejected");
+
+        // 3. Different JTI succeeds
+        let another = store.record_jti("unique-jti-2", exp).await.unwrap();
+        assert!(another, "Different JTI must succeed");
+
+        // 4. Expired timestamp returns false immediately
+        let past = Utc::now() - chrono::Duration::seconds(10);
+        let expired = store.record_jti("unique-jti-3", past).await.unwrap();
+        assert!(
+            !expired,
+            "Already-expired assertion must be rejected immediately"
+        );
     }
 }

--- a/crates/authkestra-op/src/redis_store.rs
+++ b/crates/authkestra-op/src/redis_store.rs
@@ -1,0 +1,67 @@
+use crate::client_assertion::ClientAssertionStore;
+use crate::error::OpError;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+/// A Redis-backed store for client assertions to prevent replay attacks.
+#[derive(Clone)]
+pub struct RedisClientAssertionStore {
+    client: redis::Client,
+    prefix: String,
+}
+
+impl RedisClientAssertionStore {
+    /// Creates a new RedisClientAssertionStore from a redis URL and a key prefix.
+    pub fn new(redis_url: &str, prefix: String) -> Result<Self, OpError> {
+        let client = redis::Client::open(redis_url).map_err(|e| {
+            tracing::error!("Failed to open redis client: {e}");
+            OpError::Storage
+        })?;
+        Ok(Self { client, prefix })
+    }
+
+    /// Creates a new RedisClientAssertionStore from an existing redis client and a key prefix.
+    pub fn with_client(client: redis::Client, prefix: String) -> Self {
+        Self { client, prefix }
+    }
+
+    fn key(&self, jti: &str) -> String {
+        format!("{prefix}:{jti}", prefix = self.prefix)
+    }
+}
+
+#[async_trait]
+impl ClientAssertionStore for RedisClientAssertionStore {
+    async fn record_jti(&self, jti: &str, expires_at: DateTime<Utc>) -> Result<bool, OpError> {
+        let mut conn = self
+            .client
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "Redis connection error");
+                OpError::Storage
+            })?;
+
+        let now = Utc::now();
+        if expires_at <= now {
+            return Ok(false);
+        }
+        let ttl_secs = (expires_at - now).num_seconds().max(1) as u64;
+
+        let res: Option<String> = redis::cmd("SET")
+            .arg(self.key(jti))
+            .arg("1")
+            .arg("NX")
+            .arg("EX")
+            .arg(ttl_secs)
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "Redis SET NX error");
+                OpError::Storage
+            })?;
+
+        // If res is Some("OK"), it means SET NX succeeded (the JTI is new).
+        Ok(res.is_some())
+    }
+}


### PR DESCRIPTION
## Description

Adds `RedisClientAssertionStore` for `authkestra-op`, addressing the gap where multi-replica deployments could not safely use `private_key_jwt`. This uses Redis `SET NX EX` to prevent assertion replay across a cluster.

Closes #185