### PR TITLE
chore(resource)!: mark ValidationConfig non_exhaustive and pin its documented defaults

### DIFF
--- a/crates/authkestra-resource/src/jwt.rs
+++ b/crates/authkestra-resource/src/jwt.rs
@@ -125,8 +125,18 @@ impl JwksCache {
     }
 }
 
-/// A builder for configuring offline JWT validation.
 /// Configuration for JWT validation.
+///
+/// Construct this via [`ValidationConfig::builder`]. The type is
+/// `#[non_exhaustive]` so that adding a validation knob is a non-breaking
+/// change: `jwks_url` has no meaningful default (the builder panics if it is
+/// unset), so there is deliberately no `Default` impl to spread from, which
+/// left struct-literal construction as the only alternative to the builder —
+/// and that made every new field a downstream compile error. `require_kid`
+/// (PR #110) and `require_cert_binding` (PR #231, issue #224) were both added
+/// that way already; see issue #247. Fields stay `pub` for reading and for
+/// post-build mutation.
+#[non_exhaustive]
 pub struct ValidationConfig {
     pub jwks_url: String,
     pub refresh_interval: Duration,

--- a/crates/authkestra-resource/tests/jwt_test.rs
+++ b/crates/authkestra-resource/tests/jwt_test.rs
@@ -2,6 +2,7 @@
 //! - multi-value audience support on `ValidationConfig` / `ValidationConfigBuilder`
 //! - backward compatibility of the single-value `.audience(...)` builder method
 //! - opt-in strict `kid` enforcement on `JwksCache`
+//! - the documented default values produced by `ValidationConfigBuilder`
 //!
 //! JWKS is served via a local `wiremock` server and tokens are signed with
 //! freshly generated RSA keys so the full offline-validation path (JWKS fetch,
@@ -482,4 +483,37 @@ async fn cert_binding_is_not_enforced_when_require_cert_binding_is_false() {
             "without require_cert_binding, a certificate-bound token is still a valid bearer token",
         );
     assert_eq!(result.sub, "service-a");
+}
+
+/// Pins every documented default of a minimally-configured `ValidationConfig`.
+///
+/// The security-relevant assertions are `require_cert_binding` and
+/// `require_kid`: both are documented as off by default, and flipping either
+/// on would silently start *rejecting* tokens that a deployed resource server
+/// accepts today — a change that no existing test would otherwise catch,
+/// because every other test in this file opts in explicitly. See issue #247.
+#[test]
+fn builder_defaults_match_documented_behaviour() {
+    let config = ValidationConfig::builder()
+        .jwks_url("https://issuer.example.com/.well-known/jwks.json")
+        .build();
+
+    assert_eq!(
+        config.jwks_url,
+        "https://issuer.example.com/.well-known/jwks.json"
+    );
+    assert_eq!(config.refresh_interval, Duration::from_secs(3600));
+    assert_eq!(config.issuer, None);
+    assert!(config.audience.is_empty());
+    assert_eq!(config.algorithms, vec![Algorithm::RS256]);
+    assert!(
+        !config.require_kid,
+        "require_kid must stay off by default: turning it on would reject every token whose \
+         header omits `kid`, which validated fine before"
+    );
+    assert!(
+        !config.require_cert_binding,
+        "require_cert_binding must stay off by default: turning it on would reject every \
+         certificate-bound token not presented over a matching mTLS connection"
+    );
 }


### PR DESCRIPTION
Refs #247. **Deliberately does not close it** — the release-versioning half of that issue is a maintainer decision and is untouched here.

## What this PR does

Two changes, both in `authkestra-resource`:

1. **`ValidationConfig` is now `#[non_exhaustive]`** (`crates/authkestra-resource/src/jwt.rs`), with a doc comment explaining why.
2. **New test `builder_defaults_match_documented_behaviour`** (`crates/authkestra-resource/tests/jwt_test.rs`) pinning every documented default of a minimally-configured `ValidationConfig`.

Net diff: `2 files changed, 45 insertions(+), 1 deletion(-)`. This is a small change on purpose; the substance of #247 is analysis, not code.

### Why `#[non_exhaustive]` and *not* a `Default` impl

#247 lists three options. Of the two code-level ones:

