### PR TITLE
fix(engine): gate webauthn-only test and totp_webauthn example on their features

### DIFF
--- a/crates/authkestra-engine/Cargo.toml
+++ b/crates/authkestra-engine/Cargo.toml
@@ -84,6 +84,10 @@ webauthn = ["dep:webauthn-rs"]
 totp = ["dep:totp-rs"]
 captcha = []
 
+[[example]]
+name = "totp_webauthn"
+required-features = ["totp", "sql-sqlite"]
+
 [dev-dependencies]
 
 

--- a/crates/authkestra-engine/examples/totp_webauthn.rs
+++ b/crates/authkestra-engine/examples/totp_webauthn.rs
@@ -5,63 +5,55 @@ use authkestra_engine::store::sql::SqlxCredentialStore;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 1. Initialize an in-memory SQLite connection for the example store
-    #[cfg(feature = "sql-sqlite")]
-    {
-        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await?;
+    let pool = sqlx::SqlitePool::connect("sqlite::memory:").await?;
 
-        // 2. Initialize the SqlxCredentialStore
-        let store = SqlxCredentialStore::new(pool);
+    // 2. Initialize the SqlxCredentialStore
+    let store = SqlxCredentialStore::new(pool);
 
-        // 3. Create schema tables
-        println!("Running SQLite migrations for credentials table...");
-        store.migrate().await?;
+    // 3. Create schema tables
+    println!("Running SQLite migrations for credentials table...");
+    store.migrate().await?;
 
-        // 4. Create the TOTP Authenticator Method
-        let totp_method = TotpAuthMethod::new(store);
+    // 4. Create the TOTP Authenticator Method
+    let totp_method = TotpAuthMethod::new(store);
 
-        // 5. Register a new TOTP secret for a user
-        let user_id = "user_987";
-        println!("Registering TOTP key for user '{user_id}'...");
-        let (secret_b32, otpauth_uri) = totp_method
-            .register_totp(user_id, "AuthkestraDemo", "user@example.com")
-            .await?;
+    // 5. Register a new TOTP secret for a user
+    let user_id = "user_987";
+    println!("Registering TOTP key for user '{user_id}'...");
+    let (secret_b32, otpauth_uri) = totp_method
+        .register_totp(user_id, "AuthkestraDemo", "user@example.com")
+        .await?;
 
-        println!("TOTP Secret (Base32): {secret_b32}");
-        println!("Scan this URI in Google Authenticator / 1Password: {otpauth_uri}");
+    println!("TOTP Secret (Base32): {secret_b32}");
+    println!("Scan this URI in Google Authenticator / 1Password: {otpauth_uri}");
 
-        // 6. Generate current code using totp-rs
-        use totp_rs::{Algorithm, Secret, TOTP};
-        let totp = TOTP::new(
-            Algorithm::SHA1,
-            6,
-            1,
-            30,
-            Secret::Encoded(secret_b32).to_bytes()?,
-            None,
-            "".to_string(),
-        )?;
+    // 6. Generate current code using totp-rs
+    use totp_rs::{Algorithm, Secret, TOTP};
+    let totp = TOTP::new(
+        Algorithm::SHA1,
+        6,
+        1,
+        30,
+        Secret::Encoded(secret_b32).to_bytes()?,
+        None,
+        "".to_string(),
+    )?;
 
-        let current_code = totp.generate_current()?;
-        println!("Current valid 6-digit code is: {current_code}");
+    let current_code = totp.generate_current()?;
+    println!("Current valid 6-digit code is: {current_code}");
 
-        // 7. Verify the code using the authenticator
-        println!("Verifying the current code...");
-        let auth_input = AuthInput::Totp {
-            user_id: user_id.to_string(),
-            code: current_code,
-        };
+    // 7. Verify the code using the authenticator
+    println!("Verifying the current code...");
+    let auth_input = AuthInput::Totp {
+        user_id: user_id.to_string(),
+        code: current_code,
+    };
 
-        let identity = totp_method.authenticate(auth_input).await?;
-        println!(
-            "Authentication successful! User ID: {}",
-            identity.external_id
-        );
-    }
-
-    #[cfg(not(feature = "sql-sqlite"))]
-    {
-        println!("Please run this example with `sql-sqlite` feature enabled!");
-    }
+    let identity = totp_method.authenticate(auth_input).await?;
+    println!(
+        "Authentication successful! User ID: {}",
+        identity.external_id
+    );
 
     Ok(())
 }

--- a/crates/authkestra-engine/src/tests.rs
+++ b/crates/authkestra-engine/src/tests.rs
@@ -185,6 +185,7 @@ async fn test_primary_method_requires_mfa() {
 }
 
 #[tokio::test]
