### PR TITLE
op: add issued_token_type to token-exchange response, expose default_handle_token_exchange

### DIFF
--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -76,6 +76,15 @@ pub struct TokenResponse {
     /// The scope of the granted tokens.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<String>,
+    /// The type of token issued in `access_token`, as an RFC 8693 §3 URN
+    /// (e.g. `urn:ietf:params:oauth:token-type:access_token`).
+    ///
+    /// REQUIRED by RFC 8693 §2.2.1 on a `token-exchange` grant response, so
+    /// the client can tell what it actually got back. `None` — and omitted
+    /// from the wire response — for every other grant, whose response shape
+    /// is unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issued_token_type: Option<String>,
 }
 
 /// Error response for the token endpoint.
@@ -571,6 +580,7 @@ async fn handle_device_code(
                     id_token,
                     refresh_token: issued_refresh_token,
                     scope: scope_opt,
+                    issued_token_type: None,
                 })
             } else {
                 Err(TokenErrorResponse {
@@ -767,6 +777,7 @@ async fn handle_authorization_code(
         id_token,
         refresh_token: issued_refresh_token,
         scope: scope_opt,
+        issued_token_type: None,
     })
 }
 
@@ -830,6 +841,7 @@ async fn handle_client_credentials(
         id_token: None, // client credentials does not issue ID tokens
         refresh_token: None,
         scope: requested_scope,
+        issued_token_type: None,
     })
 }
 
@@ -972,6 +984,7 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
         id_token,
         refresh_token: Some(new_refresh_val),
         scope: scope_opt,
+        issued_token_type: None,
     })
 }
 
@@ -982,7 +995,14 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
 /// — split out as a free function so the trait's default method can call it
 /// without duplicating the logic, while `handle_token` reaches it exclusively
 /// through the trait method (so an override actually takes effect).
-pub(crate) async fn default_handle_token_exchange(
+///
+/// `pub` (not `pub(crate)`) so an `OpStore::handle_token_exchange` override
+/// outside this crate can delegate to it and post-process the result — e.g.
+/// stamping extra claims via `TokenManager::issue_user_token_with_extra` —
+/// instead of having to reimplement the RFC 8693 validation (subject-token
+/// validation, audience binding, scope intersection,
+/// `subject_token_type`/`requested_token_type` checks) from scratch.
+pub async fn default_handle_token_exchange(
     req: TokenRequest,
     client_id: String,
     client: crate::client::ClientRegistration,
@@ -1201,6 +1221,11 @@ pub(crate) async fn default_handle_token_exchange(
         id_token,
         refresh_token: None,
         scope: final_scope_str,
+        // RFC 8693 §2.2.1: REQUIRED on a token-exchange response. `access_token`
+        // always carries an access token here regardless of the requested
+        // `requested_token_type` — see the id_token issuance comment above for
+        // why that value doesn't change which field the access token lives in.
+        issued_token_type: Some("urn:ietf:params:oauth:token-type:access_token".to_string()),
     })
 }
 
@@ -1728,7 +1753,13 @@ mod tests {
             &test_tokens()
         )
         .await;
-        assert!(res.is_ok());
+        let resp = res.unwrap();
+        // Read via the serialized wire shape, not the Rust field directly,
+        // so this assertion compiles unmodified: `issued_token_type` is
+        // RFC 8693 §2.2.1's requirement for the token-exchange grant only —
+        // client_credentials must keep an identical response shape.
+        let value = serde_json::to_value(&resp).unwrap();
+        assert!(value.get("issued_token_type").is_none());
     }
 
     #[tokio::test]
@@ -1801,7 +1832,14 @@ mod tests {
         )
         .await;
         assert!(res.is_ok());
-        assert!(res.unwrap().refresh_token.is_some());
+        let resp = res.unwrap();
+        assert!(resp.refresh_token.is_some());
+        // Read via the serialized wire shape, not the Rust field directly,
+        // so this assertion compiles unmodified: `issued_token_type` is
+        // RFC 8693 §2.2.1's requirement for the token-exchange grant only —
+        // refresh_token must keep an identical response shape.
+        let value = serde_json::to_value(&resp).unwrap();
+        assert!(value.get("issued_token_type").is_none());
     }
 
     // --- OpStore::handle_refresh_token override seam (issue #189) ---
