### PR TITLE
feat(engine): add private_key_jwt client auth for ClientCredentialsFlow (RFC 7523 §2.2)

### DIFF
--- a/crates/authkestra-engine/src/client_assertion.rs
+++ b/crates/authkestra-engine/src/client_assertion.rs
@@ -1,0 +1,221 @@
+//! Client-side minting of `private_key_jwt` client assertions (RFC 7523
+//! §2.2, OIDC Core §9).
+//!
+//! This is the mirror image of `authkestra_op::client_assertion`, which
+//! *verifies* an inbound assertion at the OP — that module cannot live here
+//! (it needs `ClientRegistration`/replay-store types this crate has no
+//! business knowing about), but this crate is the one place both halves can
+//! share without a dependency cycle: `authkestra-op` already depends on
+//! `authkestra-engine`, never the other way around. So the two constants
+//! below are defined exactly once, here, and `authkestra-op` re-exports them
+//! rather than keeping its own copies — the assertion-type URN and the
+//! maximum assertion lifetime literally cannot drift between the client side
+//! ([`crate::flow::ClientCredentialsFlow::new_private_key_jwt`]) and this
+//! workspace's own OP.
+//!
+//! See [`mint_client_assertion`] for the minting logic itself.
+
+use crate::auth::error::AuthError;
+use chrono::Utc;
+use jsonwebtoken::{Algorithm, EncodingKey, Header};
+use serde::Serialize;
+
+/// The `client_assertion_type` value RFC 7523 §2.2 requires when presenting
+/// a `private_key_jwt` assertion at a token endpoint.
+pub const CLIENT_ASSERTION_TYPE_JWT_BEARER: &str =
+    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+
+/// Upper bound on how far in the future a minted assertion's `exp` may sit.
+///
+/// RFC 7523 §3 requires `exp` to be present and unexpired but sets no
+/// ceiling, and an assertion is a bearer credential for its whole lifetime —
+/// a decade-long one would be a permanent password in JWT clothing. This
+/// crate's own OP (`authkestra_op::client_assertion`) enforces the identical
+/// bound on the verifying side, so minting anything longer-lived here would
+/// only produce assertions that OP (or any other conformant verifier
+/// applying the same discipline) rejects for a reason invisible from the
+/// client side.
+pub const MAX_CLIENT_ASSERTION_LIFETIME_SECS: i64 = 300;
+
+/// The claims RFC 7523 §3 requires a `private_key_jwt` assertion to carry.
+///
+/// `iss` and `sub` are both the client's own `client_id` — RFC 7523 §3
+/// points 1-2 require the assertion to be self-issued for the client it
+/// authenticates, and `authkestra_op::client_assertion::verify_client_assertion`
+/// rejects anything else.
+#[derive(Debug, Serialize)]
+struct AssertionClaims<'a> {
+    iss: &'a str,
+    sub: &'a str,
+    aud: &'a str,
+    jti: String,
+    exp: i64,
+    iat: i64,
+}
+
+/// Mints a fresh `private_key_jwt` client assertion authenticating
+/// `client_id` to `audience` (the token endpoint URL, per RFC 7523 §3).
+///
+/// A fresh `jti` (UUIDv4) is generated on every call: reusing one across
+/// calls would hand a replay-tracking verifier — such as
+/// `authkestra_op::client_assertion::ClientAssertionStore` — a second
+/// presentation of an id it already spent, which is indistinguishable from
+/// an actual replay and would be rejected.
+///
+/// `lifetime_secs` is clamped to `1..=MAX_CLIENT_ASSERTION_LIFETIME_SECS`
+/// rather than trusted verbatim: a caller-supplied value above that ceiling
+/// would only mint an assertion this workspace's own OP (or any verifier
+/// enforcing the same bound) refuses, for a reason invisible from here: it's
+/// cheaper to clamp than to hand back an assertion doomed to fail
+/// verification for a reason invisible at the call site.
+#[tracing::instrument(skip(encoding_key))]
+pub fn mint_client_assertion(
+    client_id: &str,
+    audience: &str,
+    encoding_key: &EncodingKey,
+    alg: Algorithm,
+    kid: Option<&str>,
+    lifetime_secs: i64,
+) -> Result<String, AuthError> {
+    let lifetime_secs = lifetime_secs.clamp(1, MAX_CLIENT_ASSERTION_LIFETIME_SECS);
+    let now = Utc::now();
+    let exp = now + chrono::Duration::seconds(lifetime_secs);
+
+    let claims = AssertionClaims {
+        iss: client_id,
+        sub: client_id,
+        aud: audience,
+        jti: uuid::Uuid::new_v4().to_string(),
+        exp: exp.timestamp(),
+        iat: now.timestamp(),
+    };
+
+    let mut header = Header::new(alg);
+    header.kid = kid.map(str::to_string);
+
+    let assertion = jsonwebtoken::encode(&header, &claims, encoding_key).map_err(|e| {
+        tracing::error!(client_id = %client_id, error = %e, "failed to sign private_key_jwt client assertion");
+        AuthError::Token(e.to_string())
+    })?;
+
+    tracing::debug!(client_id = %client_id, audience = %audience, "minted private_key_jwt client assertion");
+    Ok(assertion)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    use serde_json::Value;
+
+    /// Throwaway Ed25519 private key (PKCS#8 PEM), test-only. Same key used
+    /// in `crate::token::tests`, generated with
+    /// `openssl genpkey -algorithm ed25519`.
+    const TEST_ED25519_PRIVATE_KEY_PEM: &[u8] = b"-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIKIPR2jojpdobYr1M/pjIRuMONpZGYQ+y5yxSqKX9T9/
+-----END PRIVATE KEY-----";
+
+    fn decode_parts(jwt: &str) -> (Value, Value) {
+        let mut parts = jwt.split('.');
+        let header_b64 = parts.next().unwrap();
+        let payload_b64 = parts.next().unwrap();
+        let header: Value =
+            serde_json::from_slice(&URL_SAFE_NO_PAD.decode(header_b64).unwrap()).unwrap();
+        let payload: Value =
+            serde_json::from_slice(&URL_SAFE_NO_PAD.decode(payload_b64).unwrap()).unwrap();
+        (header, payload)
+    }
+
+    #[test]
+    fn mints_an_assertion_with_iss_sub_client_id_and_correct_aud() {
+        let key = EncodingKey::from_ed_pem(TEST_ED25519_PRIVATE_KEY_PEM).unwrap();
+        let jwt = mint_client_assertion(
+            "svc-1",
+            "https://auth.example.com/token",
+            &key,
+            Algorithm::EdDSA,
+            None,
+            60,
+        )
+        .unwrap();
+
+        let (header, payload) = decode_parts(&jwt);
+        assert_eq!(header["alg"], "EdDSA");
+        assert_eq!(payload["iss"], "svc-1");
+        assert_eq!(payload["sub"], "svc-1");
+        assert_eq!(payload["aud"], "https://auth.example.com/token");
+    }
+
+    #[test]
+    fn mints_a_fresh_jti_every_call() {
+        let key = EncodingKey::from_ed_pem(TEST_ED25519_PRIVATE_KEY_PEM).unwrap();
+        let jwt_a = mint_client_assertion(
+            "svc-1",
+            "https://auth.example.com/token",
+            &key,
+            Algorithm::EdDSA,
+            None,
+            60,
+        )
+        .unwrap();
+        let jwt_b = mint_client_assertion(
+            "svc-1",
+            "https://auth.example.com/token",
+            &key,
+            Algorithm::EdDSA,
+            None,
+            60,
+        )
+        .unwrap();
+
+        let (_, payload_a) = decode_parts(&jwt_a);
+        let (_, payload_b) = decode_parts(&jwt_b);
+
+        let jti_a = payload_a["jti"].as_str().unwrap();
+        let jti_b = payload_b["jti"].as_str().unwrap();
+        assert!(!jti_a.is_empty());
+        assert!(!jti_b.is_empty());
+        assert_ne!(jti_a, jti_b, "each minted assertion must carry its own jti");
+    }
+
+    #[test]
+    fn clamps_a_lifetime_beyond_the_max_to_the_max() {
+        let key = EncodingKey::from_ed_pem(TEST_ED25519_PRIVATE_KEY_PEM).unwrap();
+        let jwt = mint_client_assertion(
+            "svc-1",
+            "https://auth.example.com/token",
+            &key,
+            Algorithm::EdDSA,
+            None,
+            MAX_CLIENT_ASSERTION_LIFETIME_SECS * 100,
+        )
+        .unwrap();
+
+        let (_, payload) = decode_parts(&jwt);
+        let exp = payload["exp"].as_i64().unwrap();
+        let iat = payload["iat"].as_i64().unwrap();
+        assert!(
+            exp - iat <= MAX_CLIENT_ASSERTION_LIFETIME_SECS,
+            "exp must never be minted further out than MAX_CLIENT_ASSERTION_LIFETIME_SECS, \
+             got a lifetime of {} seconds",
+            exp - iat
+        );
+    }
+
+    #[test]
+    fn stamps_the_given_kid_onto_the_header() {
+        let key = EncodingKey::from_ed_pem(TEST_ED25519_PRIVATE_KEY_PEM).unwrap();
+        let jwt = mint_client_assertion(
+            "svc-1",
+            "https://auth.example.com/token",
+            &key,
+            Algorithm::EdDSA,
+            Some("key-1"),
+            60,
+        )
+        .unwrap();
+
+        let (header, _) = decode_parts(&jwt);
+        assert_eq!(header["kid"], "key-1");
+    }
+}