+#[cfg(feature = "webauthn")]
 async fn test_mfa_equivalent_bypasses_mfa() {
     use crate::auth::AuthResult;
     use crate::Engine;


### PR DESCRIPTION
## Motivation

`cargo test -p authkestra-engine --no-run` fails to compile on a clean `origin/main` checkout with default features — two independent, unrelated problems, both reproduced before making any change:

```
error[E0599]: no variant named `WebAuthnAuthentication` found for enum `AuthInput`
   --> crates/authkestra-engine/src/tests.rs:218:34

error[E0432]: unresolved import `authkestra_engine::auth::totp`
  --> crates/authkestra-engine/examples/totp_webauthn.rs:1:30
error[E0432]: unresolved import `authkestra_engine::store::sql`
  --> crates/authkestra-engine/examples/totp_webauthn.rs:3:31
```

This reached `main` undetected because CI's `test` job runs `cargo test --workspace --all-features` — every feature is enabled, so neither gap is ever exercised. Anyone building this crate the plain way (`cargo test -p authkestra-engine`, or as a downstream dependency pulling in only what they need) hits a hard compile error today.

**Time-sensitive:** #239 ("chore: release v0.5.5") is open. Landing this before it merges means the fix ships in 0.5.5 instead of needing its own patch release.

## What changed

**`crates/authkestra-engine/src/tests.rs`** — `test_mfa_equivalent_bypasses_mfa` uses `AuthInput::WebAuthnAuthentication { .. }`, which is `#[cfg(feature = "webauthn")]` (`src/auth/mod.rs:91-93`). Gated the test itself with `#[cfg(feature = "webauthn")]`, at the narrowest scope (just this one function) — mirroring the identical, already-existing pattern one test up: `test_totp_primary_requires_mfa` is already `#[cfg(feature = "totp")]`. No other test or import in the file needed gating; `TestWebAuthnMethod` is declared locally inside the function body, so it's gated along with it for free.

**`crates/authkestra-engine/examples/totp_webauthn.rs`** — imports `auth::totp::TotpAuthMethod` (`#[cfg(feature = "totp")]`) and `store::sql::SqlxCredentialStore` (`#[cfg(any(feature = "sql-postgres", feature = "sql-sqlite", feature = "sql-mysql"))]`) at the top level. Cargo compiles every file under `examples/` for `cargo test`/`cargo build` regardless of which example is actually being run, so a top-level `use` of a feature-gated item fails to compile before the function body's own (existing) `#[cfg(feature = "sql-sqlite")]` guard ever gets a chance to matter.

Fixed the idiomatic Cargo way — added `required-features` so cargo skips building the example entirely unless they're present:

```toml
[[example]]
name = "totp_webauthn"
required-features = ["totp", "sql-sqlite"]
```

Verified `webauthn` is **not** actually needed — nothing in the file references any WebAuthn type despite the filename — by building with exactly `--features totp,sql-sqlite` (no webauthn) and confirming it compiles.

**Drive-by cleanup, same file:** once `required-features` is declared, cargo will never build this example without `sql-sqlite` present, so the existing `#[cfg(not(feature = "sql-sqlite"))]` "please enable the feature" fallback branch became genuinely dead code — it can no longer be reached under any feature combination cargo will actually compile it with. Removed it and un-indented the body out of the now-redundant `#[cfg(feature = "sql-sqlite")]` block for the same reason. No behavior change: the example still does exactly what it did before when run with the required features.

**Autodiscovery check:** adding a `[[example]]` block can, in older Cargo/edition setups, disable autodiscovery of the *other* examples in the directory. Verified empirically on this repo (edition 2021, current stable) that it does not: `cargo build -p authkestra-engine --examples` still builds `client_credentials` and `device_flow` with no manifest entry of their own, before and after this change.

## Not in scope

No runtime behavior changes anywhere in this PR — this is exclusively fixing what does/doesn't compile under which feature flags.

## Verification

```
$ cargo test -p authkestra-engine --no-run      # default features only
   Compiling authkestra-engine ...
    Finished `test` profile [unoptimized + debuginfo] target(s)
(compiles clean, 0 errors — previously 2 hard failures)

$ cargo test -p authkestra-engine
test result: ok. 4 passed; 0 failed        (lib)
test result: ok. 3 passed; 0 failed        (client_credentials_flow_tests)
test result: ok. 1 passed; 0 failed        (device_flow_tests)
test result: ok. 3 passed; 0 failed        (oauth2_flow_tests)

$ cargo test --workspace --all-features     # exact CI `test` job command
(every crate, every test result: ok, 0 failed — includes the sqlx/redis/testcontainers-backed suites)

$ cargo build -p authkestra-engine --examples --features totp,webauthn,sql-sqlite
    Finished `dev` profile ... (totp_webauthn builds)

$ cargo build -p authkestra-engine --example totp_webauthn --features totp,sql-sqlite
    Finished `dev` profile ... (confirms webauthn is genuinely not required)

$ cargo build -p authkestra-engine --examples   # default features, no totp/sql-sqlite
    Finished `dev` profile ... (client_credentials + device_flow still autodiscovered and built; totp_webauthn correctly skipped)

$ cargo fmt --all -- --check
(clean, no output)

$ cargo clean -p authkestra-engine && cargo clippy --all-targets --all-features -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 39.65s
(clean, zero warnings, whole workspace — clean build first per house rule, not a cached run)
```

## Interaction with #241 (the SD-JWT docs recovery)

This PR is the sole owner of `crates/authkestra-engine/Cargo.toml`'s `[[example]]` entries. It does not add one for the `sd_jwt` example (introduced in #241) because that example needs no extra features to build — it stays on cargo's default autodiscovery regardless of merge order with the SD-JWT docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
