### PR TITLE
fix(actix): let request extensions reach AuthenticationStrategy

### DIFF
--- a/crates/authkestra-actix/Cargo.toml
+++ b/crates/authkestra-actix/Cargo.toml
@@ -68,3 +68,7 @@ required-features = ["macros", "session"]
 [[test]]
 name = "engine_token_integration"
 required-features = ["macros", "token"]
+
+[[test]]
+name = "auth_extensions_integration"
+required-features = ["resource"]

--- a/crates/authkestra-actix/README.md
+++ b/crates/authkestra-actix/README.md
@@ -79,6 +79,42 @@ async fn external_api(Jwt(claims): Jwt<MyClaims>) -> HttpResponse {
 }
 ```
 
+#### `Auth<I>` and request extensions
+
+`Auth<I>` runs the `Guard<I>` from `app_data` over the request. actix has no
+`http::request::Parts` of its own (actix-http 3.x is still built on `http` 0.2),
+so the adapter synthesises one from the request's method, URI and headers — and
+that synthetic value starts with an **empty extension map**.
+
+If your `AuthenticationStrategy` reads a request extension put there by another
+middleware, register its type with `CarriedExtensions`:
+
+```rust
+use actix_web::{dev::Service as _, web, App, HttpMessage};
+use authkestra_actix::CarriedExtensions;
+
+#[derive(Clone)]
+struct TenantId(String);
+
+let app = App::new()
+    .wrap_fn(|req, srv| {
+        req.extensions_mut().insert(TenantId("acme".to_string()));
+        srv.call(req)
+    })
+    .app_data(web::Data::new(
+        CarriedExtensions::new().carry::<TenantId>(),
+    ));
+```
+
+The strategy then reads `parts.extensions.get::<TenantId>()`.
+
+Registration is required because `actix_http::Extensions` exposes no way to
+enumerate its contents and stores `Box<dyn Any>`, while `http::Extensions`
+accepts only `T: Clone + Send + Sync`; copying the whole map generically is not
+expressible. See the `extensions` module docs for the full rationale.
+`ClientCertificateDer` is carried unconditionally and needs no registration, so
+RFC 8705 certificate-bound token checks keep working out of the box.
+
 ### OAuth2 Helpers
 
 The crate provides helpers to manage the OAuth2 flow lifecycle.

--- a/crates/authkestra-actix/src/extensions.rs
+++ b/crates/authkestra-actix/src/extensions.rs
@@ -1,0 +1,220 @@
+//! Carrying actix request extensions into the `http::request::Parts` handed to
+//! [`AuthenticationStrategy::authenticate`].
+//!
+//! # Why this module exists at all
+//!
+//! `authkestra-engine`'s [`AuthenticationStrategy`] is defined over
+//! [`http::request::Parts`] (`http` 1.x). axum hands its extractors that exact
+//! type, so `authkestra-axum` passes the framework's own `Parts` straight
+//! through and nothing is ever lost. actix-web has no such type: its request is
+//! an `actix_http::RequestHead` plus a separate `RefCell<Extensions>` map, and
+//! actix-http 3.x is still built on `http` **0.2**. So the actix adapter has to
+//! *synthesise* an `http` 1.x `Parts` from method + URI + headers, and that
+//! synthetic value starts with an empty extension map (issue #246).
+//!
+//! # Why the whole map cannot simply be copied
+//!
+//! A fully generic "move/clone every extension across" is not expressible on the
+//! pinned versions (`actix-http` 3.13, `http` 1.5). Three independent blockers,
+//! any one of which is fatal:
+//!
+//! 1. **No enumeration.** `actix_http::Extensions` wraps a private
+//!    `HashMap<TypeId, Box<dyn Any>>` and exposes only *typed* accessors
+//!    (`get::<T>`, `remove::<T>`, `extend(Extensions)`). There is no `iter()`,
+//!    no `drain()`, no `IntoIterator`. Nothing outside actix-http can discover
+//!    which types a request is carrying.
+//! 2. **No `Send`/`Sync`/`Clone` on the values.** Even given enumeration, actix
+//!    stores `Box<dyn Any>`, while `http::Extensions` stores
+//!    `Box<dyn AnyClone + Send + Sync>` and its only insertion API is
+//!    `insert<T: Clone + Send + Sync + 'static>(val: T)`. A type-erased
+//!    `Box<dyn Any>` cannot be re-boxed into that; the bounds are unrecoverable
+//!    once the concrete type is gone.
+//! 3. **Two different `http` crates.** `http` 0.2's `Extensions` and `http`
+//!    1.x's `Extensions` are unrelated types from separately-compiled crates,
+//!    so even `extend` has nothing to bridge.
+//!
+//! Storing a handle to actix's map inside the `Parts` instead is equally
+//! blocked: `HttpRequest`/`Extensions` are `!Send + !Sync`, and
+//! `http::Extensions::insert` requires `Send + Sync`.
+//!
+//! # What this module does instead
+//!
+//! Option 2 from issue #246: an explicit, host-registered list of extension
+//! *types* to carry. Registration is generic over `T` and monomorphises a
+//! transfer function per type, so the adapter never names a concrete extension
+//! type — the host decides. See [`CarriedExtensions`].
+//!
+//! [`AuthenticationStrategy`]: authkestra_engine::auth::AuthenticationStrategy
+//! [`AuthenticationStrategy::authenticate`]: authkestra_engine::auth::AuthenticationStrategy::authenticate
+
+use actix_web::dev::Extensions as ActixExtensions;
+
+/// A monomorphised "copy extension of type `T`" step.
+///
+/// Deliberately a plain `fn` pointer rather than a boxed closure: the transfer
+/// is fully determined by `T`, so there is no state to capture, and `fn`
+/// pointers keep [`CarriedExtensions`] `Clone + Send + Sync` for free (it is
+/// stored in actix `app_data`, which requires `Send + Sync`).
+type Carrier = fn(&ActixExtensions, &mut http::Extensions);
+
+/// The body of a [`Carrier`], monomorphised once per registered type.
+///
+/// `pub(crate)` rather than private: the [`Auth`](crate::Auth) extractor calls
+/// it directly to carry `ClientCertificateDer` unconditionally, without going
+/// through the host-visible registry.
+pub(crate) fn carry_one<T>(src: &ActixExtensions, dst: &mut http::Extensions)
+where
+    T: Clone + Send + Sync + 'static,
+{
+    if let Some(value) = src.get::<T>() {
+        dst.insert(value.clone());
+    }
+}
+
+/// The set of actix request-extension types that must survive into the
+/// `http::request::Parts` seen by an [`AuthenticationStrategy`].
+///
+/// Register it in `app_data` and the [`Auth`](crate::Auth) extractor will copy
+/// each listed type out of actix's per-request extension map before calling
+/// `Guard::authenticate`. Types not listed are **not** carried — see the module
+/// docs for why an automatic carry-everything is impossible here.
+///
+/// `ClientCertificateDer` is always carried and does not need registering
+/// (RFC 8705 certificate-bound tokens depend on it).
+///
+/// # Example
+///
+/// ```no_run
+/// use actix_web::{web, App, HttpMessage};
+/// use authkestra_actix::CarriedExtensions;
+///
+/// #[derive(Clone)]
+/// struct TenantId(String);
+///
+/// let app = App::new()
+///     .wrap_fn(|req, srv| {
+///         use actix_web::dev::Service as _;
+///         req.extensions_mut().insert(TenantId("acme".to_string()));
+///         srv.call(req)
+///     })
+///     .app_data(web::Data::new(
+///         CarriedExtensions::new().carry::<TenantId>(),
+///     ));
+/// ```
+///
+/// A strategy can then read `parts.extensions.get::<TenantId>()`.
+///
+/// [`AuthenticationStrategy`]: authkestra_engine::auth::AuthenticationStrategy
+#[derive(Clone, Default)]
+pub struct CarriedExtensions {
+    carriers: Vec<Carrier>,
+}
+
+impl CarriedExtensions {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register `T` to be carried into `Parts`.
+    ///
+    /// The `Clone + Send + Sync` bounds are not a design choice — they are
+    /// exactly what `http::Extensions::insert` demands. A type that cannot meet
+    /// them cannot be put into an `http` 1.x extension map at all, by anyone.
+    #[must_use]
+    pub fn carry<T>(mut self) -> Self
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        self.carriers.push(carry_one::<T>);
+        self
+    }
+
+    /// Number of registered types.
+    pub fn len(&self) -> usize {
+        self.carriers.len()
+    }
+
+    /// Whether no type is registered.
+    pub fn is_empty(&self) -> bool {
+        self.carriers.is_empty()
+    }
+
+    /// Run every registered carrier.
+    ///
+    /// Returns how much the destination map grew, which the caller logs: a
+    /// registry with entries but a growth of zero is the signature of a
+    /// middleware-ordering mistake, which is otherwise completely silent. It is
+    /// a growth count rather than a hit count because a type already present in
+    /// `dst` (e.g. `ClientCertificateDer`, carried unconditionally beforehand)
+    /// is overwritten rather than added.
+    pub(crate) fn apply(&self, src: &ActixExtensions, dst: &mut http::Extensions) -> usize {
+        let before = dst.len();
+        for carrier in &self.carriers {
+            carrier(src, dst);
+        }
+        dst.len().saturating_sub(before)
+    }
+}
+
+impl std::fmt::Debug for CarriedExtensions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The registered types are erased into `fn` pointers, so there is
+        // nothing more informative to print than the count.
+        f.debug_struct("CarriedExtensions")
+            .field("registered", &self.carriers.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct Alpha(&'static str);
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct Beta(u8);
+
+    #[test]
+    fn carries_only_registered_types() {
+        let mut src = ActixExtensions::new();
+        src.insert(Alpha("a"));
+        src.insert(Beta(7));
+
+        let mut dst = http::Extensions::new();
+        let carried = CarriedExtensions::new()
+            .carry::<Alpha>()
+            .apply(&src, &mut dst);
+
+        assert_eq!(carried, 1);
+        assert_eq!(dst.get::<Alpha>(), Some(&Alpha("a")));
+        assert_eq!(dst.get::<Beta>(), None);
+    }
+
+    #[test]
+    fn registered_but_absent_type_is_a_no_op() {
+        let src = ActixExtensions::new();
+        let mut dst = http::Extensions::new();
+
+        let carried = CarriedExtensions::new()
+            .carry::<Alpha>()
+            .carry::<Beta>()
+            .apply(&src, &mut dst);
+
+        assert_eq!(carried, 0);
+        assert!(dst.is_empty());
+    }
+
+    #[test]
+    fn empty_registry_carries_nothing() {
+        let mut src = ActixExtensions::new();
+        src.insert(Alpha("a"));
+        let mut dst = http::Extensions::new();
+
+        assert!(CarriedExtensions::new().is_empty());
+        assert_eq!(CarriedExtensions::new().apply(&src, &mut dst), 0);
+        assert!(dst.is_empty());
+    }
+}

--- a/crates/authkestra-actix/src/extensions.rs
+++ b/crates/authkestra-actix/src/extensions.rs
@@ -53,8 +53,13 @@ use actix_web::dev::Extensions as ActixExtensions;
 ///
 /// Deliberately a plain `fn` pointer rather than a boxed closure: the transfer
 /// is fully determined by `T`, so there is no state to capture, and `fn`
-/// pointers keep [`CarriedExtensions`] `Clone + Send + Sync` for free (it is
-/// stored in actix `app_data`, which requires `Send + Sync`).
+/// pointers keep [`CarriedExtensions`] `Clone + Send + Sync` for free.
+///
+/// Note `App::app_data` and `HttpRequest::app_data` themselves require only
+/// `'static`, not `Send + Sync`; those bounds arrive transitively from
+/// `HttpServer::new`'s factory, which must be `Send + Clone` to be moved into
+/// each worker. The `fn`-pointer choice is still right — it just isn't
+/// `app_data` that forces it.
 type Carrier = fn(&ActixExtensions, &mut http::Extensions);
 
 /// The body of a [`Carrier`], monomorphised once per registered type.
@@ -103,6 +108,23 @@ where
 /// ```
 ///
 /// A strategy can then read `parts.extensions.get::<TenantId>()`.
+///
+/// # Registration forms and their precedence
+///
+/// Both `.app_data(web::Data::new(registry))` and the bare
+/// `.app_data(registry)` are accepted, because matching only one would turn
+/// the other into a silent no-op — the failure mode #246 is about.
+///
+/// If **both** are present, the `web::Data` form always wins, *even when the
+/// bare form is registered on a more specific scope*. `HttpRequest::app_data`
+/// scans the whole App → Scope → Resource chain for one type before the
+/// fallback is consulted, so an app-level `web::Data` registration takes
+/// precedence over a resource-level bare one. Register one form, not both.
+///
+/// # Feature gate
+///
+/// This type is only available with the `resource` feature, which is what
+/// gates the [`Auth`](crate::Auth) extractor it feeds.
 ///
 /// [`AuthenticationStrategy`]: authkestra_engine::auth::AuthenticationStrategy
 #[derive(Clone, Default)]

--- a/crates/authkestra-actix/src/lib.rs
+++ b/crates/authkestra-actix/src/lib.rs
@@ -20,7 +20,12 @@ use futures::future::LocalBoxFuture;
 #[cfg(any(feature = "session", feature = "token", feature = "resource"))]
 use std::sync::Arc;
 
+#[cfg(feature = "resource")]
+pub mod extensions;
 pub mod helpers;
+
+#[cfg(feature = "resource")]
+pub use extensions::CarriedExtensions;
 
 #[cfg(feature = "op")]
 pub mod op;
@@ -272,6 +277,15 @@ where
 /// A unified extractor for authentication.
 ///
 /// It uses the `Guard` from the application state to validate the request.
+///
+/// # Request extensions
+///
+/// Unlike axum, actix has no `http::request::Parts` of its own, so this
+/// extractor synthesises one from the request's method, URI and headers. Actix
+/// request extensions therefore do not come along automatically. Register the
+/// types that must survive with [`CarriedExtensions`] in `app_data`; see that
+/// type's docs (and `extensions`' module docs) for why carrying the whole map
+/// generically is not possible on actix-http 3.x / `http` 1.x. Issue #246.
 #[cfg(feature = "resource")]
 pub struct Auth<I>(pub I);
 
@@ -315,27 +329,51 @@ where
             })?;
             let (mut parts, _) = http_req.into_parts();
 