- `#[non_exhaustive]` is the **only** one that actually makes future field additions non-breaking. It is what would have prevented this.
- A `Default` impl was considered and deliberately rejected:
  - `jwks_url` has **no meaningful default** — `ValidationConfigBuilder::build()` *panics* if it is unset. A `Default` impl would have to fabricate `String::new()`, converting a loud build-time panic into a silent runtime JWKS-fetch failure. That is a new footgun in exchange for a semver benefit it does not deliver.
  - With `#[non_exhaustive]`, the functional-update syntax `ValidationConfig { x, ..Default::default() }` that `Default` was proposed to enable **is not available cross-crate at all** (E0639 covers FRU too). So the two options are largely mutually exclusive, and `Default` is the weaker one.

Fields stay `pub`, so reading them and mutating them after `build()` both still work; only cross-crate struct-literal construction is now blocked, and `ValidationConfig::builder()` covers all 7 fields.

Verified empirically rather than assumed — a temporary cross-crate struct literal in the integration test yields:

```
error[E0639]: cannot create non-exhaustive struct using struct expression
```

### Why the test is worth its lines

`require_kid` and `require_cert_binding` are both documented as **off by default**. Flipping either to `true` would silently start *rejecting* tokens that deployed resource servers accept today — a availability-affecting change, not a compile error. Every other test in `jwt_test.rs` opts in explicitly, so nothing caught that.

Confirmed the test genuinely fails on the flip (not just passes on the current code): temporarily hardcoding `require_cert_binding: true` in `build()` produces

```
test builder_defaults_match_documented_behaviour ... FAILED
require_cert_binding must stay off by default: turning it on would reject every
certificate-bound token not presented over a matching mTLS connection
```

then reverted.

---

## What still needs a maintainer decision

**Nothing in this PR bumps a version or touches `release-plz.toml`.** `Cargo.toml` stays at `0.5.5`.

### 1. How to account for the already-shipped v0.5.4 break

`require_cert_binding` shipped in v0.5.4 (and v0.5.5) as a breaking addition to an exhaustive struct without a version bump. **No code change can retroactively undo that** — `#[non_exhaustive]` prevents recurrence, it does not repair the releases already on crates.io. Options are the maintainer's: leave it, note it in the changelog, or yank. I have not acted on any of them.

### 2. The next release must be `0.6.0`, not `0.5.6`

This is a recommendation, **not** something I have actioned.

`#[non_exhaustive]` is itself a breaking change for any downstream struct-literal user, so under 0.x SemVer the next release should be **`0.6.0`**. The commit is marked with `!` and a `BREAKING CHANGE:` footer so release-plz classifies it correctly rather than proposing a patch bump.

> ⚠️ `release-plz.toml` sets `release_always = true`, so merging this triggers a release. **Please confirm the release PR proposes `0.6.0` before merging it.** If it proposes `0.5.6`, do not merge — that would ship a second unversioned break, which is the exact failure #247 is about.

If the maintainer would rather not take a breaking change right now, the correct response is to **hold this PR** until a 0.6.0 is planned, not to strip the `#[non_exhaustive]` — the hardening only makes sense riding on a release that is already acknowledged as breaking.

---

## Investigation findings (from #247)

### 1. Current state of `ValidationConfig` — confirmed

Before this PR: no `#[non_exhaustive]`, no `Default` (neither derived nor a manual `impl Default for ValidationConfig`), 7 all-`pub` fields — `jwks_url`, `refresh_interval`, `issuer`, `audience`, `algorithms`, `require_kid`, `require_cert_binding`. `ValidationConfigBuilder` **does** cover all 7 (`jwks_url`, `refresh_interval`, `issuer`, `audience`/`audiences`, `algorithms`, `require_kid`, `require_cert_binding`), so the builder is a complete migration path with no gaps.

### 2. Struct-literal constructions of `ValidationConfig` in-tree: **zero** — independently confirmed

Searched `crates/`, `docs/`, `plans/`, `website/`, `README*` across `.rs`/`.md`/`.mdx`/`.toml`/`.ts`/`.tsx`. All 20 in-tree uses go through `.builder()`:

- `crates/authkestra-resource/tests/jwt_test.rs` — 9 call sites
- `crates/authkestra/examples/axum_resource_server.rs`, `axum_resource_server_strategy.rs`, `actix_resource_server_strategy.rs` — 1 each
- `crates/authkestra-resource/README.md`, `website/src/content/docs/advanced/resource-server.mdx` — docs, builder only