--- a/crates/authkestra-engine/src/flow/client_credentials_flow.rs
+++ b/crates/authkestra-engine/src/flow/client_credentials_flow.rs
@@ -1,4 +1,33 @@
 use crate::auth::{error::AuthError, state::OAuthToken};
+use crate::client_assertion::{self, CLIENT_ASSERTION_TYPE_JWT_BEARER};
+use jsonwebtoken::{Algorithm, EncodingKey};
+
+/// How a `ClientCredentialsFlow` authenticates itself to the token endpoint.
+///
+/// An enum rather than a trait object: there are exactly two RFC-defined
+/// shapes this flow speaks (a shared secret, or a self-signed assertion), and
+/// both need direct access to this struct's private fields (`client_id`,
+/// `token_url`) to do their job — an `AuthMethod`-style trait would need to
+/// hand those back in, for no abstraction benefit over a closed enum only
+/// this module matches on.
+enum ClientAuth {
+    /// `client_secret_post` (RFC 6749 §2.3.1): the shared secret is sent as
+    /// a form parameter alongside the request.
+    Secret(String),
+    /// `private_key_jwt` (RFC 7523 §2.2): no shared secret is sent at all —
+    /// instead, a freshly minted assertion proves possession of the private
+    /// half of a key the authorization server already has the public half
+    /// of. See [`crate::client_assertion::mint_client_assertion`].
+    PrivateKeyJwt {
+        encoding_key: EncodingKey,
+        alg: Algorithm,
+        /// Stamped onto the assertion's header `kid`, if the server needs
+        /// it to select among several registered keys. `None` is valid only
+        /// when the server has exactly one registered key for this client —
+        /// see `authkestra_op::client_assertion::select_key`.
+        kid: Option<String>,
+    },
+}
 
 /// Orchestrates the Client Credentials Flow (RFC 6749 Section 4.4).
 ///
