### PR TITLE
fix(engine): honor extra["jti"] as a jti override, stop emitting duplicate-key JWTs

### DIFF
--- a/crates/authkestra-engine/src/token/mod.rs
+++ b/crates/authkestra-engine/src/token/mod.rs
@@ -45,6 +45,29 @@ impl From<&str> for Audience {
     }
 }
 
+/// Removes a caller-supplied `jti` from `extra`, if present as a JSON
+/// string, so it can be assigned to the named `Claims::jti` field instead
+/// of staying in the flattened `extra` map. Falls back to a generated
+/// UUIDv4 when `extra` has no usable `"jti"` entry — either absent, or
+/// present but not a JSON string (RFC 7519 §4.1.7 requires `jti` to be a
+/// string).
+///
+/// This is the fix for #212: `Claims::extra` is `#[serde(flatten)]`ed
+/// alongside the named `jti` field, so a `"jti"` entry left in `extra`
+/// would serialize twice under the same key — a payload `TokenManager`
+/// could mint but never decode again (`serde_json` hard-errors on a
+/// literal duplicate field, flattened or not). Removing the key here,
+/// unconditionally, guarantees the wire payload can never carry two `jti`
+/// entries, and doubles as the override mechanism: a caller who needs a
+/// non-UUID id format (e.g. CUID2) supplies it via `extra["jti"]` and it
+/// is used verbatim.
+fn take_jti(extra: &mut HashMap<String, serde_json::Value>) -> String {
+    match extra.remove("jti") {
+        Some(serde_json::Value::String(jti)) => jti,
+        _ => uuid::Uuid::new_v4().to_string(),
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Claims {
     // Standard OIDC claims
@@ -234,17 +257,24 @@ impl TokenManager {
     /// database round-trip. Keys in `extra` take precedence over any
     /// same-named field set elsewhere in `extra` by this method; they cannot
     /// override the top-level standard claims (`sub`, `aud`, `exp`, etc.)
-    /// since those are not part of the flattened map.
+    /// since those are not part of the flattened map, with one exception:
+    /// `jti` is a reserved key. If `extra["jti"]` is a JSON string, it is
+    /// removed from `extra` and used verbatim as the token's `jti` claim
+    /// instead of a generated UUIDv4 — see [`take_jti`] for why this has to
+    /// happen this way rather than leaving the key in `extra`. `nbf`
+    /// (not-before, set to issuance time) and `identity` are unconditional
+    /// parts of this token's contract and have no opt-out.
     pub fn issue_user_token_with_extra(
         &self,
         identity: Identity,
         expires_in_secs: u64,
         scope: Option<String>,
         aud: Option<String>,
-        extra: HashMap<String, serde_json::Value>,
+        mut extra: HashMap<String, serde_json::Value>,
     ) -> Result<String, AuthError> {
         let now = chrono::Utc::now().timestamp() as usize;
         let expiration = now + expires_in_secs as usize;
+        let jti = take_jti(&mut extra);
 
         let claims = Claims {
             iss: self.issuer.clone(),
@@ -253,7 +283,7 @@ impl TokenManager {
             exp: expiration,
             iat: now,
             nbf: Some(now),
-            jti: Some(uuid::Uuid::new_v4().to_string()),
+            jti: Some(jti),
             scope,
             identity: Some(identity),
             extra,
@@ -288,16 +318,22 @@ impl TokenManager {
     /// is left as-is. This preserves OIDC `nonce` semantics — it reflects
     /// what the client sent in the authorization request — and keeps it from
     /// being accidentally clobbered by unrelated custom claims.
+    ///
+    /// `jti` is likewise reserved: see
+    /// [`Self::issue_user_token_with_extra`] for how `extra["jti"]`
+    /// overrides the generated one. `nbf` and `identity` are unconditional
+    /// on this path too, with no opt-out.
     pub fn issue_id_token_with_extra(
         &self,
         identity: Identity,
         client_id: &str,
         nonce: Option<String>,
         expires_in_secs: u64,
-        extra: HashMap<String, serde_json::Value>,
+        mut extra: HashMap<String, serde_json::Value>,
     ) -> Result<String, AuthError> {
         let now = chrono::Utc::now().timestamp() as usize;
         let expiration = now + expires_in_secs as usize;
+        let jti = take_jti(&mut extra);
 
         let mut claims = Claims {
             iss: self.issuer.clone(),
@@ -306,7 +342,7 @@ impl TokenManager {
             exp: expiration,
             iat: now,
             nbf: Some(now),
-            jti: Some(uuid::Uuid::new_v4().to_string()),
+            jti: Some(jti),
             scope: None,
             identity: Some(identity),
             extra,
@@ -339,17 +375,19 @@ impl TokenManager {
 
     /// Issues a machine-to-machine (M2M) token for a client, stamping the
     /// given `extra` claims onto the token in addition to the standard/core
-    /// claims. See [`Self::issue_user_token_with_extra`] for the rationale.
+    /// claims. See [`Self::issue_user_token_with_extra`] for the rationale,
+    /// including the `extra["jti"]` override.
     pub fn issue_client_token_with_extra(
         &self,
         client_id: &str,
         expires_in_secs: u64,
         scope: Option<String>,
         aud: Option<String>,
-        extra: HashMap<String, serde_json::Value>,
+        mut extra: HashMap<String, serde_json::Value>,
     ) -> Result<String, AuthError> {
         let now = chrono::Utc::now().timestamp() as usize;
         let expiration = now + expires_in_secs as usize;
+        let jti = take_jti(&mut extra);
 
         let claims = Claims {
             iss: self.issuer.clone(),
@@ -358,7 +396,7 @@ impl TokenManager {
             exp: expiration,
             iat: now,
             nbf: Some(now),
-            jti: Some(uuid::Uuid::new_v4().to_string()),
+            jti: Some(jti),
             scope,
             identity: None,
             extra,
@@ -378,15 +416,17 @@ impl TokenManager {
     /// apart from those (e.g. `authkestra-op`'s device/service attestations,
     /// whose contract requires `typ: "webank-attest+jws"` rather than the
     /// default `"JWT"`). Additive alongside the `issue_*_token*` family
-    /// above; those are unchanged.
+    /// above; those are unchanged. `extra["jti"]` is honored the same way
+    /// as [`Self::issue_user_token_with_extra`].
     pub fn issue_custom_token(
         &self,
         sub: String,
         expires_in_secs: u64,
         typ: &str,
-        extra: HashMap<String, serde_json::Value>,
+        mut extra: HashMap<String, serde_json::Value>,
     ) -> Result<String, AuthError> {
         let now = chrono::Utc::now().timestamp() as usize;
+        let jti = take_jti(&mut extra);
         let claims = Claims {
             iss: self.issuer.clone(),
             sub,
@@ -394,7 +434,7 @@ impl TokenManager {
             exp: now + expires_in_secs as usize,
             iat: now,
             nbf: Some(now),
-            jti: Some(uuid::Uuid::new_v4().to_string()),
+            jti: Some(jti),
             scope: None,
             identity: None,
             extra,
@@ -688,6 +728,30 @@ MC4CAQAwBQYDK2VwBCIEIPlsnSfvh53rJ+Tlbo8e7cgq2mIkWQ1NCM5paVeinUh8
         assert_eq!(claims.extra.get("cnf").unwrap()["jkt"], "abc");
     }
 
+    /// Same jti-override coverage as
+    /// `test_issue_user_token_with_extra_jti_override_no_duplicate_key`,
+    /// exercised on `issue_custom_token`.
+    #[test]
+    fn test_issue_custom_token_jti_override_round_trips() {
+        let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
+
+        let mut extra = HashMap::new();
+        extra.insert(
+            "jti".to_string(),
+            serde_json::json!("caller-supplied-cuid2"),
+        );
+
+        let token = manager
+            .issue_custom_token("device-1".to_string(), 60, "webank-attest+jws", extra)
+            .unwrap();
+        let claims = manager
+            .validate_token(&token, None)
+            .expect("TokenManager must be able to decode the token it just issued");
+
+        assert_eq!(claims.jti, Some("caller-supplied-cuid2".to_string()));
+        assert!(!claims.extra.contains_key("jti"));
+    }
+
     #[test]
     fn test_issue_user_token_with_extra_round_trips_custom_claims() {
         let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
@@ -737,6 +801,74 @@ MC4CAQAwBQYDK2VwBCIEIPlsnSfvh53rJ+Tlbo8e7cgq2mIkWQ1NCM5paVeinUh8
         assert!(claims.extra.is_empty());
     }
 
+    /// Regression test for #212: `extra["jti"]` used to be merged onto the
+    /// token alongside the named `Claims::jti` field via
+    /// `#[serde(flatten)]`, producing a wire payload with two `"jti"` keys
+    /// that `TokenManager` itself could not decode (serde hard-errors on a
+    /// literal duplicate field). This asserts both halves of that bug are
+    /// gone: the payload has exactly one `jti` key, and it carries the
+    /// caller's value, not a generated one.
+    #[test]
+    fn test_issue_user_token_with_extra_jti_override_no_duplicate_key() {
+        let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
+        let identity = Identity {
+            provider_id: "mock".to_string(),
+            external_id: "user123".to_string(),
+            email: None,
+            username: None,
+            attributes: HashMap::new(),
+        };
+
+        let mut extra = HashMap::new();
+        extra.insert(
+            "jti".to_string(),
+            serde_json::json!("caller-supplied-cuid2"),
+        );
+
+        let token = manager
+            .issue_user_token_with_extra(identity, 3600, None, None, extra)
+            .unwrap();
+
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let payload_b64 = token.split('.').nth(1).unwrap();
+        let payload_json = String::from_utf8(URL_SAFE_NO_PAD.decode(payload_b64).unwrap()).unwrap();
+        assert_eq!(
+            payload_json.matches("\"jti\"").count(),
+            1,
+            "wire payload must contain exactly one jti key, got: {payload_json}"
+        );
+
+        let claims = manager
+            .validate_token(&token, None)
+            .expect("TokenManager must be able to decode the token it just issued");
+        assert_eq!(claims.jti, Some("caller-supplied-cuid2".to_string()));
+    }
+
+    /// Proves the default path (no `jti` in `extra`) is unchanged: a
+    /// generated UUIDv4 is still stamped when the caller doesn't supply one.
+    #[test]
+    fn test_issue_user_token_with_extra_default_jti_is_still_generated_uuid() {
+        let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
+        let identity = Identity {
+            provider_id: "mock".to_string(),
+            external_id: "user123".to_string(),
+            email: None,
+            username: None,
+            attributes: HashMap::new(),
+        };
+
+        let token = manager
+            .issue_user_token_with_extra(identity, 3600, None, None, HashMap::new())
+            .unwrap();
+        let claims = manager.validate_token(&token, None).unwrap();
+
+        let jti = claims.jti.expect("jti must still be generated by default");
+        assert!(
+            uuid::Uuid::parse_str(&jti).is_ok(),
+            "default-path jti must still be a UUID, got: {jti}"
+        );
+    }
+
     #[test]
     fn test_issue_client_token_with_extra_round_trips_custom_claims() {
         let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
@@ -765,6 +897,30 @@ MC4CAQAwBQYDK2VwBCIEIPlsnSfvh53rJ+Tlbo8e7cgq2mIkWQ1NCM5paVeinUh8
         let claims = manager.validate_token(&token, None).unwrap();
 
         assert!(claims.extra.is_empty());
+    }
+
+    /// Same jti-override coverage as
+    /// `test_issue_user_token_with_extra_jti_override_no_duplicate_key`,
+    /// exercised on the client (M2M) token path.
+    #[test]
+    fn test_issue_client_token_with_extra_jti_override_round_trips() {
+        let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
+
+        let mut extra = HashMap::new();
+        extra.insert(
+            "jti".to_string(),
+            serde_json::json!("caller-supplied-cuid2"),
+        );
+
+        let token = manager
+            .issue_client_token_with_extra("client-1", 3600, None, None, extra)
+            .unwrap();
+        let claims = manager
+            .validate_token(&token, None)
+            .expect("TokenManager must be able to decode the token it just issued");
+
+        assert_eq!(claims.jti, Some("caller-supplied-cuid2".to_string()));
+        assert!(!claims.extra.contains_key("jti"));
     }
 
     #[test]
@@ -837,6 +993,37 @@ MC4CAQAwBQYDK2VwBCIEIPlsnSfvh53rJ+Tlbo8e7cgq2mIkWQ1NCM5paVeinUh8
             claims.extra.get("nonce"),
             Some(&serde_json::json!("real-nonce"))
         );
+    }
+
+    /// Same jti-override coverage as
+    /// `test_issue_user_token_with_extra_jti_override_no_duplicate_key`,
+    /// exercised on the id-token path.
+    #[test]
+    fn test_issue_id_token_with_extra_jti_override_round_trips() {
+        let manager = TokenManager::new(b"secret", Some("issuer".to_string()));
+        let identity = Identity {
+            provider_id: "mock".to_string(),
+            external_id: "user123".to_string(),
+            email: None,
+            username: None,
+            attributes: HashMap::new(),
+        };
+
+        let mut extra = HashMap::new();
+        extra.insert(
+            "jti".to_string(),
+            serde_json::json!("caller-supplied-cuid2"),
+        );
+
+        let token = manager
+            .issue_id_token_with_extra(identity, "client-1", None, 3600, extra)
+            .unwrap();
+        let claims = manager
+            .validate_token(&token, None)
+            .expect("TokenManager must be able to decode the token it just issued");
+
+        assert_eq!(claims.jti, Some("caller-supplied-cuid2".to_string()));
+        assert!(!claims.extra.contains_key("jti"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #212: `TokenManager` (`crates/authkestra-engine/src/token/mod.rs`) gives callers no way to supply their own `jti`, and the one workaround that looks like it should work — passing `"jti"` via the `extra` map — silently produces a token the engine itself cannot decode.

## The mechanism, precisely

`Claims` has both a named `jti: Option<String>` field (`token/mod.rs:57`, unchanged line numbers as of `a19cdd2`) and a `#[serde(flatten)]`-merged `extra: HashMap<String, serde_json::Value>`. If a caller puts `"jti"` in `extra`, both the named field and the flattened entry serialize under the same JSON key. `encode()` doesn't validate that, so minting succeeds and produces a payload with two `"jti"` keys — undefined per RFC 8259 §4 ("names within an object SHOULD be unique") and assumed-unique per RFC 7519 §4 for JWTs specifically.

I reproduced this on unmodified `a19cdd2` before writing any fix: `issue_user_token_with_extra` with `extra["jti"] = "caller-supplied-cuid2"` produces `{...,"jti":"<generated-uuid>",...,"jti":"caller-supplied-cuid2"}`, and feeding that same token straight back into `manager.validate_token(...)` returns `Err(Token("JSON error: duplicate field \`jti\` at line 1 column ..."))` — `serde_json` hard-errors on the literal duplicate key when deserializing back into `Claims`. So `TokenManager` can mint a token it cannot decode, silently at mint time and loudly at verify time. A generic/spec-tolerant parser (e.g. `serde_json::Value`, or any last-value-wins parser, which covers most real-world JWT libraries) would instead silently keep the caller's `jti` and drop the engine-minted one — so which value "wins" depends entirely on which parser reads the token.

The same shape hits `issue_id_token_with_extra`, `issue_client_token_with_extra`, and `issue_custom_token` — anywhere `extra` reaches a `Claims` literal.

## The fix

Added `take_jti(extra: &mut HashMap<String, Value>) -> String`, called by all four issuance paths before constructing `Claims`:

```rust
fn take_jti(extra: &mut HashMap<String, serde_json::Value>) -> String {
    match extra.remove("jti") {
        Some(serde_json::Value::String(jti)) => jti,
        _ => uuid::Uuid::new_v4().to_string(),
    }
}
```

It unconditionally removes any `"jti"` entry from `extra` — present-and-a-string, present-and-not-a-string (RFC 7519 §4.1.7 requires `jti` to be a string, so a non-string value is treated the same as absent and a UUID is generated), or absent — before `extra` is moved into `Claims`. That's what guarantees the wire payload can never carry two `jti` keys, regardless of what a caller puts in `extra`. When the removed value is a string, it becomes the token's `jti` verbatim; this is also how a caller now supplies their own `jti` — no new parameter, no new signature. It mirrors the precedent already in this file: `issue_id_token_with_extra` already treats `"nonce"` in `extra` as a reserved, overridable key, just with the explicit `nonce` parameter winning instead of a generated default.

## Design chosen and why

Went with "fix `extra["jti"]` to be a real override, using the existing `_with_extra` entry points" rather than adding a new `jti: Option<String>` parameter to four function signatures. The issue text itself flagged the `_with_extra` variants as "the natural place... but the important part isn't the exact mechanism." This gets the override for free from the fix that was mandatory anyway (the duplicate-key bug has to be fixed regardless of what happens with the override ask), and it's zero new API surface. If you'd rather have an explicit parameter (or a small options struct, given `issue_user_token_with_extra` is already at 5 positional args), I'm not attached to this shape — happy to adjust.

**`nbf`/`identity`**: left unconditional, as before, but now called out explicitly in the doc comments of `issue_user_token_with_extra` and `issue_id_token_with_extra` as fixed contract elements with no opt-out (client-credentials and custom-token paths already pass `identity: None`, which `skip_serializing_if` omits, so this only applies to the two identity-bearing paths). I judged a full opt-out mechanism more invasive than one PR should bundle with a duplicate-key bug fix — happy to open that as a separate, focused follow-up if you'd like it, now that it's a documented, not just implicit, gap.

## Compatibility story

Every existing caller of `issue_user_token`, `issue_id_token`, `issue_client_token`, `issue_custom_token`, and their `_with_extra` variants keeps compiling and behaves identically, because `extra` without a `"jti"` key hits the same `uuid::Uuid::new_v4()` fallback as before — proven by `test_issue_user_token_with_extra_default_jti_is_still_generated_uuid`. The only behavior change is for callers who put `"jti"` in `extra`, and that path was producing an undecodable token before this fix, so there's no working behavior to preserve there.

## Downstream motivation

`lightbridge-authz` (ADORSYS-GIS) is adopting `authkestra-op`/`authkestra-engine` as its OIDC issuance surface. It currently pins the dependency to `a19cdd2` by git rev rather than a released version, because #207 and #208 are merged but not yet in a tagged release. `lightbridge-authz` mints every id it owns — including `jti` by name — as a CUID2 through a single chokepoint (an explicit architecture decision, ADR-0039), specifically so nothing else on the call path picks its own id format. `extra["jti"]` now being a real override is what makes adopting `TokenManager` compatible with that.

## Test evidence

All five new tests were run against **unmodified** code first, to prove they fail for the predicted reason, before the fix was applied.

**Before the fix** (`cargo test -p authkestra-engine --all-features jti_override -- --nocapture`, four tests, one per issuance path):

```
thread 'token::tests::test_issue_user_token_with_extra_jti_override_no_duplicate_key' panicked:
assertion `left == right` failed: wire payload must contain exactly one jti key, got:
{"iss":"issuer","sub":"user123","aud":null,"exp":1786743415,"iat":1786739815,"nbf":1786739815,
"jti":"04a39bea-6c16-40a7-9493-0b5c6727f914","scope":null,"identity":{...},"jti":"caller-supplied-cuid2"}
  left: 2
 right: 1

thread 'token::tests::test_issue_id_token_with_extra_jti_override_round_trips' panicked:
TokenManager must be able to decode the token it just issued: Token("JSON error: duplicate field `jti` at line 1 column 266")

thread 'token::tests::test_issue_custom_token_jti_override_round_trips' panicked:
TokenManager must be able to decode the token it just issued: Token("JSON error: duplicate field `jti` at line 1 column 158")

thread 'token::tests::test_issue_client_token_with_extra_jti_override_round_trips' panicked:
TokenManager must be able to decode the token it just issued: Token("JSON error: duplicate field `jti` at line 1 column 158")

test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 53 filtered out
```

Each fails for exactly the predicted mechanism — a literal duplicate `"jti"` key in the raw payload, and the corresponding `duplicate field \`jti\`` decode error — not a compile error or something incidental. (`test_issue_user_token_with_extra_default_jti_is_still_generated_uuid`, the invariance guard, already passed pre-fix as expected — it doesn't touch new behavior.)

**After the fix**, full `authkestra-engine` suite:

```
$ cargo test -p authkestra-engine --all-features
test result: ok. 57 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
  (up from 52 on unmodified main; includes all 5 new jti tests plus every
   pre-existing token::tests::* test unchanged in outcome)
```

`authkestra-op` (the crate one level up, which calls into these issuance paths for the token-exchange/authorization-code/refresh grants) unaffected:

```
$ cargo test -p authkestra-op --all-features
test result: ok. 123 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Lints:

```
$ cargo fmt --all -- --check
(clean)

$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) — no warnings
```

`cargo test --workspace --all-features` is green except the pre-existing `authkestra::tests::examples_e2e::test_all_oauth_examples_sequentially`, which fails with `AddrInUse`/a `404` from whichever example loses the port-3000 race (`lsof -i :3000` shows an unrelated local `node` process already bound there in this environment). Confirmed this is not something this change introduced: stashed this diff and ran the identical test against unmodified `origin/main` — same failure class, same non-deterministic "whichever example runs first" symptom (a different example failed each time: `axum_oauth2_github` with the diff applied, `axum_oidc_google` on unmodified `main`). Restored the diff (`git stash pop`) afterward and re-verified the fix/tests were intact.

## AI Usage Declaration

This PR was authored by an AI coding agent (Claude), prompted by the maintainer of the downstream consumer (`lightbridge-authz`) who filed #212, working in an isolated clone. The agent read #212's full analysis (and re-verified its line numbers and claims against current `main`, all of which held), `CONTRIBUTING.md`/`AGENTS.md`, the CI workflow, and PRs #207/#208 for convention before making changes; wrote the tests; ran them against unmodified code first to confirm they fail for the predicted reason; then applied the fix and confirmed the full suite plus lints. All command output quoted above is real, from this run. A human reviews this PR before merge.

- [x] AI-authored, human-reviewed before merge
- [x] All new logic covered by tests written and run by the agent — including running the duplicate-key tests against unmodified code first to confirm they fail for the predicted reason
- [x] Source-of-truth: https://github.com/marcjazz/authkestra/issues/212

Happy to reshape the `jti`-override mechanism (explicit parameter, options struct, whatever you prefer) or split the `nbf`/`identity` documentation from the `jti` fix if you'd rather review them separately — treat this as a proposal, not a final answer.

Closes #212
