### PR TITLE
docs(engine): recover SD-JWT example, doctests, and book docs dropped by #238 squash-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ check with `cargo tree -i aws-lc-rs -e features`.
 - **Flexible Chaining**: Chain multiple authentication strategies (Token, Session, Basic, Custom) seamlessly.
 - **OpenID Connect Provider (OP)**: Build your own identity provider and authorization server using `authkestra-op`.
 - **Session Management**: Built-in support for in-memory, Redis, and SQL via `sqlx`.
+- **SD-JWT (Selective Disclosure)**: Issue a single JWT carrying selectively disclosable claims (`draft-ietf-oauth-selective-disclosure-jwt`); the holder decides, per presentation, which claims to reveal to each verifier.
 
 ## 📦 Workspace Crates
 
@@ -104,6 +105,7 @@ To see complete, runnable examples for various frameworks and flows, check out t
 - [Axum with SQL Store](https://github.com/marcjazz/authkestra/blob/main/crates/authkestra-axum/examples/sql_store.rs): `cargo run -p authkestra-axum --example sql_store`
 - [Client Credentials Flow](https://github.com/marcjazz/authkestra/blob/main/crates/authkestra-engine/examples/client_credentials.rs): `cargo run -p authkestra-engine --example client_credentials`
 - [Device Flow](https://github.com/marcjazz/authkestra/blob/main/crates/authkestra-engine/examples/device_flow.rs): `cargo run -p authkestra-engine --example device_flow`
+- [SD-JWT (Selective Disclosure)](https://github.com/marcjazz/authkestra/blob/main/crates/authkestra-engine/examples/sd_jwt.rs): `cargo run -p authkestra-engine --example sd_jwt`
 - [Axum Resource Server](https://github.com/marcjazz/authkestra/blob/main/crates/authkestra-axum/examples/resource_server.rs): `cargo run -p authkestra-axum --example resource_server`
 - [Axum OP Server](https://github.com/marcjazz/authkestra/blob/main/crates/authkestra-axum/examples/op_server.rs): `cargo run -p authkestra-axum --example op_server`
 - [Axum MFA Server (TOTP + WebAuthn)](https://github.com/marcjazz/authkestra/blob/main/crates/authkestra-axum/examples/mfa_server.rs): `cargo run -p authkestra-axum --example mfa_server`

--- a/crates/authkestra-engine/examples/sd_jwt.rs
+++ b/crates/authkestra-engine/examples/sd_jwt.rs
@@ -1,0 +1,140 @@
+use authkestra_engine::token::sd_jwt::DisclosableClaim;
+use authkestra_engine::TokenManager;
+use std::collections::HashMap;
+
+/// This example demonstrates the actual point of SD-JWT: an issuer mints
+/// ONE token, and the holder decides -- per verifier, at presentation time
+/// -- which of the issuer-vouched claims to reveal. Nothing here needs
+/// network I/O, so this runs as a plain `fn main`.
+///
+/// See `crates/authkestra-engine/src/token/sd_jwt.rs`'s module docs for the
+/// full scope, including what this module does NOT implement.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("=== SD-JWT (Selective Disclosure) ===\n");
+
+    // 1. Issuer mints ONE SD-JWT with five selectively-disclosable claims
+    //    plus one claim ("account_type") that stays in the clear on every
+    //    presentation, regardless of which Disclosures the holder forwards.
+    let issuer = TokenManager::new(
+        b"sd-jwt-example-secret",
+        Some("https://issuer.example".to_string()),
+    );
+
+    let mut clear_claims = HashMap::new();
+    clear_claims.insert(
+        "account_type".to_string(),
+        serde_json::Value::String("verified".to_string()),
+    );
+
+    println!("1. Issuer mints a single SD-JWT for the holder...");
+    let issued = issuer.issue_sd_jwt(
+        "user-42".to_string(),
+        3600,
+        None,
+        Some("profile".to_string()),
+        vec![
+            DisclosableClaim::new("given_name", "Ada"),
+            DisclosableClaim::new("family_name", "Lovelace"),
+            DisclosableClaim::new("birthdate", "1985-12-10"),
+            DisclosableClaim::new("email", "ada@example.com"),
+            DisclosableClaim::new("country", "GB"),
+        ],
+        clear_claims,
+    )?;
+
+    println!(
+        "   1 JWT ({} bytes) + {} Disclosures -> full compact form is {} bytes.",
+        issued.jwt.len(),
+        issued.disclosures.len(),
+        issued.compact.len(),
+    );
+    println!("   The issuer never mints a second token for the different verifiers below.\n");
+
+    // Disclosures are returned in the same order as `disclosable_claims`
+    // above: [given_name, family_name, birthdate, email, country].
+    let birthdate_disclosure = &issued.disclosures[2];
+    let email_disclosure = &issued.disclosures[3];
+    let country_disclosure = &issued.disclosures[4];
+
+    // 2. Holder -> bar: only needs to prove age, so it reconstructs a
+    //    presentation carrying ONLY the birthdate Disclosure, in SD-JWT
+    //    compact form (`<jwt>~<disclosure>~`).
+    println!("2. Holder presents to a bar, forwarding only `birthdate`...");
+    let bar_presentation = format!("{}~{birthdate_disclosure}~", issued.jwt);
+    let bar_view = issuer.validate_sd_jwt(&bar_presentation, None)?;
+    println!(
+        "   Bar's presentation is {} bytes (vs {} bytes for the full compact form).",
+        bar_presentation.len(),
+        issued.compact.len()
+    );
+    println!(
+        "   Bar sees disclosed_claims = {:?}",
+        sorted_keys(&bar_view.disclosed_claims)
+    );
+    println!(
+        "   birthdate = {:?}\n",
+        bar_view.disclosed_claims.get("birthdate")
+    );
+
+    // 3. Holder -> shipping form: only needs `country`, so it reconstructs a
+    //    DIFFERENT presentation from the SAME issued token, carrying only
+    //    the country Disclosure this time.
+    println!("3. Holder presents to a shipping form, forwarding only `country`...");
+    let shipping_presentation = format!("{}~{country_disclosure}~", issued.jwt);
+    let shipping_view = issuer.validate_sd_jwt(&shipping_presentation, None)?;
+    println!(
+        "   Shipping form sees disclosed_claims = {:?}",
+        sorted_keys(&shipping_view.disclosed_claims)
+    );
+    println!(
+        "   country = {:?}\n",
+        shipping_view.disclosed_claims.get("country")
+    );
+
+    // 4. Clear claims are present on EVERY verification, disclosed or not --
+    //    selective disclosure only gates the claims the issuer chose to
+    //    make disclosable, never the standard/clear ones.
+    println!("4. Clear claims are present on every verification, regardless of disclosures:");
+    println!(
+        "   bar_view.claims.sub                        = {}",
+        bar_view.claims.sub
+    );
+    println!(
+        "   bar_view.claims.extra[\"account_type\"]      = {:?}",
+        bar_view.claims.extra.get("account_type")
+    );
+    println!(
+        "   shipping_view.claims.extra[\"account_type\"] = {:?}\n",
+        shipping_view.claims.extra.get("account_type")
+    );
+
+    // 5. Negative demo: a Disclosure tampered with after issuance no longer
+    //    hashes to anything in `_sd[]`, so verification of the WHOLE
+    //    presentation is rejected -- not just the tampered claim.
+    println!("5. Negative demo: a tampered Disclosure is rejected outright...");
+    let mut tampered_email = email_disclosure.clone();
+    let last_char = tampered_email.pop().expect("disclosure is non-empty");
+    tampered_email.push(if last_char == 'A' { 'B' } else { 'A' });
+    let tampered_presentation = format!("{}~{tampered_email}~", issued.jwt);
+    match issuer.validate_sd_jwt(&tampered_presentation, None) {
+        Ok(_) => {
+            println!("   Unexpected: the tampered disclosure verified (this would be a bug!).")
+        }
+        Err(err) => println!("   Rejected as expected: {err}"),
+    }
+
+    println!("\nOut of scope for this module (see the sd_jwt.rs module docs):");
+    println!("  - Key Binding JWT (KB-JWT) / holder proof-of-possession");
+    println!("  - Array-element and recursive/nested Disclosures");
+    println!("  - SD-JWT VC (`vc+sd-jwt`) type metadata");
+
+    Ok(())
+}
+
+/// Small helper so the printed claim-name sets are in a stable order across
+/// runs (`HashMap` iteration order is not deterministic).
+fn sorted_keys(map: &HashMap<String, serde_json::Value>) -> Vec<&String> {
+    let mut keys: Vec<&String> = map.keys().collect();
+    keys.sort();
+    keys
+}

--- a/crates/authkestra-engine/src/token/sd_jwt.rs
+++ b/crates/authkestra-engine/src/token/sd_jwt.rs
@@ -108,6 +108,14 @@ pub struct DisclosableClaim {
 impl DisclosableClaim {
     /// Convenience constructor so callers don't have to name the struct
     /// fields at every call site.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use authkestra_engine::token::sd_jwt::DisclosableClaim;
+    /// let claim = DisclosableClaim::new("email", "user@example.com");
+    /// assert_eq!(claim.name, "email");
+    /// ```
     pub fn new(name: impl Into<String>, value: impl Into<Value>) -> Self {
         Self {
             name: name.into(),
@@ -345,6 +353,26 @@ impl TokenManager {
     /// accept whichever ones it's shown. Callers that need "exactly one
     /// value per name" are responsible for enforcing that themselves; nothing
     /// about the wire format requires it.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use authkestra_engine::token::sd_jwt::DisclosableClaim;
+    /// # use authkestra_engine::TokenManager;
+    /// # use std::collections::HashMap;
+    /// let manager = TokenManager::new(b"example-secret", Some("issuer".to_string()));
+    /// let issued = manager.issue_sd_jwt(
+    ///     "user-1".to_string(),
+    ///     3600,
+    ///     None,
+    ///     None,
+    ///     vec![DisclosableClaim::new("email", "user@example.com")],
+    ///     HashMap::new(),
+    /// )?;
+    /// assert_eq!(issued.disclosures.len(), 1);
+    /// assert!(issued.compact.starts_with(&issued.jwt));
+    /// # Ok::<(), authkestra_engine::AuthError>(())
+    /// ```
     #[tracing::instrument(skip(self, extra, disclosable_claims), fields(sub = %sub, disclosure_count = disclosable_claims.len()))]
     pub fn issue_sd_jwt(
         &self,
@@ -430,6 +458,35 @@ impl TokenManager {
     /// `_sd_alg`, or a disclosed claim name that shadows a registered or
     /// already-present claim. See the module docs for why each of these
     /// has to fail closed rather than degrading gracefully.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use authkestra_engine::token::sd_jwt::DisclosableClaim;
+    /// # use authkestra_engine::TokenManager;
+    /// # use std::collections::HashMap;
+    /// let manager = TokenManager::new(b"example-secret", Some("issuer".to_string()));
+    /// let issued = manager.issue_sd_jwt(
+    ///     "user-1".to_string(),
+    ///     3600,
+    ///     None,
+    ///     None,
+    ///     vec![DisclosableClaim::new("email", "user@example.com")],
+    ///     HashMap::new(),
+    /// )?;
+    ///
+    /// // A holder can present the full compact form...
+    /// let verified = manager.validate_sd_jwt(&issued.compact, None)?;
+    /// assert_eq!(
+    ///     verified.disclosed_claims.get("email"),
+    ///     Some(&serde_json::Value::String("user@example.com".to_string()))
+    /// );
+    ///
+    /// // ...or withhold the Disclosure entirely and present the bare JWT.
+    /// let bare = manager.validate_sd_jwt(&issued.jwt, None)?;
+    /// assert!(bare.disclosed_claims.is_empty());
+    /// # Ok::<(), authkestra_engine::AuthError>(())
+    /// ```
     #[tracing::instrument(skip(self, presented))]
     pub fn validate_sd_jwt(
         &self,

--- a/docs/book/ch04-flows-and-protocols.md
+++ b/docs/book/ch04-flows-and-protocols.md
@@ -23,3 +23,11 @@ As users transition to digital wallets (e.g., the EUDI Wallet), Authkestra provi
 Our WebAuthn implementation is being upgraded to handle **Post-Quantum Cryptography**.
 - **ML-DSA Support**: Preparing for the day when classical ECC and RSA are broken by quantum computers.
 - **Fragmented Payloads**: Specialized transport handling to manage the multi-kilobyte PQC signatures that exceed standard CTAP-HID limits.
+
+## 5. SD-JWT: Selective Disclosure Today
+Separate from the wallet-facing OIDC4VP verifier support in section 3 above, `authkestra-engine` ships a concrete, usable-today primitive for issuing and verifying **SD-JWTs** (`draft-ietf-oauth-selective-disclosure-jwt`) directly — no wallet or VP exchange required.
+- **One Token, Many Presentations**: `TokenManager::issue_sd_jwt` mints a single JWT carrying some claims in the clear and others only as `_sd[]` digests, plus a matching list of Disclosures. The holder reconstructs a different SD-JWT compact form (`<jwt>~<disclosure>~...~`) per verifier, forwarding only the Disclosures that verifier needs — the issuer never mints a second token.
+- **`TokenManager::validate_sd_jwt`**: validates the underlying JWT exactly like `validate_token` (signature, issuer, audience, expiry), then checks every presented Disclosure against `_sd[]`, returning only the claims that were both presented and proved out.
+- **What this covers today**: flat, top-level, object-property Disclosures only.
+- **What this does NOT cover** (see the module docs on `token/sd_jwt.rs` for the full rationale): no **Key Binding JWT (KB-JWT)** / holder proof-of-possession, no **array-element or recursive/nested Disclosures**, and no **SD-JWT VC** (`vc+sd-jwt`) type metadata. A caller needing any of those has to build it on top — there is no code path for them yet.
+- A full worked example (one issuer, two verifiers each seeing a different subset of claims, plus a rejected tampered Disclosure) lives at `crates/authkestra-engine/examples/sd_jwt.rs` — run it with `cargo run -p authkestra-engine --example sd_jwt`.

--- a/docs/book/ch09-security-and-threat-model.md
+++ b/docs/book/ch09-security-and-threat-model.md
@@ -21,3 +21,12 @@ To prevent user tracking and correlation between services:
 - **PKCE Mandatory**: No OAuth flows without Proof Key for Code Exchange.
 - **Exact Redirect Matching**: Preventing open redirector vulnerabilities.
 - **Sender-Constrained Tokens**: Using DPoP to bind tokens to the client's cryptographic key.
+
+## 5. SD-JWT: Fail-Closed Disclosure Verification
+`authkestra-engine`'s SD-JWT support (`token::sd_jwt`) is deliberately fail-closed rather than lenient, on four specific points:
+- **`_sd_alg` is never silently defaulted.** An absent `_sd_alg` defaults to `sha-256` per spec, but a *present-and-different* value is rejected outright rather than coerced — an unrecognized digest algorithm being treated as "must mean sha-256" is exactly the kind of algorithm-confusion bug that lets an attacker steer a verifier onto a weaker hash while it still believes it's checking sha-256.
+- **An unmatched Disclosure digest fails the whole verification**, not just that one claim. A Disclosure whose digest isn't in the signed `_sd[]` is a claim the issuer never vouched for; accepting it would let a holder (or a network attacker appending to the compact form) inject arbitrary claims.
+- **Duplicate digests in `_sd[]` are rejected.** Legitimately-generated Disclosures are independently salted and never collide, so a duplicate digest is a cheap way to smuggle a second, attacker-chosen Disclosure past the digest-membership check once one legitimate digest becomes known.
+- **A disclosed claim can never shadow a registered top-level claim** (`iss`, `sub`, `aud`, `exp`, `iat`, `nbf`, `jti`, `scope`) or an already-present `extra` claim. Selective disclosure is additive by design; letting a Disclosure silently overwrite `aud` or `exp` would let a holder forge the very claims the issuer's signature is supposed to pin down.
+
+**This module does not provide holder proof-of-possession.** Unlike the unlinkability BBS+ signatures give under section 3 above, there is no Key Binding JWT (KB-JWT) support here: `validate_sd_jwt` verifies the issuer's signature and the Disclosure digests only, with no notion of a holder key. A verifier that needs to confirm the presenter is the token's legitimate holder — not just an eavesdropper replaying a captured presentation — has to build that binding itself; it is not implied by a successful `validate_sd_jwt` call. Array-element/nested Disclosures and SD-JWT VC (`vc+sd-jwt`) type metadata are likewise out of scope today.


### PR DESCRIPTION
## Motivation

#238 added SD-JWT support to `crates/authkestra-engine/src/token/sd_jwt.rs`. Documentation and a runnable example for it were pushed to that PR's branch (`feat/sd-jwt-engine`) as commit `9d141d4`, but #238 was squash-merged onto `main` as `13ab20e` from a state that did not include that commit — so the docs and example were silently dropped. Confirmed:

```
$ git merge-base --is-ancestor 9d141d4 origin/main; echo $?
1   # not an ancestor

$ ls crates/authkestra-engine/examples/sd_jwt.rs
No such file or directory
```

The commit still existed on `origin/feat/sd-jwt-engine`, so this recovers it rather than rewriting from scratch.

**Time-sensitive:** #239 ("chore: release v0.5.5") is open. Landing this before it merges means the SD-JWT docs/example ship in 0.5.5 alongside the code they document, instead of trailing a release behind it.

## What changed

Fetched `origin/feat/sd-jwt-engine` and cherry-picked `9d141d4` onto a fresh branch off current `main` — purely additive, +216 lines across 5 files, unchanged from the original commit (clean cherry-pick, no conflicts):

- **`crates/authkestra-engine/examples/sd_jwt.rs`** (new, 140 lines) — a runnable issuer → holder → verifier walkthrough: one issuer-minted SD-JWT presented to two different verifiers (a bar checking `birthdate`, a shipping form checking `country`), each seeing only the Disclosures forwarded to them, plus a negative demo of a tampered Disclosure being rejected.
- **`crates/authkestra-engine/src/token/sd_jwt.rs`** (+57 lines) — three `# Examples` doctests, on `DisclosableClaim::new`, `issue_sd_jwt`, and `validate_sd_jwt`. Doc comments only — verified with:
  ```
  $ git diff main -- crates/authkestra-engine/src/token/sd_jwt.rs | grep -E '^[+-]' | grep -vE '^[+-]{3}' | grep -vE '^\+\s*(///|//!)'
  (no output)
  ```
- **`README.md`** (+2) — adds SD-JWT to the Features list and the runnable-examples list.
- **`docs/book/ch04-flows-and-protocols.md`** (+8), **`docs/book/ch09-security-and-threat-model.md`** (+9) — usage and threat-model coverage.

All docs explicitly restate, in multiple places, what is **not** implemented: **Key Binding JWT (KB-JWT) / holder proof-of-possession**, **array-element and recursive/nested Disclosures**, and **SD-JWT VC** (`vc+sd-jwt`). This is deliberate — an integrator who assumed holder binding exists from the feature name alone would end up building something materially insecure (accepting a replayed presentation as proof the presenter is the legitimate holder).

**Re-verified against current `main`** since the underlying `sd_jwt.rs` could in principle have drifted since the commit was originally authored — it hadn't, cherry-pick applied clean with zero conflicts.

## Interaction with #240 (the feature-gating fix)

This PR does not touch `crates/authkestra-engine/Cargo.toml` at all. `sd_jwt.rs` needs no extra features to build — it's just Cargo's default example autodiscovery, same as `client_credentials.rs`/`device_flow.rs` — so it builds and runs regardless of whether #240 has merged yet. Verified on this branch, without #240's changes present:

```
$ cargo build -p authkestra-engine --example sd_jwt
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.19s
```

These two PRs merge in either order with no shared commits and no dependency on each other.

## Not in scope

No runtime behavior changes — `sd_jwt.rs` (the implementation) only gained doc comments, not logic (verified above). Everything else is new files or additive documentation.

## Verification

```
$ cargo run -p authkestra-engine --example sd_jwt
=== SD-JWT (Selective Disclosure) ===

1. Issuer mints a single SD-JWT for the holder...
   1 JWT (691 bytes) + 5 Disclosures -> full compact form is 1018 bytes.
   The issuer never mints a second token for the different verifiers below.

2. Holder presents to a bar, forwarding only `birthdate`...
   Bar's presentation is 761 bytes (vs 1018 bytes for the full compact form).
   Bar sees disclosed_claims = ["birthdate"]
   birthdate = Some(String("1985-12-10"))

3. Holder presents to a shipping form, forwarding only `country`...
   Shipping form sees disclosed_claims = ["country"]
   country = Some(String("GB"))

4. Clear claims are present on every verification, regardless of disclosures:
   bar_view.claims.sub                        = user-42
   bar_view.claims.extra["account_type"]      = Some(String("verified"))
   shipping_view.claims.extra["account_type"] = Some(String("verified"))

5. Negative demo: a tampered Disclosure is rejected outright...
   Rejected as expected: Token error: presented SD-JWT disclosure digest is not present in _sd[]

Out of scope for this module (see the sd_jwt.rs module docs):
  - Key Binding JWT (KB-JWT) / holder proof-of-possession
  - Array-element and recursive/nested Disclosures
  - SD-JWT VC (`vc+sd-jwt`) type metadata

$ cargo test -p authkestra-engine --doc
running 3 tests
test crates/authkestra-engine/src/token/sd_jwt.rs - token::sd_jwt::DisclosableClaim::new (line 114) ... ok
test crates/authkestra-engine/src/token/sd_jwt.rs - token::sd_jwt::TokenManager::issue_sd_jwt (line 359) ... ok
test crates/authkestra-engine/src/token/sd_jwt.rs - token::sd_jwt::TokenManager::validate_sd_jwt (line 464) ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo test --workspace --all-features   # exact CI `test` job command
(every crate, every test result: ok, 0 failed — includes the pre-existing 16-test token::sd_jwt::tests suite from #238, unaffected)

$ cargo fmt --all -- --check
(clean, no output)

$ cargo clean -p authkestra-engine && cargo clippy --all-targets --all-features -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.09s
(clean, zero warnings — clean build first per house rule, not a cached run)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