@@ -1913,6 +1951,7 @@ mod tests {
                 id_token: Some("overridden-id-token".to_string()),
                 refresh_token: Some("overridden-refresh-token".to_string()),
                 scope: Some("overridden-scope".to_string()),
+                issued_token_type: None,
             })
         }
     }
@@ -2392,6 +2431,7 @@ mod tests {
                 id_token: Some("overridden-tx-id-token".to_string()),
                 refresh_token: None,
                 scope: Some("overridden-scope".to_string()),
+                issued_token_type: None,
             })
         }
     }
@@ -2510,6 +2550,61 @@ mod tests {
         assert_eq!(resp.scope.as_deref(), Some("profile"));
         assert_eq!(resp.id_token, None);
         assert_eq!(resp.refresh_token, None);
+    }
+
+    #[tokio::test]
+    async fn test_tx_issued_token_type_present_and_correct() {
+        let tokens = test_tokens();
+        let subject_token = issue_subject_token(&tokens, "client1", Some("profile".to_string()));
+        let req = default_tx_req(&subject_token);
+
+        let clients = authkestra_engine::store::memory::MemoryStore::<
+            crate::client::ClientRegistration,
+        >::new();
+        clients
+            .set(
+                "client1",
+                ClientRegistration {
+                    client_id: "client1".to_string(),
+                    client_secret_hash: None,
+                    redirect_uris: vec![],
+                    grant_types: vec![GrantType::TokenExchange],
+                    scopes: vec!["profile".to_string()],
+                    require_pkce: false,
+                    allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
+                },
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let res = handle_token(
+            req,
+            None,
+            &test_config(true),
+            &crate::store::CompositeOpStore::new(
+                clients,
+                authkestra_engine::store::memory::MemoryStore::<AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(),
+            ),
+            &tokens,
+        )
+        .await;
+
+        let resp = res.unwrap();
+        // Read via the serialized wire shape rather than the Rust field
+        // directly, so this test compiles unmodified: RFC 8693 §2.2.1 makes
+        // `issued_token_type` a REQUIRED response parameter on a
+        // token-exchange grant response, and its absence on the wire is
+        // exactly the gap this test guards against.
+        let value = serde_json::to_value(&resp).unwrap();
+        assert_eq!(
+            value.get("issued_token_type").and_then(|v| v.as_str()),
+            Some("urn:ietf:params:oauth:token-type:access_token"),
+        );
     }
 
     // --- Token Exchange DoD Tests ---

--- a/crates/authkestra-op/tests/default_handle_token_exchange_visibility_tests.rs
+++ b/crates/authkestra-op/tests/default_handle_token_exchange_visibility_tests.rs
@@ -1,0 +1,137 @@
+//! Proves `authkestra_op::handlers::token::default_handle_token_exchange` is
+//! reachable from *outside* the crate, and that a consumer can delegate to
+//! it and post-process the result instead of reimplementing the RFC 8693
+//! validation (subject-token validation, audience binding, scope
+//! intersection, `subject_token_type`/`requested_token_type` checks) that
+//! already lives inside it.
+//!
+//! Being an integration test (a separate compilation unit under `tests/`,
+//! not `#[cfg(test)] mod tests` inside the crate), `pub(crate)` visibility on
+//! the function is genuinely enforced here: this file would fail to
+//! *compile* against the crate as published prior to this change, because
+//! `default_handle_token_exchange` was not part of the crate's public API.
+
+use std::collections::HashMap;
+
+use authkestra_engine::auth::state::Identity;
+use authkestra_engine::token::TokenManager;
+use authkestra_op::client::{ClientRegistration, GrantType};
+use authkestra_op::config::OpConfig;
+use authkestra_op::handlers::token::TokenRequest;
+
+fn test_tokens() -> TokenManager {
+    TokenManager::new(b"super_secret_key_that_is_long_enough_for_hmac", None)
+}
+
+fn test_identity() -> Identity {
+    Identity {
+        provider_id: "test".to_string(),
+        external_id: "user123".to_string(),
+        username: Some("user123".to_string()),
+        email: None,
+        attributes: HashMap::new(),
+    }
+}
+
+fn test_config() -> OpConfig {
+    OpConfig {
+        issuer: "https://issuer.example.com".to_string(),
+        scopes_supported: vec!["profile".to_string()],
+        response_types_supported: vec!["code".to_string()],
+        grant_types_supported: vec!["urn:ietf:params:oauth:grant-type:token-exchange".to_string()],
+        id_token_signing_alg: "RS256".to_string(),
+        authorization_code_ttl_secs: 60,
+        access_token_ttl_secs: 3600,
+        device_code_ttl_secs: 1800,
+        token_exchange_enabled: true,
+    }
+}
+
+fn test_client() -> ClientRegistration {
+    ClientRegistration {
+        client_id: "client1".to_string(),
+        client_secret_hash: None,
+        redirect_uris: vec![],
+        grant_types: vec![GrantType::TokenExchange],
+        scopes: vec!["profile".to_string()],
+        require_pkce: false,
+        allowed_audiences: vec![],
+        token_endpoint_auth_method: None,
+        jwks: None,
+    }
+}
+
+fn exchange_request(subject_token: &str) -> TokenRequest {
+    TokenRequest {
+        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange".to_string(),
+        code: None,
+        redirect_uri: None,
+        client_id: Some("client1".to_string()),
+        client_secret: None,
+        code_verifier: None,
+        scope: None,
+        refresh_token: None,
+        device_code: None,
+        subject_token: Some(subject_token.to_string()),
+        subject_token_type: Some("urn:ietf:params:oauth:token-type:access_token".to_string()),
+        actor_token: None,
+        actor_token_type: None,
+        requested_token_type: None,
+        audience: None,
+        client_assertion: None,
+        client_assertion_type: None,
+    }
+}
+
+#[tokio::test]
+async fn op_store_override_can_delegate_to_default_and_post_process() {
+    let tokens = test_tokens();
+    let identity = test_identity();
+    let subject_token = tokens
+        .issue_user_token(
+            identity.clone(),
+            3600,
+            Some("profile".to_string()),
+            Some("client1".to_string()),
+        )
+        .unwrap();
+
+    let config = test_config();
+    let client = test_client();
+    let req = exchange_request(&subject_token);
+
+    // This is the seam #204/#208 added: an `OpStore::handle_token_exchange`
+    // override delegating to the built-in default and post-processing the
+    // result, instead of hand-reimplementing every RFC 8693 check the
+    // default already performs. Success here proves the default ran the
+    // real validation (subject-token signature, audience binding, scope
+    // intersection) against a request only a passing exchange satisfies.
+    let default_resp = authkestra_op::handlers::token::default_handle_token_exchange(
+        req,
+        "client1".to_string(),
+        client,
+        &config,
+        &tokens,
+    )
+    .await
+    .expect("a valid exchange request should be accepted by the built-in default");
+
+    assert_eq!(default_resp.scope.as_deref(), Some("profile"));
+
+    // Post-process: stamp an extra claim the default alone never adds (the
+    // downstream motivation cited in the issue — `issue_user_token_with_extra`
+    // exists precisely for this, but the default has no way to reach it).
+    let mut extra = HashMap::new();
+    extra.insert("post_processed".to_string(), serde_json::Value::Bool(true));
+    let post_processed_token = tokens
+        .issue_user_token_with_extra(
+            identity,
+            3600,
+            default_resp.scope.clone(),
+            Some(config.issuer.clone()),
+            extra,
+        )
+        .unwrap();
+
+    assert_ne!(post_processed_token, default_resp.access_token);
+}

--- a/crates/authkestra/examples/actix_op_server_custom_grant.rs
+++ b/crates/authkestra/examples/actix_op_server_custom_grant.rs
@@ -180,6 +180,7 @@ impl<
                 refresh_token: None,
                 id_token: None,
                 scope: None,
+                issued_token_type: None,
             });
         }
 

