### PR TITLE
fix(op): omit authorization_endpoint when unsupported, gate authorization_code on client grant

### DIFF
--- a/crates/authkestra-op/src/handlers/discovery.rs
+++ b/crates/authkestra-op/src/handlers/discovery.rs
@@ -7,7 +7,14 @@ pub struct OidcDiscovery {
     /// The OP's Issuer identifier.
     pub issuer: String,
     /// URL of the OP's OAuth 2.0 Authorization Endpoint.
-    pub authorization_endpoint: String,
+    ///
+    /// Omitted entirely (not sent as `null`) when this provider's
+    /// `grant_types_supported` does not include `authorization_code` — e.g.
+    /// a deployment that owns no users and only serves token-exchange
+    /// and/or refresh_token grants has no `/authorize` route at all, so
+    /// advertising one would point clients at an endpoint that 404s.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorization_endpoint: Option<String>,
     /// URL of the OP's OAuth 2.0 Token Endpoint.
     pub token_endpoint: String,
     /// URL of the OP's JSON Web Key Set document.
@@ -39,7 +46,11 @@ impl OidcDiscovery {
     pub fn from_config(config: &OpConfig) -> Self {
         Self {
             issuer: config.issuer.clone(),
-            authorization_endpoint: config.authorization_endpoint(),
+            authorization_endpoint: config
+                .grant_types_supported
+                .iter()
+                .any(|grant| grant == "authorization_code")
+                .then(|| config.authorization_endpoint()),
             token_endpoint: config.token_endpoint(),
             jwks_uri: config.jwks_url(),
             userinfo_endpoint: Some(config.userinfo_endpoint()),
@@ -112,7 +123,7 @@ mod tests {
         assert_eq!(doc.issuer, "https://auth.example.com");
         assert_eq!(
             doc.authorization_endpoint,
-            "https://auth.example.com/authorize"
+            Some("https://auth.example.com/authorize".to_string())
         );
         assert_eq!(doc.token_endpoint, "https://auth.example.com/token");
         assert_eq!(doc.jwks_uri, "https://auth.example.com/jwks.json");
@@ -175,5 +186,47 @@ mod tests {
         assert!(doc
             .token_endpoint_auth_methods_supported
             .contains(&"client_secret_basic".to_string()));
+    }
+
+    /// A provider that serves no `authorization_code` grant (e.g. a
+    /// token-exchange-only deployment with no `/authorize` route at all)
+    /// must not advertise an `authorization_endpoint` that 404s. Asserted
+    /// against the serialized JSON, not the Rust field, so this test's
+    /// expectations hold regardless of whether the field is typed as a
+    /// plain `String` or an omittable `Option<String>`.
+    #[test]
+    fn authorization_endpoint_omitted_when_no_auth_code_grant() {
+        let mut config = discovery_config();
+        config.grant_types_supported = vec![
+            "urn:ietf:params:oauth:grant-type:token-exchange".to_string(),
+            "refresh_token".to_string(),
+        ];
+        config.response_types_supported = vec![];
+
+        let doc = OidcDiscovery::from_config(&config);
+        let json = serde_json::to_value(&doc).unwrap();
+
+        assert!(
+            json.get("authorization_endpoint").is_none(),
+            "a provider serving no authorization_code grant must not advertise \
+             an authorization_endpoint that 404s; got {:?}",
+            json.get("authorization_endpoint")
+        );
+    }
+
+    /// A provider that does serve `authorization_code` must keep advertising
+    /// `authorization_endpoint` exactly as before — byte-identical JSON, not
+    /// just field presence.
+    #[test]
+    fn authorization_endpoint_present_and_byte_identical_when_auth_code_grant_supported() {
+        let doc = OidcDiscovery::from_config(&discovery_config());
+        let json = serde_json::to_value(&doc).unwrap();
+
+        assert_eq!(
+            json.get("authorization_endpoint"),
+            Some(&serde_json::Value::String(
+                "https://auth.example.com/authorize".to_string()
+            ))
+        );
     }
 }

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -591,6 +591,15 @@ async fn handle_authorization_code(
     op_store: &dyn OpStore,
     tokens: &TokenManager,
 ) -> Result<TokenResponse, TokenErrorResponse> {
+    if !client.allows_grant_type(&GrantType::AuthorizationCode) {
+        tracing::warn!(client_id = %client_id, "Client not authorized for authorization_code grant");
+        return Err(TokenErrorResponse {
+            error: "unauthorized_client".to_string(),
+            error_description: "Client is not authorized to use authorization_code grant type"
+                .to_string(),
+        });
+    }
+
     let code_str = req.code.as_ref().unwrap();
     let req_redirect_uri = req.redirect_uri.as_deref().unwrap_or("");
 
@@ -1356,6 +1365,80 @@ mod tests {
         )
         .await;
         assert_eq!(res.unwrap_err().error, "unauthorized_client");
+    }
+
+    #[tokio::test]
+    async fn test_authorization_code_grant_rejected_when_client_not_granted() {
+        // `client1` is registered without `authorization_code` in its
+        // `grant_types` — unlike `handle_device_code`,
+        // `handle_client_credentials`, `default_handle_refresh_token`, and
+        // `default_handle_token_exchange`, `handle_authorization_code` must
+        // reject this the same way, before ever looking up a code.
+        let req = TokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: Some("some-code".to_string()),
+            redirect_uri: Some("https://cb".to_string()),
+            client_id: Some("client1".to_string()),
+            client_secret: None,
+            code_verifier: None,
+            scope: None,
+            refresh_token: None,
+            subject_token: None,
+            subject_token_type: None,
+            device_code: None,
+            actor_token: None,
+            actor_token_type: None,
+            requested_token_type: None,
+            audience: None,
+            client_assertion: None,
+            client_assertion_type: None,
+        };
+        let clients = authkestra_engine::store::memory::MemoryStore::<
+            crate::client::ClientRegistration,
+        >::new();
+        clients
+            .set(
+                "client1",
+                ClientRegistration {
+                    client_id: "client1".to_string(),
+                    client_secret_hash: None,
+                    redirect_uris: vec!["https://cb".to_string()],
+                    grant_types: vec![GrantType::ClientCredentials],
+                    scopes: vec![],
+                    require_pkce: false,
+                    allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
+                },
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+        let codes =
+            authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new();
+        let refresh =
+            authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new();
+
+        let res = handle_token(
+            req,
+            None,
+            &test_config(false),
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                codes.clone(),
+                refresh.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            ),
+            ),
+            &test_tokens()
+        )
+        .await;
+        let err = res.unwrap_err();
+        assert_eq!(err.error, "unauthorized_client");
+        assert_eq!(
+            err.error_description,
+            "Client is not authorized to use authorization_code grant type"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #213: two small, independent defects in `authkestra-op`'s token endpoint area, found while adopting `authkestra-op` downstream in `lightbridge-authz` (ADORSYS-GIS) as our OIDC issuance surface for the token-exchange grant. `lightbridge-authz` owns no users — it delegates authentication to an upstream IdP and never wires up `/authorize` — which is what surfaced defect 1.

## Defect 1 — discovery always advertises `authorization_endpoint`, even with no `/authorize` route

`OpConfig::authorization_endpoint()` (`crates/authkestra-op/src/config.rs:52-54`) is derived (`format!("{}/authorize", self.issuer)`), not backed by a settable field, so `OidcDiscovery::from_config` always populated it as a non-optional `String` — even for a deployment with no `/authorize` route wired in either framework adapter. A client that trusts discovery gets pointed at an endpoint that 404s.

**Fix:** `OidcDiscovery::authorization_endpoint` becomes `Option<String>` with `#[serde(skip_serializing_if = "Option::is_none")]`, populated only when `authorization_code` is present in `OpConfig.grant_types_supported`:

```rust
authorization_endpoint: config
    .grant_types_supported
    .iter()
    .any(|grant| grant == "authorization_code")
    .then(|| config.authorization_endpoint()),
```

I picked this derivation (rather than a new config field or an opt-out builder method mirroring `with_private_key_jwt()`) because `grant_types_supported` already is the field that says which grants this provider serves, and every existing test fixture that wants `/authorize` already sets `grant_types_supported: vec!["authorization_code".to_string()]` — so this needed no new API surface and every existing caller's serialized output is unchanged. Open to a different shape if you'd prefer one.

**`response_types_supported` observation (not fixed here):** it has the same shape of problem — `from_config` publishes whatever's configured with no validation against the grants actually enabled. Left as a follow-up per the issue; happy to open a separate issue/PR for it if useful.

## Defect 2 — `handle_authorization_code` doesn't check `client.allows_grant_type`

Confirmed by reading every sibling handler in `crates/authkestra-op/src/handlers/token.rs`:

- `handle_device_code` (line 433) checks `client.allows_grant_type(&GrantType::DeviceCode)` first.
- `handle_client_credentials` (line 780) checks `client.allows_grant_type(&GrantType::ClientCredentials)` first.
- `default_handle_refresh_token` (line 850) checks `client.allows_grant_type(&GrantType::RefreshToken)` first.
- `default_handle_token_exchange` (line 1004) checks `client.allows_grant_type(&GrantType::TokenExchange)` first.
- `handle_authorization_code` (line 586) had **no** such check — straight to `op_store.consume_code(code_str)`.

**Fix:** added the same check, same style, same error shape, at the top of `handle_authorization_code`:

```rust
if !client.allows_grant_type(&GrantType::AuthorizationCode) {
    tracing::warn!(client_id = %client_id, "Client not authorized for authorization_code grant");
    return Err(TokenErrorResponse {
        error: "unauthorized_client".to_string(),
        error_description: "Client is not authorized to use authorization_code grant type"
            .to_string(),
    });
}
```

## Overlap with concurrent PRs — heads up

I was told two other agents are concurrently preparing PRs against `crates/authkestra-engine/src/token/mod.rs` and `crates/authkestra-op/src/handlers/token.rs` (the latter adding `issued_token_type` to `TokenResponse` and changing a function's visibility). This PR's `token.rs` change is intentionally surgical: it only touches inside the body of `handle_authorization_code` (adds a check before the existing first line) plus one new test appended after an existing one — it does not touch `TokenResponse`, its constructors, or any function signature/visibility. I confirmed by grep that `TokenResponse` on current `main` has no `issued_token_type` field, so this PR is based on pre-that-change `main`; if it lands after the other PR, the diff should still apply cleanly since the two touch disjoint regions, but flagging in case a rebase is needed.

## Test evidence

Both tests were run against **unmodified** `origin/main` (`a19cdd2`) first and confirmed to fail for the predicted reason, then again after the fix.

**Defect 2, before the fix:**
```
$ cargo test -p authkestra-op --all-features test_authorization_code_grant_rejected_when_client_not_granted -- --nocapture
thread 'handlers::token::tests::test_authorization_code_grant_rejected_when_client_not_granted' panicked at crates/authkestra-op/src/handlers/token.rs:1428:9:
assertion `left == right` failed
  left: "invalid_grant"
 right: "unauthorized_client"
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 123 filtered out
```
— exactly the predicted mechanism: without the gate, the request falls through to code lookup and fails there instead, with the wrong error.

**Defect 1, before the fix:**
```
$ cargo test -p authkestra-op --all-features authorization_endpoint_ -- --nocapture
thread 'handlers::discovery::tests::authorization_endpoint_omitted_when_no_auth_code_grant' panicked at crates/authkestra-op/src/handlers/discovery.rs:198:9:
a provider serving no authorization_code grant must not advertise an authorization_endpoint that 404s; got Some(String("https://auth.example.com/authorize"))
test handlers::discovery::tests::authorization_endpoint_present_and_byte_identical_when_auth_code_grant_supported ... ok
test handlers::discovery::tests::authorization_endpoint_omitted_when_no_auth_code_grant ... FAILED
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 124 filtered out
```
— the byte-identical case already passed pre-fix (expected — that's the existing behavior this PR must not change), and the omission case failed for exactly the predicted reason.

**After the fix**, full `authkestra-op` suite:
```
$ cargo test -p authkestra-op --all-features
test result: ok. 126 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
(123 pre-existing + the 3 new/changed tests above; `test_discovery_from_config`'s `authorization_endpoint` assertion updated from a bare `String` compare to `Some(...)`, no other pre-existing test touched.)

## Verification

```
$ cargo fmt --all -- --check
(clean)

$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) — no warnings

$ cargo test --workspace --all-features
(all 30 test binaries across the workspace: 225 passed, 0 failed, 0 AddrInUse —
 including authkestra-op's 126, examples_e2e's 25, and authkestra-engine's 52)
```

## AI Usage Declaration

I (an AI agent, prompted by a human maintainer of a downstream consumer) verified both defects directly against `origin/main` before writing any code, wrote both tests against the unmodified handlers first and confirmed each failed for the predicted reason (output above is real, from this run), then applied the minimal fix matching each function's existing sibling conventions, and reran fmt/clippy/tests for the touched crate plus the full workspace. A human reviewed the diff before it was pushed. Treat this as a proposal — happy to adjust either fix's shape if you'd prefer something different.