@@ -6,13 +35,14 @@ use crate::auth::{error::AuthError, state::OAuthToken};
 /// of a user. This is typically used for client-to-client communication.
 pub struct ClientCredentialsFlow {
     client_id: String,
-    client_secret: String,
+    auth: ClientAuth,
     token_url: String,
     http_client: reqwest::Client,
 }
 
 impl ClientCredentialsFlow {
-    /// Creates a new `ClientCredentialsFlow` instance.
+    /// Creates a new `ClientCredentialsFlow` instance authenticating with a
+    /// shared `client_secret` (RFC 6749 §2.3.1).
     ///
     /// # Arguments
     ///
@@ -22,10 +52,69 @@ impl ClientCredentialsFlow {
     pub fn new(client_id: String, client_secret: String, token_url: String) -> Self {
         Self {
             client_id,
-            client_secret,
+            auth: ClientAuth::Secret(client_secret),
             token_url,
             http_client: reqwest::Client::new(),
         }
+    }
+
+    /// Creates a new `ClientCredentialsFlow` instance authenticating with
+    /// `private_key_jwt` (RFC 7523 §2.2) instead of a shared secret.
+    ///
+    /// Use this when the client cannot hold a shared secret at all — e.g. a
+    /// backend service that only ever authenticates from a keystore holding
+    /// an asymmetric keypair, with just the public half registered against
+    /// this `client_id` at the authorization server. `get_token` mints a
+    /// fresh assertion JWT (`iss`/`sub` = `client_id`, `aud` = `token_url`, a
+    /// new `jti`, and `exp` bounded by
+    /// [`crate::client_assertion::MAX_CLIENT_ASSERTION_LIFETIME_SECS`]) on
+    /// every call and sends it as `client_assertion` alongside
+    /// `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer`,
+    /// in place of `client_secret`.
+    ///
+    /// # Arguments
+    ///
+    /// * `client_id` - The client ID assigned to the client.
+    /// * `signing_key` - The private key to sign assertions with. Must match
+    ///   `alg` (e.g. an Ed25519 key for [`Algorithm::EdDSA`]).
+    /// * `alg` - The signature algorithm `signing_key` signs with. This
+    ///   crate's own OP (`authkestra_op::client_assertion`) derives the
+    ///   algorithm it will accept from the client's *registered public key*,
+    ///   never from this header, so `alg` here must agree with whatever key
+    ///   type was registered.
+    /// * `token_url` - The URL of the token endpoint; also the `aud` claim
+    ///   minted into every assertion.
+    pub fn new_private_key_jwt(
+        client_id: String,
+        signing_key: EncodingKey,
+        alg: Algorithm,
+        token_url: String,
+    ) -> Self {
+        Self {
+            client_id,
+            auth: ClientAuth::PrivateKeyJwt {
+                encoding_key: signing_key,
+                alg,
+                kid: None,
+            },
+            token_url,
+            http_client: reqwest::Client::new(),
+        }
+    }
+
+    /// Stamps `kid` onto the header of every assertion minted by
+    /// `private_key_jwt` authentication, so a server with several keys
+    /// registered for this client can tell which one signed it (see
+    /// `authkestra_op::client_assertion::select_key`).
+    ///
+    /// A no-op when this flow was constructed via [`Self::new`] — there is
+    /// no assertion to stamp a `kid` onto when authenticating with a shared
+    /// secret.
+    pub fn with_kid(mut self, kid: impl Into<String>) -> Self {
+        if let ClientAuth::PrivateKeyJwt { kid: slot, .. } = &mut self.auth {
+            *slot = Some(kid.into());
+        }
+        self
     }
 
     /// Obtains an access token using the client credentials.
@@ -37,17 +126,46 @@ impl ClientCredentialsFlow {
     /// # Returns
     ///
     /// A `Result` containing the `OAuthToken` if successful, or an `AuthError` otherwise.
+    #[tracing::instrument(skip(self, scopes), fields(client_id = %self.client_id))]
     pub async fn get_token(&self, scopes: Option<&[&str]>) -> Result<OAuthToken, AuthError> {
-        let mut params = vec![
-            ("grant_type", "client_credentials"),
-            ("client_id", &self.client_id),
-            ("client_secret", &self.client_secret),
+        let mut params: Vec<(&str, String)> = vec![
+            ("grant_type", "client_credentials".to_string()),
+            ("client_id", self.client_id.clone()),
         ];
 
-        let scope_str;
+        match &self.auth {
+            ClientAuth::Secret(secret) => {
+                tracing::debug!("authenticating with client_secret_post");
+                params.push(("client_secret", secret.clone()));
+            }
+            ClientAuth::PrivateKeyJwt {
+                encoding_key,
+                alg,
+                kid,
+            } => {
+                tracing::debug!("authenticating with private_key_jwt; minting a fresh assertion");
+                let assertion = client_assertion::mint_client_assertion(
+                    &self.client_id,
+                    &self.token_url,
+                    encoding_key,
+                    *alg,
+                    kid.as_deref(),
+                    client_assertion::MAX_CLIENT_ASSERTION_LIFETIME_SECS,
+                )
+                .map_err(|e| {
+                    tracing::error!(error = %e, "failed to mint private_key_jwt client assertion");
+                    e
+                })?;
+                params.push((
+                    "client_assertion_type",
+                    CLIENT_ASSERTION_TYPE_JWT_BEARER.to_string(),
+                ));
+                params.push(("client_assertion", assertion));
+            }
+        }
+
         if let Some(s) = scopes {
-            scope_str = s.join(" ");
-            params.push(("scope", &scope_str));
+            params.push(("scope", s.join(" ")));
         }
 
         let response = self
@@ -57,18 +175,22 @@ impl ClientCredentialsFlow {
             .form(&params)
             .send()
             .await
-            .map_err(|_| AuthError::Network)?;
+            .map_err(|e| {
+                tracing::error!(error = %e, "network error requesting token");
+                AuthError::Network
+            })?;
 
         if !response.status().is_success() {
             let error_text = response.text().await.unwrap_or_default();
+            tracing::warn!(error = %error_text, "token request failed");
             return Err(AuthError::Provider(format!(
                 "Token request failed: {error_text}"
             )));
         }
 
-        response
-            .json::<OAuthToken>()
-            .await
-            .map_err(|e| AuthError::Provider(format!("Failed to parse token response: {e}")))
+        response.json::<OAuthToken>().await.map_err(|e| {
+            tracing::error!(error = %e, "failed to parse token response");
+            AuthError::Provider(format!("Failed to parse token response: {e}"))
+        })
     }
 }

--- a/crates/authkestra-engine/src/lib.rs
+++ b/crates/authkestra-engine/src/lib.rs
@@ -7,6 +7,7 @@ compile_error!(
 );
 
 pub mod auth;
+pub mod client_assertion;
 pub mod engine;
 pub mod flow;
 pub mod protocol;

--- a/crates/authkestra-engine/tests/client_credentials_flow_private_key_jwt_tests.rs
+++ b/crates/authkestra-engine/tests/client_credentials_flow_private_key_jwt_tests.rs
@@ -1,0 +1,250 @@
+//! Client-side `private_key_jwt` (RFC 7523 §2.2) coverage for
+//! `ClientCredentialsFlow`, issue #222.
+//!
+//! Unit coverage of the assertion's claim shape lives alongside
+//! `mint_client_assertion` in `authkestra_engine::client_assertion`; these
+//! tests instead exercise `ClientCredentialsFlow::get_token` end-to-end
+//! against a mock token endpoint, proving the assertion is actually sent on
+//! the wire the way RFC 7523 §2.2 requires.
+
+use authkestra_engine::flow::ClientCredentialsFlow;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use jsonwebtoken::{Algorithm, EncodingKey};
+use serde_json::Value;
+use std::collections::HashMap;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Throwaway Ed25519 private key (PKCS#8 PEM), test-only. Generated with
+/// `openssl genpkey -algorithm ed25519`. Matches the OP's own accepted
+/// algorithm derivation for an `OctetKeyPair` JWK
+/// (`authkestra_op::client_assertion::assertion_algorithms`).
+const TEST_ED25519_PRIVATE_KEY_PEM: &[u8] = b"-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIKIPR2jojpdobYr1M/pjIRuMONpZGYQ+y5yxSqKX9T9/
+-----END PRIVATE KEY-----";
+
+/// Parses `application/x-www-form-urlencoded` bytes into a map, so a test
+/// can pull out individual form fields without depending on field order.
+fn parse_form(body: &[u8]) -> HashMap<String, String> {
+    url::form_urlencoded::parse(body)
+        .into_owned()
+        .collect::<HashMap<_, _>>()
+}
+
+fn decode_jwt_payload(jwt: &str) -> Value {
+    let payload_b64 = jwt.split('.').nth(1).expect("jwt must have 3 segments");
+    serde_json::from_slice(&URL_SAFE_NO_PAD.decode(payload_b64).unwrap()).unwrap()
+}
+
+fn decode_jwt_header(jwt: &str) -> Value {
+    let header_b64 = jwt.split('.').next().expect("jwt must have 3 segments");
+    serde_json::from_slice(&URL_SAFE_NO_PAD.decode(header_b64).unwrap()).unwrap()
+}
+
+/// The core acceptance criterion: `get_token` must send
+/// `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer`
+/// plus a `client_assertion` JWT in place of `client_secret`, and that JWT
+/// must have `iss == sub == client_id`, the token endpoint as `aud`, a
+/// `jti`, a bounded `exp`, and the `EdDSA` `alg` the signing key requires.
+///
+/// Without the change this asserts against, `ClientCredentialsFlow` has no
+/// `new_private_key_jwt` constructor at all, so this test fails to compile —
+/// which is itself proof the capability did not previously exist.
+#[tokio::test]
+async fn sends_a_private_key_jwt_assertion_with_the_right_shape() {
+    let mock_server = MockServer::start().await;
+    let token_url = format!("{}/token", mock_server.uri());
+
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "at-1",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let signing_key = EncodingKey::from_ed_pem(TEST_ED25519_PRIVATE_KEY_PEM).unwrap();
+    let flow = ClientCredentialsFlow::new_private_key_jwt(
+        "svc-1".to_string(),
+        signing_key,
+        Algorithm::EdDSA,
+        token_url.clone(),
+    );
+
+    let token = flow
+        .get_token(None)
+        .await
+        .expect("token request must succeed against the mock server");
+    assert_eq!(token.access_token, "at-1");
+
+    let received = mock_server
+        .received_requests()
+        .await
+        .expect("request recording must be enabled");
+    assert_eq!(received.len(), 1);
+
+    let form = parse_form(&received[0].body);
+
+    // Sent as client_assertion_type + client_assertion, never client_secret.
+    assert_eq!(
+        form.get("client_assertion_type").map(String::as_str),
+        Some("urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+    );
+    assert!(
+        form.get("client_secret").is_none(),
+        "private_key_jwt must never also send a client_secret"
+    );
+
+    let assertion = form
+        .get("client_assertion")
+        .expect("client_assertion must be present on the wire");
+
+    let header = decode_jwt_header(assertion);
+    assert_eq!(header["alg"], "EdDSA");
+
+    let payload = decode_jwt_payload(assertion);
+    assert_eq!(payload["iss"], "svc-1");
+    assert_eq!(payload["sub"], "svc-1");
+    assert_eq!(payload["aud"], token_url);
+
+    let jti = payload["jti"].as_str().expect("jti must be present");
+    assert!(!jti.is_empty());
+
+    let exp = payload["exp"].as_i64().expect("exp must be present");
+    let iat = payload["iat"].as_i64().expect("iat must be present");
+    assert!(
+        exp > iat && exp - iat <= 300,
+        "exp must be a bounded, short-lived window (<= 300s per RFC 7523 \
+         §3 discipline this workspace's OP enforces), got {}s",
+        exp - iat
+    );
+}
+
+/// A fresh assertion — with a fresh `jti` — must be minted on every call to
+/// `get_token`, not cached and replayed: a replay-tracking verifier (this
+/// workspace's own `authkestra_op::client_assertion::ClientAssertionStore`)
+/// would reject a `jti` it already spent.
+#[tokio::test]
+async fn mints_a_fresh_assertion_and_jti_on_every_call() {
+    let mock_server = MockServer::start().await;
+    let token_url = format!("{}/token", mock_server.uri());
+
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "at-1",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let signing_key = EncodingKey::from_ed_pem(TEST_ED25519_PRIVATE_KEY_PEM).unwrap();
+    let flow = ClientCredentialsFlow::new_private_key_jwt(
+        "svc-1".to_string(),
+        signing_key,
+        Algorithm::EdDSA,
+        token_url,
+    );
+
+    flow.get_token(None).await.unwrap();
+    flow.get_token(None).await.unwrap();
+
+    let received = mock_server.received_requests().await.unwrap();
+    assert_eq!(received.len(), 2);
+
+    let assertion_a = parse_form(&received[0].body)
+        .get("client_assertion")
+        .unwrap()
+        .clone();
+    let assertion_b = parse_form(&received[1].body)
+        .get("client_assertion")
+        .unwrap()
+        .clone();
+
+    let jti_a = decode_jwt_payload(&assertion_a)["jti"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let jti_b = decode_jwt_payload(&assertion_b)["jti"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    assert_ne!(
+        jti_a, jti_b,
+        "each token request must mint its own assertion with its own jti"
+    );
+}
+
+/// `with_kid` must stamp the header `kid` onto the minted assertion, so a
+/// server with several registered keys for this client can select the right
+/// one (`authkestra_op::client_assertion::select_key`).
+#[tokio::test]
+async fn with_kid_stamps_the_assertion_header() {
+    let mock_server = MockServer::start().await;
+    let token_url = format!("{}/token", mock_server.uri());
+
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "at-1",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let signing_key = EncodingKey::from_ed_pem(TEST_ED25519_PRIVATE_KEY_PEM).unwrap();
+    let flow = ClientCredentialsFlow::new_private_key_jwt(
+        "svc-1".to_string(),
+        signing_key,
+        Algorithm::EdDSA,
+        token_url,
+    )
+    .with_kid("key-1");
+
+    flow.get_token(None).await.unwrap();
+
+    let received = mock_server.received_requests().await.unwrap();
+    let assertion = parse_form(&received[0].body)
+        .get("client_assertion")
+        .unwrap()
+        .clone();
+    let header = decode_jwt_header(&assertion);
+    assert_eq!(header["kid"], "key-1");
+}
+
+/// Regression guard: the pre-existing `client_secret` path must be
+/// unaffected by the `private_key_jwt` addition — still sends
+/// `client_secret`, never a `client_assertion`.
+#[tokio::test]
+async fn client_secret_flow_is_unaffected() {
+    let mock_server = MockServer::start().await;
+    let token_url = format!("{}/token", mock_server.uri());
+
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "at-1",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let flow = ClientCredentialsFlow::new("svc-1".to_string(), "shh-secret".to_string(), token_url);
+
+    flow.get_token(None).await.unwrap();
+
+    let received = mock_server.received_requests().await.unwrap();
+    let form = parse_form(&received[0].body);
+    assert_eq!(
+        form.get("client_secret").map(String::as_str),
+        Some("shh-secret")
+    );
+    assert!(form.get("client_assertion").is_none());
+    assert!(form.get("client_assertion_type").is_none());
+}

--- a/crates/authkestra-op/src/client_assertion.rs
+++ b/crates/authkestra-op/src/client_assertion.rs
@@ -42,8 +42,15 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 /// The only `client_assertion_type` this OP accepts (RFC 7523 §2.2).
-pub const CLIENT_ASSERTION_TYPE_JWT_BEARER: &str =
-    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+///
+/// Re-exported from `authkestra_engine::client_assertion` rather than
+/// defined here: that crate mints `private_key_jwt` assertions for the
+/// *client* side (`ClientCredentialsFlow::new_private_key_jwt`, added for
+/// issue #222), this module verifies them for the *OP* side, and
+/// `authkestra-op` already depends on `authkestra-engine` — so a single
+/// definition, re-exported, is what keeps the assertion-type URN this OP
+/// accepts and the one a client mints from ever drifting apart.
+pub use authkestra_engine::client_assertion::CLIENT_ASSERTION_TYPE_JWT_BEARER;
 
 /// Upper bound on how far in the future a client assertion's `exp` may sit.
 ///
@@ -55,7 +62,12 @@ pub const CLIENT_ASSERTION_TYPE_JWT_BEARER: &str =
 /// than an `OpConfig` field on purpose: `OpConfig`'s fields are all public and
 /// it is constructed with struct literals throughout this workspace, so
 /// growing it is a breaking change that this feature does not need to make.
-pub const MAX_CLIENT_ASSERTION_LIFETIME_SECS: i64 = 300;
+///
+/// Same re-export rationale as [`CLIENT_ASSERTION_TYPE_JWT_BEARER`] above:
+/// defined once in `authkestra_engine::client_assertion`, so the client-side
+/// minting logic and this OP's verification can never disagree on the
+/// ceiling.
+pub use authkestra_engine::client_assertion::MAX_CLIENT_ASSERTION_LIFETIME_SECS;
 
 /// What a caller learns from a successfully verified client assertion.
 ///


### PR DESCRIPTION
Addresses #222.

## What changed

Adds `private_key_jwt` (RFC 7523 §2.2) client authentication to `ClientCredentialsFlow` — **client side only**.

- **`crates/authkestra-engine/src/client_assertion.rs`** (new) — `mint_client_assertion(client_id, audience, encoding_key, alg, kid, lifetime_secs)`, plus `CLIENT_ASSERTION_TYPE_JWT_BEARER` and `MAX_CLIENT_ASSERTION_LIFETIME_SECS`.
- **`crates/authkestra-engine/src/flow/client_credentials_flow.rs`** — `ClientCredentialsFlow::new_private_key_jwt(client_id, signing_key: EncodingKey, alg: Algorithm, token_url)` and `.with_kid(...)`, matching the signature the issue itself proposed. `get_token` mints a fresh assertion per call and sends `client_assertion_type` + `client_assertion` instead of `client_secret`.
- **`crates/authkestra-op/src/client_assertion.rs`** — the two shared constants become `pub use` re-exports of the engine's definitions. **No verification logic changed.**

### Why the constants moved to the engine

`authkestra-op` depends on `authkestra-engine`, never the reverse, so the engine's module cannot call into `authkestra-op`'s verification types (`ClientRegistration`, replay stores) — that logic stays server-side. But the assertion-type URN and the lifetime ceiling are pure data both halves must agree on. Defining them once in `authkestra-engine` and re-exporting is the only direction that eliminates drift, which is what the issue's "Proposed shape" asks for.

## Design decisions — surfaced, not silently made

- **Key/algorithm supply**: used `EncodingKey` + `Algorithm` (jsonwebtoken's own types), exactly as the issue proposed, rather than inventing a PEM-path / JWK / signer-trait alternative. The issue already made this call.
- **Token caching — deliberately NOT implemented.** The issue's "Proposed shape" suggests caching `OAuthToken` near expiry since signing costs something. Left out: the pre-existing `client_secret` path has never cached either, and caching introduces a new behavioural contract (margin, invalidation) beyond the stated acceptance criteria. Flagging as unimplemented rather than dropping it silently.

## Tests

`crates/authkestra-engine/tests/client_credentials_flow_private_key_jwt_tests.rs` (new) plus unit tests in the new module:

```
test client_assertion::tests::mints_an_assertion_with_iss_sub_client_id_and_correct_aud ... ok
test client_assertion::tests::mints_a_fresh_jti_every_call ... ok
test client_assertion::tests::clamps_a_lifetime_beyond_the_max_to_the_max ... ok
test client_assertion::tests::stamps_the_given_kid_onto_the_header ... ok
test result: ok. 61 passed; 0 failed

Running tests/client_credentials_flow_private_key_jwt_tests.rs
test sends_a_private_key_jwt_assertion_with_the_right_shape ... ok
test mints_a_fresh_assertion_and_jti_on_every_call ... ok
test with_kid_stamps_the_assertion_header ... ok
test result: ok. 4 passed; 0 failed

Running unittests src/lib.rs (authkestra-op)
test handlers::token::client_auth_tests::private_key_jwt_client_gets_a_token ... ok
test handlers::token::client_auth_tests::private_key_jwt_client_is_refused_a_valid_client_secret ... ok
test result: ok. 128 passed; 0 failed
```

Server-side `RedisClientAssertionStore` / `ClientAssertionStore` verification tests pass unchanged.

## Verification

| Command | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo +1.98.0 clippy -p authkestra-engine -p authkestra-op --all-features -- -D warnings` | exit 0 |
| `cargo test -p authkestra-engine -p authkestra-op --all-features` | all pass (see above) |

Full-workspace clippy fails only at the pre-existing `clippy::result_large_err` in `crates/authkestra-axum/src/devsig.rs:192`, untouched by this diff and fixed separately in #227.

## Not run

Full-workspace `cargo test --workspace --all-features` was not re-run in the final pass (a concurrent six-agent build OOM-killed the machine earlier). Only the touched crates were gated. CI is the authority here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