-            // Carry over `ClientCertificateDer`, if a host-app
-            // middleware/acceptor stashed one in actix's own per-request
-            // extensions from real mTLS termination — RFC 8705
-            // certificate-bound tokens (`JwtStrategy::require_cert_binding`,
-            // issue #224) need it, and this hand-built `http::request::Parts`
-            // would otherwise silently drop it, since it is assembled from
-            // only the method/URI/headers above.
-            //
-            // NOTE: this carries `ClientCertificateDer` and nothing else. The
-            // underlying defect is general — every actix request extension is
-            // dropped here — and remains open for other types. It bites any
-            // downstream `AuthenticationStrategy` impl that reads a different
-            // extension (tenant id, session context, a `DeviceIdentity` set by
-            // other middleware): those still silently see `None` under actix,
-            // though not under axum, whose `FromRequestParts` gets native
-            // `Parts`. Only `ClientCertificateDer` is consumed this way in-tree
-            // today, so there is no live regression here — but a general fix
-            // (and a regression test; this crate currently has no tests at all)
-            // belongs in its own change.
-            if let Some(cert) = req_clone.extensions().get::<ClientCertificateDer>() {
-                parts.extensions.insert(cert.clone());
+            // The `Parts` above are synthesised from method/URI/headers only,
+            // so actix's per-request extension map is not represented in them
+            // at all. Copy across the types the host asked for (issue #246);
+            // `extensions`' module docs record why an automatic
+            // carry-everything is not expressible on actix-http 3.x + `http`
+            // 1.x. This must happen before `authenticate`, and the borrow of
+            // actix's `RefCell`-backed extensions is scoped so it is released
+            // before the `.await` below.
+            {
+                let src = req_clone.extensions();
+
+                // Always carried, no registration required: a host-app
+                // middleware/acceptor stashes this from real mTLS termination
+                // and RFC 8705 certificate-bound tokens
+                // (`JwtStrategy::require_cert_binding`, issue #224) fail
+                // closed without it. Keeping it implicit means the #224 fix
+                // cannot be silently undone by a host forgetting to register
+                // it.
+                extensions::carry_one::<ClientCertificateDer>(&src, &mut parts.extensions);
+
+                // Accept both `.app_data(web::Data::new(registry))` and the
+                // bare `.app_data(registry)` form. Matching only one would
+                // turn the other into a silent no-op, which is precisely the
+                // failure mode issue #246 is about.
+                let registry = req_clone
+                    .app_data::<web::Data<extensions::CarriedExtensions>>()
+                    .map(web::Data::get_ref)
+                    .or_else(|| req_clone.app_data::<extensions::CarriedExtensions>());
+
+                match registry {
+                    Some(registry) => {
+                        let carried = registry.apply(&src, &mut parts.extensions);
+                        tracing::debug!(
+                            registered = registry.len(),
+                            carried,
+                            "carried registered actix request extensions into request parts"
+                        );
+                    }
+                    None => {
+                        tracing::debug!(
+                            "no CarriedExtensions registry in actix app data; only \
+                             ClientCertificateDer is carried into request parts"
+                        );
+                    }
+                }
             }
 
             match guard.authenticate(&parts).await {

--- a/crates/authkestra-actix/src/lib.rs
+++ b/crates/authkestra-actix/src/lib.rs
@@ -361,14 +361,33 @@ where
                 match registry {
                     Some(registry) => {
                         let carried = registry.apply(&src, &mut parts.extensions);
-                        tracing::debug!(
-                            registered = registry.len(),
-                            carried,
-                            "carried registered actix request extensions into request parts"
-                        );
+                        if !registry.is_empty() && carried == 0 {
+                            // The host registered types but none were present
+                            // on the request. Almost always a wiring mistake:
+                            // wrong type registered, or the middleware that
+                            // inserts it ordered after this extractor. Warn
+                            // rather than debug — the symptom is otherwise a
+                            // bare 401 with no operator-visible signal, which
+                            // is the exact silence #246 exists to remove.
+                            tracing::warn!(
+                                registered = registry.len(),
+                                "CarriedExtensions registered types but none were present on \
+                                 the request; check the registered type and that the \
+                                 middleware inserting it runs before the extractor"
+                            );
+                        } else {
+                            tracing::debug!(
+                                registered = registry.len(),
+                                carried,
+                                "carried registered actix request extensions into request parts"
+                            );
+                        }
                     }
                     None => {
-                        tracing::debug!(
+                        // Deliberately `trace!`, not `debug!`: this arm fires on
+                        // every request of every app that never opts in, where
+                        // it carries no signal.
+                        tracing::trace!(
                             "no CarriedExtensions registry in actix app data; only \
                              ClientCertificateDer is carried into request parts"
                         );

--- a/crates/authkestra-actix/tests/auth_extensions_integration.rs
+++ b/crates/authkestra-actix/tests/auth_extensions_integration.rs
@@ -1,0 +1,202 @@
+//! Regression tests for issue #246: actix request extensions must be able to
+//! reach a custom `AuthenticationStrategy` through the `Auth<I>` extractor.
+//!
+//! The load-bearing test here deliberately uses `TenantId`, a test-only marker
+//! type, **not** `ClientCertificateDer`: before this change the adapter carried
+//! exactly one hardcoded type across, so a test written against that type would
+//! have passed on the buggy code and proved nothing.
+//!
+//! Driven through a real `actix_web::App` + `test::call_service`, matching the
+//! other integration tests in this crate.
+
+use actix_web::{
+    dev::Service as _,
+    http::StatusCode,
+    test::{self, TestRequest},
+    web, App, HttpMessage, HttpResponse, Responder,
+};
+use async_trait::async_trait;
+use authkestra_actix::{Auth, CarriedExtensions};
+use authkestra_engine::auth::strategy::AuthenticationStrategy;
+use authkestra_engine::auth::AuthError;
+use authkestra_engine::token::cert_binding::ClientCertificateDer;
+use authkestra_resource::Guard;
+use http::request::Parts;
+use std::sync::Arc;
+
+/// A test-only extension type standing in for whatever a host application puts
+/// in actix's request extensions (tenant id, session context, device identity).
+/// Nothing in this repo consumes it, which is the point.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TenantId(String);
+
+/// A second test-only type, registered but never inserted, to check that a
+/// missing extension is a quiet no-op rather than an error.
+#[derive(Clone, Debug)]
+struct NeverInserted;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TestIdentity(String);
+
+/// A custom strategy of exactly the kind issue #246 says is broken: it reads a
+/// request extension and nothing else.
+struct TenantStrategy;
+
+#[async_trait]
+impl AuthenticationStrategy<TestIdentity> for TenantStrategy {
+    async fn authenticate(&self, parts: &Parts) -> Result<Option<TestIdentity>, AuthError> {
+        assert!(
+            parts.extensions.get::<NeverInserted>().is_none(),
+            "a registered-but-absent type must not be fabricated"
+        );
+        Ok(parts
+            .extensions
+            .get::<TenantId>()
+            .map(|t| TestIdentity(t.0.clone())))
+    }
+}
+
+/// Reads `ClientCertificateDer`, which the adapter carries unconditionally so
+/// the RFC 8705 resource-side check (#224) keeps working without registration.
+struct CertStrategy;
+
+#[async_trait]
+impl AuthenticationStrategy<TestIdentity> for CertStrategy {
+    async fn authenticate(&self, parts: &Parts) -> Result<Option<TestIdentity>, AuthError> {
+        Ok(parts
+            .extensions
+            .get::<ClientCertificateDer>()
+            .map(|c| TestIdentity(format!("cert:{}", c.0.len()))))
+    }
+}
+
+async fn whoami(Auth(identity): Auth<TestIdentity>) -> impl Responder {
+    HttpResponse::Ok().body(identity.0)
+}
+
+fn tenant_guard() -> Arc<Guard<TestIdentity>> {
+    Arc::new(Guard::builder().strategy(TenantStrategy).build())
+}
+
+fn cert_guard() -> Arc<Guard<TestIdentity>> {
+    Arc::new(Guard::builder().strategy(CertStrategy).build())
+}
+
+/// The regression test for #246. A middleware inserts `TenantId` into actix's
+/// request extensions; the host registers that type; the custom strategy must
+/// observe it. On unmodified `main` the extension is dropped when `Parts` are
+/// hand-built, the strategy sees `None`, and this returns 401.
+#[actix_web::test]
+async fn custom_extension_type_reaches_a_custom_strategy() {
+    let app = test::init_service(
+        App::new()
+            .wrap_fn(|req, srv| {
+                req.extensions_mut().insert(TenantId("acme".to_string()));
+                srv.call(req)
+            })
+            .app_data(web::Data::new(tenant_guard()))
+            .app_data(web::Data::new(
+                CarriedExtensions::new()
+                    .carry::<TenantId>()
+                    .carry::<NeverInserted>(),
+            ))
+            .route("/whoami", web::get().to(whoami)),
+    )
+    .await;
+
+    let resp = test::call_service(&app, TestRequest::get().uri("/whoami").to_request()).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "TenantId inserted by middleware did not reach the strategy"
+    );
+    assert_eq!(test::read_body(resp).await, "acme");
+}
+
+/// Same as above but registered via the bare `.app_data(registry)` form rather
+/// than `web::Data`, since silently ignoring one of the two would reintroduce
+/// exactly the "extension is quietly missing" failure this issue is about.
+#[actix_web::test]
+async fn registry_also_works_without_web_data_wrapper() {
+    let app = test::init_service(
+        App::new()
+            .wrap_fn(|req, srv| {
+                req.extensions_mut().insert(TenantId("beta".to_string()));
+                srv.call(req)
+            })
+            .app_data(web::Data::new(tenant_guard()))
+            .app_data(CarriedExtensions::new().carry::<TenantId>())
+            .route("/whoami", web::get().to(whoami)),
+    )
+    .await;
+
+    let resp = test::call_service(&app, TestRequest::get().uri("/whoami").to_request()).await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(test::read_body(resp).await, "beta");
+}
+
+/// Carrying is opt-in by type: an extension present on the request but not
+/// registered stays behind. Pins the documented contract so it cannot drift
+/// into "carries everything" by accident.
+#[actix_web::test]
+async fn unregistered_extension_type_is_not_carried() {
+    let app = test::init_service(
+        App::new()
+            .wrap_fn(|req, srv| {
+                req.extensions_mut().insert(TenantId("acme".to_string()));
+                srv.call(req)
+            })
+            .app_data(web::Data::new(tenant_guard()))
+            .app_data(web::Data::new(CarriedExtensions::new()))
+            .route("/whoami", web::get().to(whoami)),
+    )
+    .await;
+
+    let resp = test::call_service(&app, TestRequest::get().uri("/whoami").to_request()).await;
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// No registry configured at all must not break: the strategy simply sees no
+/// extension.
+#[actix_web::test]
+async fn missing_registry_is_not_an_error() {
+    let app = test::init_service(
+        App::new()
+            .wrap_fn(|req, srv| {
+                req.extensions_mut().insert(TenantId("acme".to_string()));
+                srv.call(req)
+            })
+            .app_data(web::Data::new(tenant_guard()))
+            .route("/whoami", web::get().to(whoami)),
+    )
+    .await;
+
+    let resp = test::call_service(&app, TestRequest::get().uri("/whoami").to_request()).await;
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// `ClientCertificateDer` must keep flowing with no registration whatsoever —
+/// the RFC 8705 resource-side check (#224) depends on it.
+#[actix_web::test]
+async fn client_certificate_der_is_still_carried_without_registration() {
+    let app = test::init_service(
+        App::new()
+            .wrap_fn(|req, srv| {
+                req.extensions_mut()
+                    .insert(ClientCertificateDer(vec![1, 2, 3, 4, 5]));
+                srv.call(req)
+            })
+            .app_data(web::Data::new(cert_guard()))
+            .route("/whoami", web::get().to(whoami)),
+    )
+    .await;
+
+    let resp = test::call_service(&app, TestRequest::get().uri("/whoami").to_request()).await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(test::read_body(resp).await, "cert:5");
+}

--- a/crates/authkestra-actix/tests/auth_extensions_integration.rs
+++ b/crates/authkestra-actix/tests/auth_extensions_integration.rs
@@ -35,6 +35,12 @@ struct TenantId(String);
 #[derive(Clone, Debug)]
 struct NeverInserted;
 
+/// A third test-only type, carried alongside [`TenantId`] so that registering
+/// two types that are *both* present is covered — one type succeeding could
+/// otherwise mask a registry that only ever applies its first carrier.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RequestScope(String);
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct TestIdentity(String);
 
@@ -70,6 +76,22 @@ impl AuthenticationStrategy<TestIdentity> for CertStrategy {
     }
 }
 
+/// Reads **two** registered types and fails unless both arrived, so a registry
+/// that applied only its first carrier would be caught.
+struct BothStrategy;
+
+#[async_trait]
+impl AuthenticationStrategy<TestIdentity> for BothStrategy {
+    async fn authenticate(&self, parts: &Parts) -> Result<Option<TestIdentity>, AuthError> {
+        let tenant = parts.extensions.get::<TenantId>();
+        let scope = parts.extensions.get::<RequestScope>();
+        Ok(match (tenant, scope) {
+            (Some(t), Some(s)) => Some(TestIdentity(format!("{}/{}", t.0, s.0))),
+            _ => None,
+        })
+    }
+}
+
 async fn whoami(Auth(identity): Auth<TestIdentity>) -> impl Responder {
     HttpResponse::Ok().body(identity.0)
 }
@@ -80,6 +102,45 @@ fn tenant_guard() -> Arc<Guard<TestIdentity>> {
 
 fn cert_guard() -> Arc<Guard<TestIdentity>> {
     Arc::new(Guard::builder().strategy(CertStrategy).build())
+}
+
+fn both_guard() -> Arc<Guard<TestIdentity>> {
+    Arc::new(Guard::builder().strategy(BothStrategy).build())
+}
+
+/// Two registered types, both present on the request, must *both* be carried.
+///
+/// Every other positive test registers types of which only one is ever
+/// actually inserted, so a registry that stopped after applying its first
+/// carrier would still pass them. This pins that `apply` runs every carrier.
+#[actix_web::test]
+async fn two_registered_types_are_both_carried() {
+    let app = test::init_service(
+        App::new()
+            .wrap_fn(|req, srv| {
+                req.extensions_mut().insert(TenantId("acme".to_string()));
+                req.extensions_mut()
+                    .insert(RequestScope("admin".to_string()));
+                srv.call(req)
+            })
+            .app_data(web::Data::new(both_guard()))
+            .app_data(web::Data::new(
+                CarriedExtensions::new()
+                    .carry::<TenantId>()
+                    .carry::<RequestScope>(),
+            ))
+            .route("/whoami", web::get().to(whoami)),
+    )
+    .await;
+
+    let resp = test::call_service(&app, TestRequest::get().uri("/whoami").to_request()).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "both registered extension types must reach the strategy"
+    );
+    assert_eq!(test::read_body(resp).await, "acme/admin");
 }
 
 /// The regression test for #246. A middleware inserts `TenantId` into actix's


### PR DESCRIPTION
Refs #246. Deliberately **not** auto-closing: this ships option 2 from the issue (explicit registration), not option 1 (automatic whole-map carry-over), because option 1 is not expressible on the pinned versions. The maintainer should decide whether that satisfies the issue.

## The defect

`Auth<I>::from_request` synthesises an `http::request::Parts` from the request's method, URI and headers, so the extension map handed to `AuthenticationStrategy::authenticate` started empty. #231 patched this for `ClientCertificateDer` only. `AuthenticationStrategy<I>` is a public trait meant for downstream extension, so any custom strategy reading a different extension type (tenant id, session context, a `DeviceIdentity` from other middleware) still silently saw `None` under actix — though not under axum, whose `FromRequestParts` receives native `Parts`.

## Why the whole map cannot just be copied

I checked this on the pinned versions (`actix-http` 3.13.3, `actix-web` 4.14.0, `http` 1.5.0) rather than assuming. Three independent blockers, any one of which is fatal:

1. **No enumeration.** `actix_http::Extensions` wraps a *private* `HashMap<TypeId, Box<dyn Any>>` (`actix-http-3.13.3/src/extensions.rs:35`) and exposes only typed accessors — `get::<T>`, `get_mut::<T>`, `remove::<T>`, `insert::<T>`, `clear`, `extend(Extensions)`. There is no `iter()`, no `drain()`, no `IntoIterator`. Nothing outside actix-http can discover which types a request is carrying.
2. **Bounds are unrecoverable after erasure.** Even given enumeration, actix stores `Box<dyn Any>`, while `http::Extensions` stores `Box<dyn AnyClone + Send + Sync>` and its only insertion API is `insert<T: Clone + Send + Sync + 'static>(val: T)` (`http-1.5.0/src/extensions.rs:6,62`). A `Box<dyn Any>` cannot be re-boxed into that.
3. **Two different `http` crates.** actix-http 3.x depends on `http` 0.2.7, so its `Extensions` and `http` 1.x's `Extensions` are unrelated types from separately-compiled crates; `extend` has nothing to bridge.

Storing a *handle* to actix's map inside the `Parts` instead is blocked too: `HttpRequest` and `Extensions` are `!Send + !Sync`, and `http::Extensions::insert` requires `Send + Sync`.

## What this ships instead

`CarriedExtensions`: an `app_data`-registered list of extension *types* to copy across.

```rust
App::new()
    .wrap_fn(|req, srv| {
        req.extensions_mut().insert(TenantId("acme".to_string()));
        srv.call(req)
    })
    .app_data(web::Data::new(
        CarriedExtensions::new().carry::<TenantId>(),
    ))
```

Registration is generic over `T: Clone + Send + Sync + 'static` and monomorphises one `fn` pointer per type, so **the adapter no longer names any concrete extension type** — the host does. That is the sense in which this is general; it is not automatic. The `Clone + Send + Sync` bounds are not a design choice, they are exactly what `http::Extensions::insert` demands.

Both `web::Data::new(registry)` and the bare `.app_data(registry)` form are honoured, since matching only one would turn the other into the same class of silent no-op this issue is about.

`ClientCertificateDer` is still carried unconditionally and needs no registration, so the RFC 8705 resource-side check (#224) cannot be broken by a host that forgets to register it.

The full rationale lives in the `extensions` module docs so the next reader does not have to re-derive it from the registry sources.

## Tests

Five new integration tests in `crates/authkestra-actix/tests/auth_extensions_integration.rs`, driving a real `actix_web::App` via `test::call_service` like the crate's existing integration tests, plus three unit tests in the new module and one doctest.

The load-bearing test uses `TenantId`, a **test-only marker type, not `ClientCertificateDer`** — a test written against `ClientCertificateDer` would have passed on the buggy code and proved nothing.

I verified that claim rather than asserting it. Neutering only the carry-over call (keeping the API so the test still compiles, reproducing `main`'s runtime behaviour exactly):

```
test custom_extension_type_reaches_a_custom_strategy ... FAILED
test registry_also_works_without_web_data_wrapper ... FAILED

---- custom_extension_type_reaches_a_custom_strategy stdout ----
panicked at crates/authkestra-actix/tests/auth_extensions_integration.rs:109:5:
assertion `left == right` failed: TenantId inserted by middleware did not reach the strategy
  left: 401
 right: 200

test result: FAILED. 3 passed; 2 failed
```

Note which test is in the *passing* three: `client_certificate_der_is_still_carried_without_registration`. That is the direct evidence that a `ClientCertificateDer`-only test does not cover this fix.

With the fix restored, all five pass, as do the crate's 8 pre-existing integration tests.

## Verification run

```
cargo fmt --all -- --check                                                  # clean
cargo +1.98.0 clippy -p authkestra-actix --all-targets --all-features -- -D warnings   # clean
cargo test -p authkestra-actix --all-features -- --test-threads=2           # 3 + 5 + 5 + 3 + 1 doctest, all pass
```

Scoped to the touched crate rather than `--workspace`: the machine was under heavy concurrent load from sibling agents and a separate project. An earlier full-workspace run on this branch surfaced two failures, both traced to local port contention and neither reachable from this change — `authkestra`'s `examples_e2e` (port 3000 was held by an orphaned `axum_oauth2_git` from another worktree, pid 2142634) and `authkestra-engine`'s `test_mysql_indexed_store` (rootless-docker `RootlessKit PortManager.AddPort ... address already in use`). CI runs the full workspace suite on a clean machine.

## Not done

`docs/book/ch06-adapters-and-integrations.md` was left alone; the new mechanism is documented in the crate README and module docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