--- a/crates/authkestra/examples/axum_op_server_custom_grant.rs
+++ b/crates/authkestra/examples/axum_op_server_custom_grant.rs
@@ -181,6 +181,7 @@ impl<
                 refresh_token: None,
                 id_token: None,
                 scope: None,
+                issued_token_type: None,
             });
         }
 


### PR DESCRIPTION
## Summary

Fixes #216: two related gaps in the `urn:ietf:params:oauth:grant-type:token-exchange` (RFC 8693) grant handling, found while adopting `authkestra-op` downstream (`lightbridge-authz`, ADORSYS-GIS) as an OIDC issuance surface.

**Gap 1 — `issued_token_type` missing from the token-exchange response.** [RFC 8693 §2.2.1](https://www.rfc-editor.org/rfc/rfc8693#section-2.2.1) makes it a REQUIRED response parameter; `TokenResponse` had no such field at all (`git grep issued_token_type` returned zero hits).

**Gap 2 — `default_handle_token_exchange` (the #204/#208 `OpStore` seam's default body) was `pub(crate)`.** An external `OpStore::handle_token_exchange` override had no way to delegate to it and post-process (e.g. to stamp extra claims via `TokenManager::issue_user_token_with_extra`, which the default never calls) — only to hand-reimplement the whole RFC 8693 validation (subject-token validation, audience binding, scope intersection, `subject_token_type`/`requested_token_type` checks) from scratch.

## Changes

**`TokenResponse`** gets a new `issued_token_type: Option<String>` field, `skip_serializing_if = "Option::is_none"`. Every existing response-construction site (`handle_device_code`'s completion, `handle_authorization_code`, `handle_client_credentials`, `default_handle_refresh_token`) sets it to `None`, so those grants' wire responses are byte-identical to today. Only `default_handle_token_exchange`'s response sets it, to `urn:ietf:params:oauth:token-type:access_token` — the URN of the token actually issued in `access_token`. (`id_token` issuance stays additive and scope-gated as it already was; per the design note in #208, this crate's `TokenResponse` has one `access_token` field regardless of grant, so `issued_token_type` doesn't change which field carries which token.) The two custom-grant examples (`crates/authkestra/examples/{axum,actix}_op_server_custom_grant.rs`) construct a `TokenResponse` directly and needed the new field added too.

**`default_handle_token_exchange`** changes from `pub(crate)` to `pub` — a pure visibility change, no behavior change. Doc comment explains why.

## On the "asymmetry" I went looking for and didn't find

Issue #216 asked me to check whether `default_handle_refresh_token` (the #191-era sibling default) has the same visibility problem, expecting to find it already `pub` and treat that as the argument. It doesn't — it's also `pub(crate)` (line 843 on `main`), so there was no existing inconsistency to point to; both defaults were equally unreachable before this PR. I only widened `default_handle_token_exchange` here, since that's what #216's downstream motivation and test actually needed, but that does introduce a *new* asymmetry (token-exchange's default now delegatable, refresh's still isn't) where none existed before. **Happy to add the identical one-line visibility change to `default_handle_refresh_token` in this PR if you'd rather land both together** — didn't want to presume that scope without asking, per the issue's own framing of it as an open question.

## Test evidence

Proved both new tests catch real gaps by running them against **unmodified `origin/main`** first (mechanically: reverted just `token.rs` to `HEAD`, re-applied only the test-side edits, ran, then restored the full fix and re-ran):

```
$ cargo test -p authkestra-op --lib handlers::token::tests::test_tx_issued_token_type_present_and_correct -- --exact
FAILED — assertion `left == right` failed
  left: None
 right: Some("urn:ietf:params:oauth:token-type:access_token")
  (unmodified TokenResponse has no issued_token_type field at all — the test
  reads it via the serialized JSON shape rather than a direct Rust field
  access, specifically so it compiles either way and fails at runtime for
  the predicted reason, not a compile error)
```

```
$ cargo test -p authkestra-op --test default_handle_token_exchange_visibility_tests
error[E0603]: function `default_handle_token_exchange` is private
   --> crates/authkestra-op/tests/default_handle_token_exchange_visibility_tests.rs:109:56
    |
109 |     let default_resp = authkestra_op::handlers::token::default_handle_token_exchange(
    |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private function
```

This second one can't run against unmodified code at all — being a genuine integration test (a separate compilation unit under `tests/`, not `#[cfg(test)] mod tests` inside the crate), `pub(crate)` is actually enforced here, unlike an in-crate test. The compile failure itself is the proof (same pattern as `test_refresh_token_is_overridable_by_op_store` in #191 / `test_token_exchange_is_overridable_by_op_store` in #208, which couldn't compile before their respective seams existed).

After applying both fixes:

```
$ cargo test -p authkestra-op --lib handlers::token::tests::test_tx_issued_token_type_present_and_correct -- --exact
test handlers::token::tests::test_tx_issued_token_type_present_and_correct ... ok

$ cargo test -p authkestra-op --test default_handle_token_exchange_visibility_tests
test op_store_override_can_delegate_to_default_and_post_process ... ok
```

Also added (regression guards, not gap tests — pass on unmodified code too, since the field simply doesn't exist there):
- an assertion in `test_client_credentials` that `issued_token_type` is absent from a `client_credentials` response
- an assertion in `test_refresh_token` that it's absent from a `refresh_token` response

Full suite, `handlers::token`:
```
test result: ok. 52 passed; 0 failed; 0 ignored; 0 measured; 66 filtered out; finished in 0.79s
```

Full workspace, matching CI's `cargo test --workspace --all-features`:
```
$ cargo test --workspace --all-features
... (all crates)
test result: ok. 124 passed; 0 failed; ...   (authkestra-op)
test result: ok. 1 passed; 0 failed; ...     (default_handle_token_exchange_visibility_tests)
... (all other crates ok)
```
Exit code 0. `crates/authkestra/tests/examples_e2e.rs` (the port-3000 example server test flagged as environmentally flaky in #208) passed cleanly on this run — no `AddrInUse` encountered.

```
$ cargo fmt --all -- --check
(clean)

$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s)
(no warnings)
```

## Scope / concurrent work

This PR only touches `crates/authkestra-op/src/handlers/token.rs`, `crates/authkestra-op/tests/default_handle_token_exchange_visibility_tests.rs`, and the two custom-grant examples. Confirmed via `git diff` that it does not touch `crates/authkestra-engine/src/token/mod.rs` (issue #212's territory) or `crates/authkestra-op/src/handlers/discovery.rs` (the other concurrent PR's territory).

## Verification

- [x] `cargo test --workspace --all-features` — 0 failures, exit code 0
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New tests proven to fail against unmodified code for the predicted reason (one compile failure, one runtime assertion failure) before the fix, pass after
- [x] Confirmed via `git diff` that no hunk touches `crates/authkestra-engine/src/token/mod.rs` or `crates/authkestra-op/src/handlers/discovery.rs`
- [x] Branch based on latest `main` (`a19cdd2`, includes #207/#208)

## AI Usage Declaration

This PR was authored by an AI coding agent (Claude) at the repo owner's (a collaborator on this repo) explicit request, working in an isolated clone to avoid colliding with two other concurrent agents working elsewhere in this repo (issue #212, and a discovery.rs change). Both defects were independently re-verified against current `main` before any code was written — including checking `default_handle_refresh_token`'s visibility, which the issue asked about explicitly and which turned out *not* to show the asymmetry expected (see the "asymmetry" section above; reported as inaccurate rather than papered over). Tests were written first, proven to fail against unmodified code for the predicted reason, then the fix applied and re-verified. A human (the repo maintainer) reviews this PR before merge.

- [x] AI-authored, human-reviewed before merge
- [x] All new logic covered by tests written and run by the agent, not just asserted — including running both against unmodified code first to confirm they fail for the predicted reason
- [x] Source-of-truth: https://github.com/marcjazz/authkestra/issues/216

Closes #216