The only struct literal anywhere is inside `ValidationConfigBuilder::build()` in the defining crate, which `#[non_exhaustive]` does not affect. Nothing in this repo breaks; the risk was and remains entirely to external consumers.

### 3. Other public structs with the same hazard — **not fixed here, reported only**

A scan of all `pub struct`s under `crates/*/src/` found **63** with all-`pub` fields, no `Default`, and no `#[non_exhaustive]`. The subset most likely to grow fields:

**Config / policy types (highest risk — these grow knobs exactly like `ValidationConfig` did):**
| Struct | Location |
| --- | --- |
| `OpConfig` (9 fields) | `crates/authkestra-op/src/config.rs:10` |
| `VerifierConfig` (5) | `crates/authkestra-devsig/src/config.rs:17` |
| `AttestationConfig` (3) | `crates/authkestra-op/src/attestation.rs:60` |
| `ProviderConfig` (3) | `crates/authkestra-engine/src/auth/mod.rs:151` |

**Protocol wire types (grow whenever an RFC/extension is added):**
| Struct | Location |
| --- | --- |
| `TokenRequest` (17) | `crates/authkestra-op/src/handlers/token.rs:19` |
| `OidcDiscovery` (14) | `crates/authkestra-op/src/handlers/discovery.rs:6` |
| `AuthorizeRequest` (8) | `crates/authkestra-op/src/handlers/authorize.rs:13` |
| `TokenResponse` (7) | `crates/authkestra-op/src/handlers/token.rs:65` |
| `ProviderMetadata` (8) | `crates/authkestra-engine/src/auth/discovery.rs:7` |
| `DeviceAuthorizationRequest`/`Response` | `crates/authkestra-op/src/handlers/device_authorization.rs:10,27` |
| `UserInfoResponse` (4) | `crates/authkestra-op/src/handlers/userinfo.rs:14` |

**Persisted / claim types:**
| Struct | Location |
| --- | --- |
| `ClientRegistration` (9) | `crates/authkestra-op/src/client.rs:93` |
| `AuthorizationCode` (10) | `crates/authkestra-op/src/code.rs:15` |
| `DeviceCodeSession` (7) | `crates/authkestra-op/src/device.rs:21` |
| `RefreshToken` (5) | `crates/authkestra-op/src/refresh.rs:8` |
| `Claims` (10) | `crates/authkestra-engine/src/token/mod.rs:75` |
| `Claims` (8) | `crates/authkestra-oidc/src/provider.rs:32` |
| `EnrolmentChallenge` (7) | `crates/authkestra-op/src/attestation.rs:155` |

Deliberately **out of scope** for this PR — each is its own breaking change and they should be batched into whatever release is designated breaking. Worth a follow-up issue and possibly an `AGENTS.md` convention ("new public config/wire structs are `#[non_exhaustive]` unless there's a reason not to"), but that is a project-wide convention call I have not made unilaterally.

---

## Verification

Ran CI's exact commands on the toolchain CI resolves `stable` to (1.98.0):

| Command | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo +1.98.0 clippy --workspace --all-features -- -D warnings` | pass |
| `cargo +1.98.0 clippy --workspace --all-targets --all-features -- -D warnings` (per `AGENTS.md`) | pass |
| `cargo +1.98.0 test --workspace --all-features` | 2 pre-existing environmental failures, see below |
| `cargo test -p authkestra-resource --test jwt_test` | 13/13 pass |

**Two failures, both reproduced on unmodified `main` and unrelated to this change** (this change touches only `authkestra-resource`):

- `authkestra-engine` `store::sql::session::mysql_tests::test_mysql_indexed_store` — testcontainers `bind: address already in use`. Passes when re-run alone (`1 passed`).
- `authkestra` `examples_e2e::test_all_oauth_examples_sequentially` — the OAuth2 examples bind a fixed port 3000, which another process on this machine holds; `Os { code: 98, kind: AddrInUse }`. **Verified by stashing this branch's changes and re-running on pristine `main`, which fails identically.**

Everything else passed, including all 138 `authkestra-op` tests and all 79 other `authkestra-engine` lib tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
