### PR TITLE
feat(op): route authorization_code grant through the OpStore seam

### DIFF
--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -198,7 +198,15 @@ pub async fn handle_token_with_client_cert(
 
     match req.grant_type.as_str() {
         "authorization_code" => {
-            handle_authorization_code(req, client_id, client, config, op_store, tokens).await
+            // Routed through the `OpStore` seam (mirrors `handle_refresh_token`
+            // and `handle_token_exchange`) so an integrator can stamp custom
+            // claims onto, or create session state for, tokens issued by the
+            // authorization-code flow, without forking this crate. The
+            // default implementation reproduces the built-in behavior below
+            // via `default_handle_authorization_code`.
+            op_store
+                .handle_authorization_code_grant(req, client_id, client, config, tokens)
+                .await
         }
         "client_credentials" => {
             handle_client_credentials(req, client_id, client, config, tokens, client_cert_der).await
@@ -628,13 +636,28 @@ async fn handle_device_code(
     }
 }
 
+/// The built-in `authorization_code` grant (RFC 6749 §4.1) handling.
+///
+/// This is the default body for
+/// [`crate::store::OpStore::handle_authorization_code_grant`] — split out
+/// as a free function so the trait's default method can call it without
+/// duplicating the logic, while `handle_token` reaches it exclusively
+/// through the trait method (so an override actually takes effect).
+///
+/// `pub` (not `pub(crate)`), mirroring `default_handle_token_exchange`, so
+/// an `OpStore::handle_authorization_code_grant` override outside this
+/// crate can delegate to it and post-process the result — e.g. stamping
+/// extra claims via `TokenManager::issue_user_token_with_extra`, or
+/// creating session state — instead of having to reimplement code
+/// consumption, PKCE verification, and redirect_uri/client_id validation
+/// from scratch.
 #[allow(clippy::too_many_arguments)]
-async fn handle_authorization_code(
+pub async fn default_handle_authorization_code<S: OpStore + ?Sized>(
     req: TokenRequest,
     client_id: String,
     client: ClientRegistration,
     config: &OpConfig,
-    op_store: &dyn OpStore,
+    op_store: &S,
     tokens: &TokenManager,
 ) -> Result<TokenResponse, TokenErrorResponse> {
     if !client.allows_grant_type(&GrantType::AuthorizationCode) {
@@ -1065,8 +1088,8 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
 
     // Per OIDC Core §12.2, an id_token MAY be re-minted on refresh; a client
     // that never requested `openid` gets none, mirroring how
-    // `handle_authorization_code` gates `issue_id_token` on the same scope
-    // check. Refresh tokens don't carry a `nonce` (only auth codes do,
+    // `default_handle_authorization_code` gates `issue_id_token` on the same
+    // scope check. Refresh tokens don't carry a `nonce` (only auth codes do,
     // reflecting the original `/authorize` request) — Core §12.2 lists
     // `nonce` as OPTIONAL on a refreshed id_token, so omitting it is
     // conformant, not a shortcut.
@@ -1288,7 +1311,7 @@ pub async fn default_handle_token_exchange(
 
     // Per OIDC Core §12.2 / RFC 8693 §2.1, an id_token accompanies the
     // access token when the `openid` scope is in the final granted scope —
-    // mirroring how `handle_authorization_code` and
+    // mirroring how `default_handle_authorization_code` and
     // `default_handle_refresh_token` gate `issue_id_token` on the same
     // check. `requested_token_type: id_token` is a client signal that it
     // wants one, but the crate's `TokenResponse` always carries an
@@ -1501,8 +1524,8 @@ mod tests {
         // `client1` is registered without `authorization_code` in its
         // `grant_types` — unlike `handle_device_code`,
         // `handle_client_credentials`, `default_handle_refresh_token`, and
-        // `default_handle_token_exchange`, `handle_authorization_code` must
-        // reject this the same way, before ever looking up a code.
+        // `default_handle_token_exchange`, `default_handle_authorization_code`
+        // must reject this the same way, before ever looking up a code.
         let req = TokenRequest {
             grant_type: "authorization_code".to_string(),
             code: Some("some-code".to_string()),
@@ -1651,6 +1674,259 @@ mod tests {
         )
         .await;
         assert!(res.is_ok());
+    }
+
+    // --- OpStore::handle_authorization_code_grant override seam (issue #237) ---
+
+    /// A minimal `OpStore` wrapper that delegates every method to an inner
+    /// `OpStore` except `handle_authorization_code_grant`, which it
+    /// overrides with a canned response. Proves the override actually
+    /// reaches the dispatch site in `handle_token`, not just that the trait
+    /// compiles. Mirrors `OverridingRefreshStore` above.
+    struct OverridingAuthorizationCodeStore<Inner> {
+        inner: Inner,
+    }
+
+    #[async_trait::async_trait]
+    impl<Inner: OpStore> crate::client::ClientStore for OverridingAuthorizationCodeStore<Inner> {
+        async fn find_client(
+            &self,
+            client_id: &str,
+        ) -> Result<Option<ClientRegistration>, OpError> {
+            self.inner.find_client(client_id).await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<Inner: OpStore> crate::code::AuthorizationCodeStore
+        for OverridingAuthorizationCodeStore<Inner>
+    {
+        async fn store_code(&self, code: AuthorizationCode) -> Result<(), OpError> {
+            self.inner.store_code(code).await
+        }
+
+        async fn consume_code(&self, code: &str) -> Result<Option<AuthorizationCode>, OpError> {
+            self.inner.consume_code(code).await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<Inner: OpStore> RefreshTokenStore for OverridingAuthorizationCodeStore<Inner> {
+        async fn store_token(&self, token: RefreshToken) -> Result<(), OpError> {
+            self.inner.store_token(token).await
+        }
+
+        async fn get_token(&self, token: &str) -> Result<Option<RefreshToken>, OpError> {
+            self.inner.get_token(token).await
+        }
+
+        async fn revoke_token(&self, token: &str) -> Result<(), OpError> {
+            self.inner.revoke_token(token).await
+        }
+
+        async fn consume_token(&self, token: &str) -> Result<Option<RefreshToken>, OpError> {
+            self.inner.consume_token(token).await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<Inner: OpStore> crate::device::DeviceCodeStore for OverridingAuthorizationCodeStore<Inner> {
+        async fn store_device_code(
+            &self,
+            session: crate::device::DeviceCodeSession,
+        ) -> Result<(), OpError> {
+            self.inner.store_device_code(session).await
+        }
+
+        async fn get_device_code(
+            &self,
+            device_code: &str,
+        ) -> Result<Option<crate::device::DeviceCodeSession>, OpError> {
+            self.inner.get_device_code(device_code).await
+        }
+
+        async fn get_by_user_code(
+            &self,
+            user_code: &str,
+        ) -> Result<Option<crate::device::DeviceCodeSession>, OpError> {
+            self.inner.get_by_user_code(user_code).await
+        }
+
+        async fn update_device_code(
+            &self,
+            session: crate::device::DeviceCodeSession,
+        ) -> Result<(), OpError> {
+            self.inner.update_device_code(session).await
+        }
+
+        async fn delete_device_code(&self, device_code: &str) -> Result<(), OpError> {
+            self.inner.delete_device_code(device_code).await
+        }
+
+        async fn consume_device_code(
+            &self,
+            device_code: &str,
+        ) -> Result<Option<crate::device::DeviceCodeSession>, OpError> {
+            self.inner.consume_device_code(device_code).await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl<Inner: OpStore> OpStore for OverridingAuthorizationCodeStore<Inner> {
+        async fn handle_authorization_code_grant(
+            &self,
+            _req: TokenRequest,
+            _client_id: String,
+            _client: ClientRegistration,
+            _config: &OpConfig,
+            _tokens: &TokenManager,
+        ) -> Result<TokenResponse, TokenErrorResponse> {
+            Ok(TokenResponse {
+                access_token: "overridden-ac-access-token".to_string(),
+                token_type: "Bearer".to_string(),
+                expires_in: 42,
+                id_token: Some("overridden-ac-id-token".to_string()),
+                refresh_token: Some("overridden-ac-refresh-token".to_string()),
+                scope: Some("overridden-ac-scope".to_string()),
+                issued_token_type: None,
+            })
+        }
+    }
+
+    fn auth_code_test_client() -> ClientRegistration {
+        ClientRegistration {
+            client_id: "client1".to_string(),
+            client_secret_hash: None,
+            redirect_uris: vec!["https://cb".to_string()],
+            grant_types: vec![GrantType::AuthorizationCode],
+            scopes: vec![],
+            require_pkce: false,
+            allowed_audiences: vec![],
+            token_endpoint_auth_method: None,
+            jwks: None,
+        }
+    }
+
+    fn auth_code_test_req(code: &str) -> TokenRequest {
+        TokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: Some(code.to_string()),
+            redirect_uri: Some("https://cb".to_string()),
+            client_id: Some("client1".to_string()),
+            client_secret: None,
+            code_verifier: None,
+            scope: None,
+            refresh_token: None,
+            subject_token: None,
+            subject_token_type: None,
+            device_code: None,
+            actor_token: None,
+            actor_token_type: None,
+            requested_token_type: None,
+            audience: None,
+            client_assertion: None,
+            client_assertion_type: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_authorization_code_is_overridable_by_op_store() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<ClientRegistration>::new();
+        clients
+            .set(
+                "client1",
+                auth_code_test_client(),
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let store =
+            OverridingAuthorizationCodeStore {
+                inner:
+                    crate::store::CompositeOpStore::new(
+                        clients,
+                        authkestra_engine::store::memory::MemoryStore::<AuthorizationCode>::new(),
+                        authkestra_engine::store::memory::MemoryStore::<RefreshToken>::new(),
+                        authkestra_engine::store::memory::MemoryStore::<
+                            crate::device::DeviceCodeSession,
+                        >::new(),
+                    ),
+            };
+
+        // Deliberately a code no store has ever issued: if dispatch fell
+        // through to the built-in handler instead of the override, this
+        // would fail closed with `invalid_grant`, not succeed.
+        let req = auth_code_test_req("no-such-code");
+
+        let res = handle_token(req, None, &test_config(false), &store, &test_tokens()).await;
+
+        let resp =
+            res.expect("the override should have been invoked instead of the built-in handler");
+        assert_eq!(resp.access_token, "overridden-ac-access-token");
+        assert_eq!(resp.id_token.as_deref(), Some("overridden-ac-id-token"));
+        assert_eq!(
+            resp.refresh_token.as_deref(),
+            Some("overridden-ac-refresh-token")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_authorization_code_default_behavior_is_unchanged_without_override() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<ClientRegistration>::new();
+        clients
+            .set(
+                "client1",
+                ClientRegistration {
+                    scopes: vec!["openid".to_string(), "offline_access".to_string()],
+                    ..auth_code_test_client()
+                },
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let codes =
+            authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new();
+        codes
+            .store_code(AuthorizationCode {
+                code: "code-default".to_string(),
+                client_id: "client1".to_string(),
+                redirect_uri: "https://cb".to_string(),
+                identity: test_identity(),
+                scope: "openid offline_access".to_string(),
+                nonce: None,
+                expires_at: Utc::now() + Duration::minutes(5),
+                code_challenge: None,
+                code_challenge_method: None,
+                used: false,
+            })
+            .await
+            .unwrap();
+
+        // A store that does NOT override `handle_authorization_code_grant`
+        // — this is the compatibility guarantee: it must behave identically
+        // to before the trait method existed.
+        let res = handle_token(
+            auth_code_test_req("code-default"),
+            None,
+            &test_config(false),
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                codes.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(),
+            ),
+            &test_tokens(),
+        )
+        .await;
+
+        let resp = res.unwrap();
+        assert_eq!(resp.scope.as_deref(), Some("openid offline_access"));
+        assert!(resp.id_token.is_some());
+        assert!(resp.refresh_token.is_some());
+        // The code was consumed (single-use) by the exchange above.
+        assert!(codes.consume_code("code-default").await.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -3767,7 +4043,7 @@ mod tests {
         assert!(
             resp.id_token.is_some(),
             "openid scope should get an id_token from the token-exchange grant, mirroring \
-             handle_authorization_code and default_handle_refresh_token"
+             default_handle_authorization_code and default_handle_refresh_token"
         );
     }
 

--- a/crates/authkestra-op/src/store.rs
+++ b/crates/authkestra-op/src/store.rs
@@ -56,6 +56,41 @@ pub trait OpStore:
         })
     }
 
+    /// Handle an `authorization_code` grant (RFC 6749 §4.1) request during
+    /// token exchange.
+    ///
+    /// A defaulted method, same reasoning as `handle_refresh_token` and
+    /// `handle_token_exchange` below: the built-in dispatch in
+    /// `handlers::token::handle_token` used to match the literal string
+    /// `"authorization_code"` and call straight into the built-in handler,
+    /// with no seam an `OpStore` implementor could intercept. That made it
+    /// impossible to stamp custom claims onto, or create session state for,
+    /// tokens issued by the authorization-code flow — e.g.
+    /// `TokenManager::issue_user_token_with_extra` exists precisely for
+    /// this, but the built-in handler had no way to reach it — without
+    /// forking the crate.
+    ///
+    /// The default (see `default_handle_authorization_code`) reproduces the
+    /// existing authorization-code exchange logic (code consumption, PKCE
+    /// verification, redirect_uri/client_id validation, and token
+    /// issuance). Any `OpStore` that does not override this method gets
+    /// that behavior automatically; nothing about the trait or dispatch
+    /// changes for it.
+    async fn handle_authorization_code_grant(
+        &self,
+        req: crate::handlers::token::TokenRequest,
+        client_id: String,
+        client: crate::client::ClientRegistration,
+        config: &crate::config::OpConfig,
+        tokens: &authkestra_engine::token::TokenManager,
+    ) -> Result<crate::handlers::token::TokenResponse, crate::handlers::token::TokenErrorResponse>
+    {
+        crate::handlers::token::default_handle_authorization_code(
+            req, client_id, client, config, self, tokens,
+        )
+        .await
+    }
+
     /// Handle a `refresh_token` grant request during token exchange.
     ///
     /// A defaulted method, same reasoning as `handle_custom_grant`: the
@@ -68,9 +103,10 @@ pub trait OpStore:
     ///
     /// The default (see `default_handle_refresh_token`) consumes and
     /// rotates the refresh token, re-mints an access token, and — mirroring
-    /// `handle_authorization_code` — re-mints an `id_token` too when the
-    /// stored scope includes `openid` (OIDC Core §12.2 makes this optional;
-    /// this crate now exercises that option instead of always omitting it).
+    /// `default_handle_authorization_code` — re-mints an `id_token` too when
+    /// the stored scope includes `openid` (OIDC Core §12.2 makes this
+    /// optional; this crate now exercises that option instead of always
+    /// omitting it).
     /// Any `OpStore` that does not override this method gets that behavior
     /// automatically; nothing about the trait or dispatch changes for it.
     async fn handle_refresh_token(


### PR DESCRIPTION
## Summary

`handle_token`'s grant dispatch (`src/handlers/token.rs`) routes `refresh_token` and `urn:ietf:params:oauth:grant-type:token-exchange` through the `OpStore` seam via `op_store.handle_refresh_token(...)` / `op_store.handle_token_exchange(...)`, but still called `authorization_code` as a private free function. That left an `OpStore` implementor with no way to stamp custom claims onto, or create session state for, tokens issued by the authorization-code flow — the exact problem the trait's own doc comments say the other two hooks were added to solve (see `handle_token_exchange`'s doc comment in `src/store.rs`).

Closes #237

## Before / after dispatch

Before:
```rust
"authorization_code" => {
    handle_authorization_code(req, client_id, client, config, op_store, tokens).await
}
```

After:
```rust
"authorization_code" => {
    op_store
        .handle_authorization_code_grant(req, client_id, client, config, tokens)
        .await
}
```

## Change

1. Added `OpStore::handle_authorization_code_grant(&self, req, client_id, client, config, tokens)` to `src/store.rs`, a **defaulted** trait method mirroring `handle_refresh_token`/`handle_token_exchange` in doc-comment style, argument order, and shape. Its default body delegates to a new free function.
2. Exposed the previously-private `handle_authorization_code` free function as `pub async fn default_handle_authorization_code<S: OpStore + ?Sized>(...)` (unchanged body) — `pub`, not `pub(crate)`, mirroring `default_handle_token_exchange` (already `pub`, `src/handlers/token.rs`), so an external override can delegate to it and post-process the result instead of reimplementing code consumption / PKCE verification / redirect_uri validation from scratch. The `<S: OpStore + ?Sized>` generic parameter mirrors `default_handle_refresh_token`'s pattern (the other default helper that also needs `op_store`) — this was in fact required: the trait's default method passes `self` (potentially unsized in a generic default-method context), and a `&dyn OpStore` parameter can't accept that without `Self: Sized`, so the generic form is both the correct mirror and the only one that compiles.
3. Changed the `"authorization_code"` dispatch arm in `handle_token` to call `op_store.handle_authorization_code_grant(...)`.

## Backwards compatibility

This is a **pure refactor for existing users**. Because `handle_authorization_code_grant` is a *defaulted* trait method whose default body calls `default_handle_authorization_code` — the exact same code that used to run as the private free function — every existing `OpStore` implementor keeps compiling and behaves identically: same tokens, same errors, same ordering. Nothing changes unless a store explicitly overrides the new hook.

## Tests

Added to `crates/authkestra-op/src/handlers/token.rs`, mirroring the existing `test_refresh_token_is_overridable_by_op_store` / `test_refresh_token_default_behavior_is_unchanged_without_override` pair (and their `OverridingRefreshStore` test double) exactly:

- `test_authorization_code_default_behavior_is_unchanged_without_override` — an `OpStore` that does **not** override the new hook completes an `authorization_code` exchange identically to before (correct `id_token`/`refresh_token` issuance for `openid offline_access` scope, and single-use code consumption).
- `test_authorization_code_is_overridable_by_op_store` — a new `OverridingAuthorizationCodeStore` test double that overrides only `handle_authorization_code_grant` with a canned response, proving the override is actually reachable from `handle_token`'s dispatch (not just that the trait compiles) and that its return value is what the endpoint emits.

**Fail-first proof** (for `test_authorization_code_is_overridable_by_op_store`): temporarily reverted the dispatch arm to call `default_handle_authorization_code(...)` directly again (bypassing the `OpStore` seam), reran just that test.

- Predicted: the override's canned response would never be invoked; the built-in handler would try to consume the test's deliberately-nonexistent code (`"no-such-code"`) from the store and fail closed with `invalid_grant`, so the test's `res.expect(...)` should panic reporting that error.
- Observed:
  ```
  thread '...test_authorization_code_is_overridable_by_op_store' panicked at .../token.rs:1858:17:
  the override should have been invoked instead of the built-in handler: TokenErrorResponse { error: "invalid_grant", error_description: "Authorization code is invalid or already used" }
  ```
  Matches the prediction exactly. Restored the dispatch arm; the test is green again.

Also updated a handful of doc-comments/test-comments elsewhere in `token.rs` and `store.rs` that referenced the old `handle_authorization_code` function name, so they still point at the right symbol (`default_handle_authorization_code`).

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo test --workspace --all-features` — all green (0 failures across every crate)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-features -- -D warnings` — clean (matches this repo's CI `lint` job exactly; CI doesn't pass `--all-targets` to clippy, so test code isn't part of that gate, but I additionally ran `cargo clippy -p authkestra-op --all-targets --all-features -- -D warnings` for my own diligence and it's clean too)

## Deliberate follow-up: `device_code`

The issue also notes `device_code` has the identical asymmetry (dispatched as a private free function, no `OpStore` seam), and that a consumer already works around it with a router-level bypass before calling `handle_token` at all. This PR deliberately does **not** touch `device_code` — scoping this PR to `authorization_code` only, per the issue's own proposed change. Happy to open a follow-up for `device_code` mirroring this same pattern if that's wanted.

## AI Usage Declaration

This PR was implemented with AI assistance (Claude, via Claude Code) under my direction and review. I read the full issue, verified the exact trait/dispatch/test-double patterns already established by `handle_refresh_token`/`handle_token_exchange` in this codebase and mirrored them precisely, ran the fail-first proof myself (predicted the failure mode before running it, then confirmed the observed panic matched), and verified `cargo check`/`test`/`fmt`/`clippy` all pass locally before opening this PR.
