### PR TITLE
fix(devsig): verify EdDSA strictly, rejecting low-order Ed25519 keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,7 @@ version = "0.5.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "ed25519-dalek",
  "jsonwebtoken",
  "p256",
  "rand 0.8.7",

--- a/crates/authkestra-devsig/Cargo.toml
+++ b/crates/authkestra-devsig/Cargo.toml
@@ -12,6 +12,11 @@ readme = "README.md"
 
 [dependencies]
 async-trait = "0.1"
+# Direct, not transitive-by-accident: `crate::eddsa` calls `VerifyingKey::verify_strict` itself
+# because `jsonwebtoken`'s EdDSA backend uses the non-strict verifier (authkestra#242). This adds
+# no new code to the dependency graph — `jsonwebtoken`'s `rust_crypto` backend, already enabled
+# above, resolves the same `ed25519-dalek` 2.x.
+ed25519-dalek = "2"
 jsonwebtoken = { version = "11", features = ["rust_crypto"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -27,6 +32,10 @@ tokio = { version = "1", features = ["full"] }
 rsa = "0.9"
 p256 = { version = "0.13", features = ["pem", "ecdsa"] }
 rand = "0.8"
+# `pkcs8` only, and only for tests: the conformance suite needs to mint a *real* Ed25519 device
+# key in the PKCS#8 DER shape `jsonwebtoken::EncodingKey::from_ed_der` expects, so that the
+# positive EdDSA case exercises the same signing path a real device would.
+ed25519-dalek = { version = "2", features = ["pkcs8"] }
 
 [features]
 default = []

--- a/crates/authkestra-devsig/src/attestation.rs
+++ b/crates/authkestra-devsig/src/attestation.rs
@@ -1,11 +1,12 @@
 //! Parsing and trust verification of `X-Attestation`.
 
 use jsonwebtoken::jwk::Jwk;
-use jsonwebtoken::{crypto, Algorithm, DecodingKey};
+use jsonwebtoken::{Algorithm, DecodingKey};
 use serde::Deserialize;
 use serde_json::Value;
 
 use crate::config::VerifierConfig;
+use crate::eddsa::{verify_jws_signature, VerifyFailure};
 use crate::error::VerifyError;
 use crate::jwks::IssuerJwks;
 use crate::jws_util::{decode_json_segment, parse_and_check_alg, split_compact, RawJws};
@@ -96,14 +97,32 @@ pub async fn verify_trust(
     let decoding_key = DecodingKey::from_jwk(&jwk)
         .map_err(|e| VerifyError::BadAttestation(format!("issuer key unusable: {e}")))?;
 
+    // Strict EdDSA here too. The issuer key comes from the cached JWKS rather than from the
+    // request, so this is defence in depth rather than a live exposure — but a low-order key that
+    // reached the JWKS would let anyone mint attestations for any subject, and the check is free
+    // now that `crate::eddsa` exists. See that module's docs (authkestra#242).
     let signing_input = format!("{}.{}", parsed.raw.header_b64, parsed.raw.payload_b64);
-    let ok = crypto::verify(
+    let ok = verify_jws_signature(
+        parsed.alg,
+        &jwk,
+        &decoding_key,
         parsed.raw.signature_b64,
         signing_input.as_bytes(),
-        &decoding_key,
-        parsed.alg,
     )
-    .map_err(|e| VerifyError::BadAttestation(format!("signature verification error: {e}")))?;
+    .map_err(|failure| match failure {
+        VerifyFailure::Key(reason) => {
+            tracing::warn!(
+                target: "authkestra_devsig",
+                iss = %raw_claims.iss,
+                kid,
+                "attestation rejected: the issuer key resolved from the JWKS is unusable or unsafe"
+            );
+            VerifyError::BadAttestation(format!("issuer key unusable: {reason}"))
+        }
+        VerifyFailure::Backend(reason) => {
+            VerifyError::BadAttestation(format!("signature verification error: {reason}"))
+        }
+    })?;
     if !ok {
         return Err(VerifyError::BadAttestation(
             "signature does not verify".to_string(),

--- a/crates/authkestra-devsig/src/eddsa.rs
+++ b/crates/authkestra-devsig/src/eddsa.rs
@@ -165,3 +165,64 @@ fn ed25519_verifying_key(jwk: &Jwk) -> Result<VerifyingKey, VerifyFailure> {
 
     Ok(key)
 }
+
+#[cfg(test)]
+mod tests {
+    use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+
+    /// The identity point: the canonical universal low-order vector.
+    const IDENTITY: [u8; 32] = {
+        let mut b = [0u8; 32];
+        b[0] = 1;
+        b
+    };
+
+    /// Pins `verify_strict` over the non-strict `Verifier::verify`.
+    ///
+    /// Raised in review of #242: swapping `verify_strict` for `Verifier::verify`
+    /// in [`super::verify_jws_signature`] leaves the whole conformance suite
+    /// green, so nothing pinned the strict call itself. That is expected rather
+    /// than alarming — [`super::ed25519_verifying_key`]'s `is_weak()` gate
+    /// rejects a small-order `A` *before* verification runs, and producing a
+    /// small-order `R` that satisfies the equation under a non-small-order `A`
+    /// would require solving a discrete log. So there is no reachable
+    /// end-to-end input that distinguishes the two verifiers.
+    ///
+    /// The distinguishing input therefore has to be a small-order *key*, which
+    /// means calling dalek directly here, below that gate. This is the pair the
+    /// two verifiers genuinely disagree about, and it is what makes the strict
+    /// call load-bearing rather than decorative: without it, a future refactor
+    /// could drop `verify_strict` and CI would stay green.
+    #[test]
+    fn strict_verification_rejects_a_low_order_key_that_non_strict_accepts() {
+        let weak = VerifyingKey::from_bytes(&IDENTITY).expect("identity is a valid Edwards point");
+        assert!(weak.is_weak(), "the identity point must be low-order");
+
+        // (R = identity, S = 0): both sides of [S]B - [k]A == R collapse to the
+        // identity for every challenge scalar, so this verifies under ANY message.
+        let mut forged = [0u8; 64];
+        forged[..32].copy_from_slice(&IDENTITY);
+        let forged = Signature::from_bytes(&forged);
+
+        assert!(
+            weak.verify(b"authkestra", &forged).is_ok(),
+            "precondition: the NON-strict verifier accepts this forgery — if this ever fails, \
+             upstream changed and this test no longer proves what it claims"
+        );
+        assert!(
+            weak.verify_strict(b"authkestra", &forged).is_err(),
+            "verify_strict must reject a low-order key that non-strict accepts"
+        );
+    }
+
+    /// Positive control: a fix that rejects everything is not a fix.
+    #[test]
+    fn strict_verification_still_accepts_a_genuine_signature() {
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let key = signing.verifying_key();
+        assert!(!key.is_weak());
+
+        let genuine = signing.sign(b"authkestra");
+        assert!(key.verify_strict(b"authkestra", &genuine).is_ok());
+    }
+}

--- a/crates/authkestra-devsig/src/eddsa.rs
+++ b/crates/authkestra-devsig/src/eddsa.rs
@@ -1,0 +1,167 @@
+//! Compact-JWS signature verification, with a **strict** Ed25519 path of this crate's own.
+//!
+//! ## Why this module exists ([authkestra#242](https://github.com/marcjazz/authkestra/issues/242))
+//!
+//! `jsonwebtoken` 11.0.0's `rust_crypto` backend verifies EdDSA with
+//! `ed25519_dalek::Verifier::verify` — the **non-strict** verifier (see
+//! `jsonwebtoken-11.0.0/src/crypto/rust_crypto/eddsa.rs`). Non-strict verification never asks
+//! whether the public key, or the signature's `R`, is a low-order point, so the triple
+//! `(A = identity, R = identity, S = 0)` satisfies the verification equation `[S]B - [k]A == R`
+//! for *every* message: both sides collapse to the identity whatever the challenge scalar `k` is.
+//! No private key exists for such a public key — not "is unknown", *does not exist*.
+//!
+//! That is fatal for this crate specifically, because here the verifying key is **not** trusted
+//! input: it travels in the request, inside the `X-Signature` protected header's embedded `jwk`.
+//! The binding check ties that `jwk` to the attestation's `cnf.jkt`, but a low-order key
+//! thumbprints exactly like a real one, so an attacker who gets one enrolled passes the binding
+//! check honestly and then needs no secret at all to sign. Per-request proof of possession — the
+//! entire reason `authkestra-devsig` exists — would be gone.
+//!
+//! The same strict path is applied to the attestation's issuer key. That key comes from the
+//! cached Issuer JWKS, which is a great deal more trustworthy than a key arriving in the request,
+//! so this is defence in depth rather than a live exposure; but "more trustworthy" is not
+//! "unforgeable", and a low-order key reaching a verifier's JWKS (compromised issuer, hostile
+//! mirror, buggy rotation tooling) would let anyone mint attestations for any subject.
+//!
+//! ## Why not fix `jsonwebtoken` instead
+//!
+//! The backend choice is upstream of authkestra and applies to every `jsonwebtoken` consumer;
+//! waiting on it would leave the exploitable path open for however long that takes. Overriding
+//! only the EdDSA branch here is the smallest change that closes it, and
+//! `canary_upstream_jsonwebtoken_still_verifies_eddsa_non_strictly` in `tests/conformance.rs`
+//! will fail loudly if upstream ever adopts strict verification, so this workaround cannot
+//! quietly outlive its reason.
+//!
+//! Every non-EdDSA algorithm is still delegated to `jsonwebtoken::crypto::verify` unchanged —
+//! this module deliberately does not reimplement RSA or ECDSA verification.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use ed25519_dalek::{Signature, VerifyingKey};
+use jsonwebtoken::jwk::{AlgorithmParameters, EllipticCurve, Jwk};
+use jsonwebtoken::{crypto, Algorithm, DecodingKey};
+
+/// Why a signature check could not be *carried out*, as opposed to a signature that was checked
+/// and did not verify (which is an `Ok(false)`, not an error).
+///
+/// The split exists so each call site can map the two cases onto the rejection code its part of
+/// the algorithm names — a bad key is not a bad signature, and reporting a low-order key as
+/// `bad_signature` would hide the fact that the *key* is the defect.
+#[derive(Debug)]
+pub enum VerifyFailure {
+    /// The verifying key is unusable or unsafe — malformed, or a low-order Ed25519 point.
+    Key(String),
+    /// The backend could not run the check at all (e.g. a signature segment that is not
+    /// well-formed base64url, or is not 64 bytes for Ed25519).
+    Backend(String),
+}
+
+/// Verifies a compact JWS signature segment against `jwk`, using strict verification for EdDSA
+/// and `jsonwebtoken`'s own backend for every other algorithm.
+///
+/// `decoding_key` must already have been derived from `jwk`; both are taken because the EdDSA
+/// path needs the raw `x` coordinate (to run the low-order check that `DecodingKey` gives no
+/// access to) while every other path needs the `DecodingKey`.
+pub fn verify_jws_signature(
+    alg: Algorithm,
+    jwk: &Jwk,
+    decoding_key: &DecodingKey,
+    signature_b64: &str,
+    signing_input: &[u8],
+) -> Result<bool, VerifyFailure> {
+    if alg != Algorithm::EdDSA {
+        return crypto::verify(signature_b64, signing_input, decoding_key, alg)
+            .map_err(|e| VerifyFailure::Backend(e.to_string()));
+    }
+
+    let key = ed25519_verifying_key(jwk)?;
+
+    let signature_bytes = URL_SAFE_NO_PAD
+        .decode(signature_b64)
+        .map_err(|e| VerifyFailure::Backend(format!("signature is not valid base64url: {e}")))?;
+    let signature = Signature::from_slice(&signature_bytes).map_err(|_| {
+        VerifyFailure::Backend(format!(
+            "an Ed25519 signature must be exactly 64 bytes, got {}",
+            signature_bytes.len()
+        ))
+    })?;
+
+    match key.verify_strict(signing_input, &signature) {
+        Ok(()) => Ok(true),
+        Err(_) => {
+            // `verify_strict` folds "the equation did not hold" and "R is a low-order point" into
+            // a single opaque error. Recompute the latter so operators can tell routine signature
+            // failures from an attempted low-order forgery, which is an attack signal and not
+            // noise. `VerifyingKey::from_bytes` is reused purely as a compressed-Edwards-point
+            // decoder here -- `R` is the same encoding as a public key, and `is_weak()` is the
+            // only small-order predicate `ed25519-dalek` exposes publicly.
+            let r_is_small_order = VerifyingKey::from_bytes(
+                signature_bytes[..32]
+                    .try_into()
+                    .expect("a 64-byte Ed25519 signature always yields a 32-byte R"),
+            )
+            .is_ok_and(|r| r.is_weak());
+            if r_is_small_order {
+                tracing::warn!(
+                    target: "authkestra_devsig",
+                    "rejecting EdDSA signature: its R component is a low-order point — strict \
+                     verification refuses these because they carry no proof of possession \
+                     (authkestra#242)"
+                );
+            } else {
+                tracing::debug!(
+                    target: "authkestra_devsig",
+                    "EdDSA signature did not verify under strict verification"
+                );
+            }
+            Ok(false)
+        }
+    }
+}
+
+/// Extracts an Ed25519 verifying key from `jwk`, **rejecting low-order ("weak") keys**.
+///
+/// This is the check whose absence authkestra#242 reports: it must run before any verification
+/// attempt, so that the key is rejected on its own merits rather than on whichever signature
+/// bytes happened to accompany it.
+fn ed25519_verifying_key(jwk: &Jwk) -> Result<VerifyingKey, VerifyFailure> {
+    let params = match &jwk.algorithm {
+        AlgorithmParameters::OctetKeyPair(params) => params,
+        _ => return Err(VerifyFailure::Key("EdDSA requires an OKP key".to_string())),
+    };
+    if params.curve != EllipticCurve::Ed25519 {
+        return Err(VerifyFailure::Key(format!(
+            "EdDSA requires the Ed25519 curve, got {:?}",
+            params.curve
+        )));
+    }
+
+    let x = URL_SAFE_NO_PAD
+        .decode(&params.x)
+        .map_err(|e| VerifyFailure::Key(format!("OKP \"x\" is not valid base64url: {e}")))?;
+    let x: [u8; 32] = x.as_slice().try_into().map_err(|_| {
+        VerifyFailure::Key(format!(
+            "an Ed25519 public key must be exactly 32 bytes, got {}",
+            x.len()
+        ))
+    })?;
+
+    let key = VerifyingKey::from_bytes(&x)
+        .map_err(|_| VerifyFailure::Key("OKP \"x\" is not a valid Ed25519 point".to_string()))?;
+
+    if key.is_weak() {
+        tracing::warn!(
+            target: "authkestra_devsig",
+            "rejecting Ed25519 key: it is a low-order (weak) point, for which no private key \
+             exists — a signature under it would prove possession of nothing, so it is refused \
+             before verification is even attempted (authkestra#242)"
+        );
+        return Err(VerifyFailure::Key(
+            "Ed25519 public key is a low-order point; no private key exists for it, so a \
+             signature under it proves nothing"
+                .to_string(),
+        ));
+    }
+
+    Ok(key)
+}

--- a/crates/authkestra-devsig/src/error.rs
+++ b/crates/authkestra-devsig/src/error.rs
@@ -45,8 +45,13 @@ pub enum VerifyError {
     DeviceNotActive,
 
     /// The embedded `jwk` (from the request signature's protected header) is missing, is not a
-    /// public key of an allowed type, or carries a private component (`d`, `p`, `q`, `dp`, `dq`,
-    /// `qi`, `k`).
+    /// public key of an allowed type, carries a private component (`d`, `p`, `q`, `dp`, `dq`,
+    /// `qi`, `k`), or is a key no signature under it could ever prove anything about.
+    ///
+    /// That last case is a **low-order ("weak") Ed25519 public key**: no private key exists for
+    /// one, so it is rejected on its own merits, before verification is attempted, rather than
+    /// as a `bad_signature` — the key is the defect, not the signature. See `crate::eddsa` and
+    /// [authkestra#242](https://github.com/marcjazz/authkestra/issues/242).
     #[error("bad_jwk: {0}")]
     BadJwk(String),
 

--- a/crates/authkestra-devsig/src/lib.rs
+++ b/crates/authkestra-devsig/src/lib.rs
@@ -63,6 +63,7 @@
 
 mod attestation;
 mod config;
+mod eddsa;
 mod error;
 mod identity;
 mod jwks;

--- a/crates/authkestra-devsig/src/signature.rs
+++ b/crates/authkestra-devsig/src/signature.rs
@@ -22,12 +22,13 @@
 //! what was actually signed.
 
 use jsonwebtoken::jwk::{AlgorithmParameters, EllipticCurve, Jwk, ThumbprintHash};
-use jsonwebtoken::{crypto, Algorithm, AlgorithmFamily, DecodingKey};
+use jsonwebtoken::{Algorithm, AlgorithmFamily, DecodingKey};
 use serde::Deserialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use crate::config::VerifierConfig;
+use crate::eddsa::{verify_jws_signature, VerifyFailure};
 use crate::error::VerifyError;
 use crate::jws_util::{
     constant_time_eq, decode_json_segment, parse_and_check_alg, reject_private_jwk_members,
@@ -163,14 +164,25 @@ pub fn verify_bound_and_signed(
         VerifyError::BadJwk(format!("embedded jwk unusable as a decoding key: {e}"))
     })?;
 
+    // EdDSA goes through this crate's own *strict* verifier rather than `jsonwebtoken`'s
+    // non-strict one — see `crate::eddsa` for why that distinction is load-bearing precisely
+    // here, where `jwk` is attacker-supplied (authkestra#242).
     let signing_input = format!("{}.{}", parsed.raw.header_b64, parsed.raw.payload_b64);
-    let sig_ok = crypto::verify(
+    let sig_ok = verify_jws_signature(
+        parsed.alg,
+        &jwk,
+        &decoding_key,
         parsed.raw.signature_b64,
         signing_input.as_bytes(),
-        &decoding_key,
-        parsed.alg,
     )
-    .map_err(|e| VerifyError::BadSignature(format!("verification error: {e}")))?;
+    .map_err(|failure| match failure {
+        // A key that cannot be used, or must not be used, is a `bad_jwk` — reporting it as
+        // `bad_signature` would blame the signature for a defect that is in the key.
+        VerifyFailure::Key(reason) => VerifyError::BadJwk(reason),
+        VerifyFailure::Backend(reason) => {
+            VerifyError::BadSignature(format!("verification error: {reason}"))
+        }
+    })?;
     if !sig_ok {
         return Err(VerifyError::BadSignature(
             "signature does not verify".to_string(),

--- a/crates/authkestra-devsig/tests/conformance.rs
+++ b/crates/authkestra-devsig/tests/conformance.rs
@@ -8,8 +8,12 @@
 
 mod support;
 
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use jsonwebtoken::{crypto, Algorithm, DecodingKey};
+
 use authkestra_devsig::{InMemoryReplayStore, SignedRequest, UnavailableReplayStore, VerifyError};
-use support::TestSetup;
+use support::{KeyPair, TestSetup, LOW_ORDER_ED25519_POINT};
 
 /// Case 1: valid signature + valid attestation, bound, fresh -> Accept.
 #[tokio::test]
@@ -714,4 +718,237 @@ async fn expired_but_within_skew_does_not_panic_on_replay_ttl() {
     // Whether this accepts or rejects on freshness grounds depends on exact skew math; the
     // only hard requirement here is that it doesn't panic while computing the replay TTL.
     let _ = authkestra_devsig::verify(&request, &setup.config, &setup.jwks, &store).await;
+}
+
+// ---------------------------------------------------------------------------------------
+// authkestra#242 -- EdDSA must be verified *strictly*.
+//
+// `jsonwebtoken` 11.0.0's `rust_crypto` backend verifies EdDSA through
+// `ed25519_dalek::Verifier::verify`, the **non-strict** verifier
+// (`jsonwebtoken-11.0.0/src/crypto/rust_crypto/eddsa.rs`). Non-strict verification does not
+// check whether the public key -- or the signature's `R` -- is a low-order point, so the pair
+// `(A = identity, R = identity, S = 0)` satisfies the verification equation for **every**
+// message. Nobody holds a private key for that public key; there isn't one.
+//
+// For `authkestra-devsig` that is not academic. The verifying key travels inside the request,
+// in the `X-Signature` protected header's embedded `jwk`. The binding check ties that `jwk` to
+// the attestation's `cnf.jkt` -- but a low-order key thumbprints just like any other, so an
+// attacker who enrols one passes the binding check honestly and then needs no secret at all to
+// sign. See `authkestra_devsig`'s `eddsa` module for the fix.
+// ---------------------------------------------------------------------------------------
+
+/// **The vulnerability.** A device key that is a low-order Ed25519 point, genuinely attested by
+/// the trusted issuer (nothing in an enrolment flow makes such a key look unusual — it is a
+/// well-formed 32-byte OKP `x`), paired with a signature nobody needed a private key to produce.
+///
+/// Every other check in the algorithm passes honestly here: the attestation really is the
+/// issuer's, the embedded `jwk` really does thumbprint-match `cnf.jkt`, the claims really do
+/// bind this method/path/audience, the signature is fresh and unreplayed. The *only* thing
+/// standing between this request and a full impersonation is whether the EdDSA signature check
+/// is strict. Under non-strict verification it is accepted.
+#[tokio::test]
+async fn low_order_ed25519_device_key_cannot_forge_a_signature() {
+    let setup = TestSetup::new().await;
+    let low_order = KeyPair::low_order_ed25519();
+
+    let attestation = setup.attestation_binding(&low_order);
+    let signature = setup.valid_signature(&low_order, "POST", "/v1/payments/transfer", None, None);
+
+    let request = SignedRequest {
+        signature: Some(&signature),
+        attestation: Some(&attestation),
+        method: "POST",
+        path: "/v1/payments/transfer",
+        query: None,
+        body: None,
+    };
+
+    let store = InMemoryReplayStore::new();
+    let result = authkestra_devsig::verify(&request, &setup.config, &setup.jwks, &store).await;
+
+    let err = result.expect_err(
+        "a low-order Ed25519 public key has no private key behind it -- accepting a signature \
+         under it means anyone can sign as this identity, which defeats the per-request \
+         proof-of-possession this crate exists to provide (authkestra#242)",
+    );
+    assert_eq!(
+        err.code(),
+        "bad_jwk",
+        "the low-order key must be rejected as an unusable key, not merely as a bad signature: \
+         the key itself is the defect, so rejecting it before any verification attempt is what \
+         makes the rejection independent of which signature bytes were supplied -- got {err}"
+    );
+}
+
+/// The same low-order key, but with the canned forgery replaced by *arbitrary* signature bytes.
+/// Guards against a fix that only recognises one hard-coded forgery vector: the key is rejected
+/// on its own merits, whatever accompanies it.
+#[tokio::test]
+async fn low_order_ed25519_device_key_is_rejected_regardless_of_signature_bytes() {
+    let setup = TestSetup::new().await;
+    let low_order = KeyPair::low_order_ed25519_with_signature([0x42u8; 64]);
+
+    let attestation = setup.attestation_binding(&low_order);
+    let signature = setup.valid_signature(&low_order, "GET", "/v1/accounts", None, None);
+
+    let request = SignedRequest {
+        signature: Some(&signature),
+        attestation: Some(&attestation),
+        method: "GET",
+        path: "/v1/accounts",
+        query: None,
+        body: None,
+    };
+
+    let store = InMemoryReplayStore::new();
+    let err = authkestra_devsig::verify(&request, &setup.config, &setup.jwks, &store)
+        .await
+        .expect_err("a low-order Ed25519 key must be rejected on the strength of the key alone");
+    assert_eq!(err.code(), "bad_jwk", "got {err}");
+}
+
+/// **The positive control.** A fix that rejects every Ed25519 key is not a fix. A real,
+/// honestly-generated Ed25519 device key must still verify end to end, including the body hash.
+#[tokio::test]
+async fn genuine_ed25519_device_key_is_still_accepted() {
+    let setup = TestSetup::new().await;
+    let device = KeyPair::generate_ed25519();
+
+    let attestation = setup.attestation_binding(&device);
+    let body = br#"{"amount":"12.50","currency":"EUR"}"#;
+    let signature = setup.valid_signature_with_body(&device, "POST", "/v1/payments/transfer", body);
+
+    let request = SignedRequest {
+        signature: Some(&signature),
+        attestation: Some(&attestation),
+        method: "POST",
+        path: "/v1/payments/transfer",
+        query: None,
+        body: Some(body),
+    };
+
+    let store = InMemoryReplayStore::new();
+    let identity = authkestra_devsig::verify(&request, &setup.config, &setup.jwks, &store)
+        .await
+        .expect("a genuine Ed25519 device key must keep verifying after the strict-EdDSA change");
+
+    assert_eq!(identity.subject, support::SUBJECT);
+    assert_eq!(identity.key_thumbprint, device.thumbprint);
+}
+
+/// A genuine Ed25519 device key whose signature has been tampered with must still be rejected —
+/// i.e. the strict path actually verifies, rather than waving EdDSA through once the key looks
+/// healthy.
+#[tokio::test]
+async fn genuine_ed25519_device_key_with_a_tampered_body_is_rejected() {
+    let setup = TestSetup::new().await;
+    let device = KeyPair::generate_ed25519();
+
+    let attestation = setup.attestation_binding(&device);
+    let signature =
+        setup.valid_signature_with_body(&device, "POST", "/v1/payments/transfer", b"amount=10");
+
+    let request = SignedRequest {
+        signature: Some(&signature),
+        attestation: Some(&attestation),
+        method: "POST",
+        path: "/v1/payments/transfer",
+        query: None,
+        body: Some(b"amount=100000"),
+    };
+
+    let store = InMemoryReplayStore::new();
+    let err = authkestra_devsig::verify(&request, &setup.config, &setup.jwks, &store)
+        .await
+        .expect_err("a tampered body must not verify under a genuine Ed25519 key either");
+    assert_eq!(err.code(), "body_mismatch", "got {err}");
+}
+
+/// An Ed25519 signature that simply does not verify (right key, wrong signature bytes) must be
+/// reported as `bad_signature`, not silently reshaped into some other rejection by the strict
+/// path.
+#[tokio::test]
+async fn genuine_ed25519_device_key_with_a_wrong_signature_is_bad_signature() {
+    let setup = TestSetup::new().await;
+    let device = KeyPair::generate_ed25519();
+
+    let attestation = setup.attestation_binding(&device);
+    let signature = setup.signature_with_forged_bytes(&device, "GET", "/v1/accounts", [0x11u8; 64]);
+
+    let request = SignedRequest {
+        signature: Some(&signature),
+        attestation: Some(&attestation),
+        method: "GET",
+        path: "/v1/accounts",
+        query: None,
+        body: None,
+    };
+
+    let store = InMemoryReplayStore::new();
+    let err = authkestra_devsig::verify(&request, &setup.config, &setup.jwks, &store)
+        .await
+        .expect_err("garbage Ed25519 signature bytes must not verify");
+    assert_eq!(err.code(), "bad_signature", "got {err}");
+}
+
+/// Defence in depth on the *issuer* side. `authkestra-devsig`'s attestation path resolves its
+/// verifying key from the cached Issuer JWKS, which is a good deal more trustworthy than a key
+/// arriving in the request — but "more trustworthy" is not "unforgeable". A low-order Ed25519 key
+/// reaching a verifier's JWKS (compromised issuer, hostile mirror, buggy key-rotation tooling)
+/// would otherwise let anybody mint attestations for any subject, bound to a key they *do*
+/// control, and that is a complete authentication bypass without any device compromise at all.
+#[tokio::test]
+async fn low_order_ed25519_issuer_key_cannot_forge_an_attestation() {
+    let setup = TestSetup::new().await;
+
+    // The attestation is forged under a weak "issuer key" but binds the attacker's own,
+    // genuinely-held device key -- so the binding check and the request signature both pass.
+    let attestation = setup
+        .attestation_forged_under_low_order_issuer_key(&setup.attacker)
+        .await;
+    let signature =
+        setup.valid_signature(&setup.attacker, "POST", "/v1/payments/transfer", None, None);
+
+    let request = SignedRequest {
+        signature: Some(&signature),
+        attestation: Some(&attestation),
+        method: "POST",
+        path: "/v1/payments/transfer",
+        query: None,
+        body: None,
+    };
+
+    let store = InMemoryReplayStore::new();
+    let err = authkestra_devsig::verify(&request, &setup.config, &setup.jwks, &store)
+        .await
+        .expect_err(
+            "an attestation 'signed' by a low-order Ed25519 issuer key must be rejected -- \
+             accepting it lets anyone who can influence the JWKS mint attestations for any subject",
+        );
+    assert_eq!(err.code(), "bad_attestation", "got {err}");
+}
+
+/// A canary, not a requirement: it asserts the *upstream* behaviour this crate is working around.
+///
+/// If this test ever fails, `jsonwebtoken` has switched its EdDSA verifier to `verify_strict`
+/// (or otherwise started rejecting low-order keys), and the local strict path in
+/// `authkestra-devsig` can be reconsidered — deliberately fail loudly at that point rather than
+/// carry a workaround nobody remembers the reason for.
+#[test]
+fn canary_upstream_jsonwebtoken_still_verifies_eddsa_non_strictly() {
+    let mut forged_signature = [0u8; 64];
+    forged_signature[..32].copy_from_slice(&LOW_ORDER_ED25519_POINT);
+
+    let decoding_key = DecodingKey::from_ed_der(&LOW_ORDER_ED25519_POINT);
+    let signature_b64 = URL_SAFE_NO_PAD.encode(forged_signature);
+
+    for message in [b"any message at all".as_slice(), b"and this one too", b""] {
+        let accepted = crypto::verify(&signature_b64, message, &decoding_key, Algorithm::EdDSA)
+            .expect("jsonwebtoken should not error on a well-formed EdDSA key/signature pair");
+        assert!(
+            accepted,
+            "canary: jsonwebtoken no longer accepts the low-order EdDSA forgery -- upstream may \
+             have adopted verify_strict, so authkestra#242's local workaround can be revisited"
+        );
+    }
 }

--- a/crates/authkestra-devsig/tests/support/mod.rs
+++ b/crates/authkestra-devsig/tests/support/mod.rs
@@ -21,11 +21,41 @@ pub const DEVICE_ID: &str = "dev-8821bc04";
 pub const ISSUER: &str = "https://id.example.com";
 pub const AUD: &str = "api.example.com";
 
+/// The compressed Edwards encoding of the **identity element** of the Ed25519 group (`y = 1`) —
+/// a low-order ("weak") public key.
+///
+/// Under *non-strict* Ed25519 verification the pair `(A = identity, R = identity, S = 0)`
+/// satisfies the verification equation `[S]B - [k]A == R` for **every** message, because both
+/// sides collapse to the identity regardless of the challenge scalar `k`. Nobody holds — or needs
+/// — a private key for it. `verify_strict` rejects it outright via `is_small_order()`.
+///
+/// (The all-zero encoding the issue mentions is also low-order, but its order-4 point only
+/// satisfies the equation for roughly one message in four, so it is not usable as a
+/// deterministic test vector. The identity encoding is the universal one.)
+pub const LOW_ORDER_ED25519_POINT: [u8; 32] = {
+    let mut bytes = [0u8; 32];
+    bytes[0] = 1;
+    bytes
+};
+
+/// How a test [`KeyPair`] or [`Issuer`] produces the signature segment of a JWS.
+#[derive(Clone)]
+pub enum Signer {
+    /// A genuinely-held private key: really sign the real signing input.
+    PrivateKey(EncodingKey),
+    /// **No private key is held at all** — emit this canned, message-independent signature.
+    ///
+    /// This is what makes the low-order-key cases meaningful: the forger possesses nothing but a
+    /// public key, so if the verifier accepts, the per-request proof-of-possession this crate
+    /// exists to provide has collapsed completely.
+    Forged(String),
+}
+
 /// An asymmetric keypair plus its public `jsonwebtoken::jwk::Jwk` (both typed and as raw JSON,
 /// ready to splice into a JOSE header).
 #[derive(Clone)]
 pub struct KeyPair {
-    pub encoding_key: EncodingKey,
+    pub signer: Signer,
     pub alg: Algorithm,
     pub jwk_json: Value,
     pub thumbprint: String,
@@ -44,31 +74,73 @@ impl KeyPair {
             EncodingKey::from_ec_pem(pem.as_bytes()).expect("EncodingKey::from_ec_pem");
         let jwk = Jwk::from_encoding_key(&encoding_key, Algorithm::ES256)
             .expect("derive public jwk from EC encoding key");
-        let thumbprint = jwk
-            .thumbprint(jsonwebtoken::jwk::ThumbprintHash::SHA256)
-            .expect("compute thumbprint");
-        let jwk_json = serde_json::to_value(&jwk).expect("serialize device jwk");
+        Self::from_encoding_key(encoding_key, jwk, Algorithm::ES256)
+    }
+
+    /// A real, honestly-generated Ed25519 device key. The positive control for the strict-EdDSA
+    /// change: legitimate devices must keep working.
+    pub fn generate_ed25519() -> Self {
+        use ed25519_dalek::pkcs8::EncodePrivateKey;
+        use rand::RngCore;
+
+        let mut seed = [0u8; 32];
+        rand::rngs::OsRng.fill_bytes(&mut seed);
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&seed);
+        let der = signing_key
+            .to_pkcs8_der()
+            .expect("encode Ed25519 key to PKCS#8 DER");
+        let encoding_key = EncodingKey::from_ed_der(der.as_bytes());
+        let jwk = ed25519_public_jwk(signing_key.verifying_key().as_bytes());
+        Self::from_encoding_key(encoding_key, jwk, Algorithm::EdDSA)
+    }
+
+    /// The attack key: a low-order Ed25519 public key with **no private key behind it**, paired
+    /// with the canned `(R = identity, S = 0)` signature that non-strict verification accepts for
+    /// any message. See [`LOW_ORDER_ED25519_POINT`].
+    pub fn low_order_ed25519() -> Self {
+        let mut forged = [0u8; 64];
+        forged[..32].copy_from_slice(&LOW_ORDER_ED25519_POINT);
+        Self::low_order_ed25519_with_signature(forged)
+    }
+
+    /// The same low-order public key, but carrying caller-chosen signature bytes — for asserting
+    /// that the key is rejected on its own merits rather than by recognising one canned vector.
+    pub fn low_order_ed25519_with_signature(signature: [u8; 64]) -> Self {
+        let jwk = ed25519_public_jwk(&LOW_ORDER_ED25519_POINT);
         Self {
-            encoding_key,
-            alg: Algorithm::ES256,
-            jwk_json,
-            thumbprint,
+            signer: Signer::Forged(b64url(&signature)),
+            alg: Algorithm::EdDSA,
+            thumbprint: thumbprint_of(&jwk),
+            jwk_json: serde_json::to_value(&jwk).expect("serialize low-order jwk"),
         }
+    }
+
+    fn from_encoding_key(encoding_key: EncodingKey, jwk: Jwk, alg: Algorithm) -> Self {
+        Self {
+            signer: Signer::PrivateKey(encoding_key),
+            alg,
+            thumbprint: thumbprint_of(&jwk),
+            jwk_json: serde_json::to_value(&jwk).expect("serialize device jwk"),
+        }
+    }
+
+    fn sign(&self, msg: &[u8]) -> String {
+        sign_with(&self.signer, self.alg, msg)
     }
 
     fn alg_name(&self) -> &'static str {
-        match self.alg {
-            Algorithm::ES256 => "ES256",
-            other => panic!("unexpected test keypair alg {other:?}"),
-        }
+        alg_name(self.alg)
     }
 }
 
-/// The test "Issuer": an RSA keypair playing the role of `authkestra-op`.
+/// The test "Issuer" playing the role of `authkestra-op`. Normally an RSA keypair; the
+/// JWKS-ingest case swaps in a low-order Ed25519 key to prove the issuer side is hardened too.
 #[derive(Clone)]
 pub struct Issuer {
     pub kid: String,
-    pub encoding_key: EncodingKey,
+    pub alg: Algorithm,
+    pub signer: Signer,
+    jwk: Jwk,
 }
 
 impl Issuer {
@@ -84,18 +156,71 @@ impl Issuer {
         };
         let encoding_key =
             EncodingKey::from_rsa_pem(pem.as_bytes()).expect("EncodingKey::from_rsa_pem");
+        let kid = "issuer-key-1".to_string();
+        let mut jwk = Jwk::from_encoding_key(&encoding_key, Algorithm::RS256)
+            .expect("derive public jwk from RSA encoding key");
+        jwk.common.key_id = Some(kid.clone());
         Self {
-            kid: "issuer-key-1".to_string(),
-            encoding_key,
+            kid,
+            alg: Algorithm::RS256,
+            signer: Signer::PrivateKey(encoding_key),
+            jwk,
+        }
+    }
+
+    /// An "issuer key" that is really a low-order Ed25519 point, as it might reach a verifier
+    /// through a compromised, buggy, or hostile JWKS document. Nobody holds a private key for it;
+    /// the canned signature is the same universal forgery as [`KeyPair::low_order_ed25519`].
+    fn low_order_ed25519(kid: &str) -> Self {
+        let mut jwk = ed25519_public_jwk(&LOW_ORDER_ED25519_POINT);
+        jwk.common.key_id = Some(kid.to_string());
+        let mut forged = [0u8; 64];
+        forged[..32].copy_from_slice(&LOW_ORDER_ED25519_POINT);
+        Self {
+            kid: kid.to_string(),
+            alg: Algorithm::EdDSA,
+            signer: Signer::Forged(b64url(&forged)),
+            jwk,
         }
     }
 
     fn public_jwk(&self) -> Jwk {
-        let mut jwk = Jwk::from_encoding_key(&self.encoding_key, Algorithm::RS256)
-            .expect("derive public jwk from RSA encoding key");
-        jwk.common.key_id = Some(self.kid.clone());
-        jwk
+        self.jwk.clone()
     }
+
+    fn sign(&self, msg: &[u8]) -> String {
+        sign_with(&self.signer, self.alg, msg)
+    }
+}
+
+fn sign_with(signer: &Signer, alg: Algorithm, msg: &[u8]) -> String {
+    match signer {
+        Signer::PrivateKey(key) => crypto::sign(msg, key, alg).expect("sign test JWS"),
+        Signer::Forged(signature_b64) => signature_b64.clone(),
+    }
+}
+
+fn alg_name(alg: Algorithm) -> &'static str {
+    match alg {
+        Algorithm::ES256 => "ES256",
+        Algorithm::RS256 => "RS256",
+        Algorithm::EdDSA => "EdDSA",
+        other => panic!("unexpected test keypair alg {other:?}"),
+    }
+}
+
+fn ed25519_public_jwk(public_key: &[u8; 32]) -> Jwk {
+    serde_json::from_value(json!({
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": b64url(public_key),
+    }))
+    .expect("build OKP jwk")
+}
+
+fn thumbprint_of(jwk: &Jwk) -> String {
+    jwk.thumbprint(jsonwebtoken::jwk::ThumbprintHash::SHA256)
+        .expect("compute thumbprint")
 }
 
 /// RSA-2048 keygen in a pure-Rust bignum implementation is not fast; the issuer identity is the
@@ -131,7 +256,7 @@ impl TestSetup {
 
         let config = VerifierConfig::new(
             [ISSUER],
-            [Algorithm::ES256, Algorithm::RS256],
+            [Algorithm::ES256, Algorithm::RS256, Algorithm::EdDSA],
             Duration::from_secs(30),
             Duration::from_secs(120),
             AUD,
@@ -156,11 +281,41 @@ impl TestSetup {
     // ---- Attestations ----
 
     pub fn valid_attestation(&self) -> String {
+        self.attestation_binding(&self.device)
+    }
+
+    /// A genuine attestation from the trusted issuer, binding `key`'s thumbprint rather than the
+    /// default device's. Lets a case choose which key the identity is attested to — including a
+    /// key nobody actually holds the private half of.
+    pub fn attestation_binding(&self, key: &KeyPair) -> String {
         self.attestation_full(
+            &self.issuer,
             ISSUER,
             &self.issuer.kid,
             SUBJECT,
-            &self.device.thumbprint,
+            &key.thumbprint,
+            DEVICE_ID,
+            "active",
+            0,
+            30 * 24 * 3600,
+        )
+    }
+
+    /// Registers a **low-order Ed25519 "issuer key"** in the cached JWKS under its own `kid`, and
+    /// returns an attestation forged under it binding `key`. No issuer private key is involved:
+    /// if this attestation is trusted, anyone who can get such a key into a verifier's JWKS can
+    /// mint attestations for any subject.
+    pub async fn attestation_forged_under_low_order_issuer_key(&self, key: &KeyPair) -> String {
+        let weak_issuer = Issuer::low_order_ed25519("issuer-key-weak-ed25519");
+        self.jwks
+            .insert(ISSUER, weak_issuer.kid.clone(), weak_issuer.public_jwk())
+            .await;
+        self.attestation_full(
+            &weak_issuer,
+            ISSUER,
+            &weak_issuer.kid,
+            SUBJECT,
+            &key.thumbprint,
             DEVICE_ID,
             "active",
             0,
@@ -170,6 +325,7 @@ impl TestSetup {
 
     pub fn attestation_with_issuer(&self, iss: &str) -> String {
         self.attestation_full(
+            &self.issuer,
             iss,
             &self.issuer.kid,
             SUBJECT,
@@ -183,6 +339,7 @@ impl TestSetup {
 
     pub fn attestation_with_kid(&self, kid: &str) -> String {
         self.attestation_full(
+            &self.issuer,
             ISSUER,
             kid,
             SUBJECT,
@@ -196,6 +353,7 @@ impl TestSetup {
 
     pub fn attestation_with_status(&self, status: &str) -> String {
         self.attestation_full(
+            &self.issuer,
             ISSUER,
             &self.issuer.kid,
             SUBJECT,
@@ -228,6 +386,7 @@ impl TestSetup {
     #[allow(clippy::too_many_arguments)]
     fn attestation_full(
         &self,
+        issuer: &Issuer,
         iss: &str,
         kid: &str,
         sub: &str,
@@ -238,7 +397,7 @@ impl TestSetup {
         exp_offset: i64,
     ) -> String {
         let now = now_unix();
-        let header = json!({ "alg": "RS256", "kid": kid, "typ": "webank-attest+jws" });
+        let header = json!({ "alg": alg_name(issuer.alg), "kid": kid, "typ": "webank-attest+jws" });
         let claims = attestation_claims(
             iss,
             sub,
@@ -248,10 +407,7 @@ impl TestSetup {
             now + exp_offset,
             status,
         );
-        let encoding_key = self.issuer.encoding_key.clone();
-        build_raw_compact_jws(&header, &claims, |msg| {
-            crypto::sign(msg, &encoding_key, Algorithm::RS256).expect("sign test attestation")
-        })
+        build_raw_compact_jws(&header, &claims, |msg| issuer.sign(msg))
     }
 
     // ---- Request signatures ----
@@ -369,11 +525,31 @@ impl TestSetup {
             None,
             None,
         );
-        let encoding_key = key.encoding_key.clone();
-        let alg = key.alg;
-        build_raw_compact_jws(&header, &claims, |msg| {
-            crypto::sign(msg, &encoding_key, alg).expect("sign test request")
-        })
+        build_raw_compact_jws(&header, &claims, |msg| key.sign(msg))
+    }
+
+    /// A well-formed request signature for `key`, except that the signature segment is replaced
+    /// with `signature` rather than being produced by `key`'s private half.
+    pub fn signature_with_forged_bytes(
+        &self,
+        key: &KeyPair,
+        mth: &str,
+        pth: &str,
+        signature: [u8; 64],
+    ) -> String {
+        let header =
+            json!({ "alg": key.alg_name(), "typ": "webank-devsig+jws", "jwk": key.jwk_json });
+        let claims = signature_claims(
+            mth,
+            pth,
+            &self.next_jti(),
+            now_unix(),
+            now_unix() + 90,
+            AUD,
+            None,
+            None,
+        );
+        build_raw_compact_jws(&header, &claims, |_msg| b64url(&signature))
     }
 
     /// A request signature whose embedded `jwk` claims `"kty":"EC","crv":"Ed25519"` — a
@@ -450,11 +626,7 @@ impl TestSetup {
             query,
             body,
         );
-        let encoding_key = key.encoding_key.clone();
-        let alg = key.alg;
-        build_raw_compact_jws(&header, &claims, |msg| {
-            crypto::sign(msg, &encoding_key, alg).expect("sign test request")
-        })
+        build_raw_compact_jws(&header, &claims, |msg| key.sign(msg))
     }
 }
 


### PR DESCRIPTION
Refs #242.

## The defect, reproduced

`jsonwebtoken` 11.0.0's `rust_crypto` backend verifies EdDSA with `ed25519_dalek::Verifier::verify`, the **non-strict** verifier (`jsonwebtoken-11.0.0/src/crypto/rust_crypto/eddsa.rs`: `self.0.verify(msg, &Signature::from_slice(signature)?)`). Non-strict verification never asks whether the public key — or the signature's `R` — is a low-order point, so the triple `(A = identity, R = identity, S = 0)` satisfies `[S]B - [k]A == R` for **every** message. No private key exists for such a key.

In `authkestra-devsig` the verifying key is not trusted input: it travels in the request, inside `X-Signature`'s protected header as an embedded `jwk`. A low-order key thumbprints exactly like a real one, so an attacker who gets one enrolled passes the `cnf.jkt` binding check honestly and then needs no secret at all to sign.

I wrote the test first and ran it against unmodified `main` (`2731e04`), source untouched:

```
test low_order_ed25519_device_key_cannot_forge_a_signature ... FAILED

thread 'low_order_ed25519_device_key_cannot_forge_a_signature' panicked at
crates/authkestra-devsig/tests/eddsa_strict.rs:58:22:
a low-order Ed25519 public key has no private key behind it -- accepting a signature under it
means anyone can sign as this identity, which defeats the per-request proof-of-possession this
crate exists to provide (authkestra#242): DeviceIdentity { subject: "user-7f3a9c12",
device: "dev-8821bc04", key_thumbprint: "eV9frzBXPTP92MWWMpoFOh0WI_kJLvGlhcNs15APU_s",
attributes: Object {"kyc_level": Number(2), "roles": Array [String("customer")],
"status": String("active")} }
```

`verify()` returned `Ok(DeviceIdentity { .. })`. Every other check in the algorithm passed honestly — the attestation really is the issuer's, the embedded `jwk` really does thumbprint-match `cnf.jkt`, the claims really do bind the method/path/audience, the signature is fresh and unreplayed. Only the EdDSA check stood between that request and a full impersonation, and it waved it through. This is a complete authentication bypass.

The same run showed the issuer side is exposed the same way if a low-order key ever reaches the cached JWKS:

```
test low_order_ed25519_issuer_key_cannot_forge_an_attestation ... FAILED
... an attestation 'signed' by a low-order Ed25519 issuer key must be rejected -- accepting it
lets anyone who can influence the JWKS mint attestations for any subject:
DeviceIdentity { subject: "user-7f3a9c12", device: "dev-8821bc04", ... }
```

### One correction to the issue's wording

#242 says "an all-zero key with an all-zero signature verifies against **any** message". The all-zero encoding is low-order, but it is the order-4 point `y = 0`, and the equation only holds for it when the challenge scalar `k ≡ 3 (mod 4)` — roughly one message in four, so it is not a deterministic test vector. The **identity** encoding (`01 00 … 00`) is the universal one: both sides of the equation collapse to the identity whatever `k` is. The tests use that. The reasoning and the conclusion in the issue are otherwise exactly right.

## The fix

New `crates/authkestra-devsig/src/eddsa.rs`, used by both `signature.rs` and `attestation.rs`:

1. **`VerifyingKey::verify_strict`** replaces `jsonwebtoken::crypto::verify` on the EdDSA branch. This also rejects a low-order `R`.
2. **Low-order keys are rejected outright** via `is_weak()`, *before* verification is attempted — so the key is refused on its own merits, not depending on which signature bytes came with it. Surfaced as `bad_jwk`, not `bad_signature`: the key is the defect.

Either layer alone blocks acceptance; the second exists so the rejection is correctly classified and independent of the accompanying signature. Both were confirmed load-bearing by deleting them and re-running (see below).

Every non-EdDSA algorithm still delegates to `jsonwebtoken` unchanged — no RSA or ECDSA verification is reimplemented.

After:

```
running 32 tests
test canary_upstream_jsonwebtoken_still_verifies_eddsa_non_strictly ... ok
test case_01_valid_pair_is_accepted ... ok
...
test genuine_ed25519_device_key_is_still_accepted ... ok
test genuine_ed25519_device_key_with_a_tampered_body_is_rejected ... ok
test genuine_ed25519_device_key_with_a_wrong_signature_is_bad_signature ... ok
test low_order_ed25519_device_key_cannot_forge_a_signature ... ok
test low_order_ed25519_issuer_key_cannot_forge_an_attestation ... ok
test low_order_ed25519_device_key_is_rejected_regardless_of_signature_bytes ... ok

test result: ok. 32 passed; 0 failed; 0 ignored
```

No existing test was changed to accommodate this. The pre-existing conformance cases still pass as written; the only edits to `TestSetup` were adding `EdDSA` to `allowed_algs` and threading a signer through the builders so a "key" with no private half can be expressed.

### The decisive check

Neutering just the `is_weak()` branch (`if false && key.is_weak()`) and re-running:

```
test low_order_ed25519_device_key_cannot_forge_a_signature ... FAILED
  left: "bad_signature"
 right: "bad_jwk"
test low_order_ed25519_device_key_is_rejected_regardless_of_signature_bytes ... FAILED
```

Worth reading precisely: with the key check removed the forgery is still *rejected* (`verify_strict` catches the low-order `R`), but as `bad_signature`. Both layers are doing real work.

## Tests added

| test | what it pins |
| --- | --- |
| `low_order_ed25519_device_key_cannot_forge_a_signature` | the reported bypass, end to end through `verify()` |
| `low_order_ed25519_device_key_is_rejected_regardless_of_signature_bytes` | the key is rejected on its own merits, not by matching one canned forgery vector |
| `genuine_ed25519_device_key_is_still_accepted` | **positive control** — a real Ed25519 device key still verifies, body hash included |
| `genuine_ed25519_device_key_with_a_tampered_body_is_rejected` | the strict path still actually verifies |
| `genuine_ed25519_device_key_with_a_wrong_signature_is_bad_signature` | garbage bytes stay `bad_signature`, not reclassified |
| `low_order_ed25519_issuer_key_cannot_forge_an_attestation` | JWKS-ingest hardening |
| `canary_upstream_jsonwebtoken_still_verifies_eddsa_non_strictly` | **deliberate canary**: asserts the upstream behaviour being worked around. If `jsonwebtoken` ever adopts `verify_strict`, this fails and tells us the local path can be revisited, so the workaround cannot quietly outlive its reason. |

## Behaviour change

Signatures and attestations under low-order Ed25519 keys are **now rejected where they were previously accepted**. No honestly generated key is affected — a low-order point is not something a real Ed25519 keygen produces — and no public API changed.

I did **not** mark this `!`. No consumer API breaks, and the only traffic that stops being accepted is forged. But that is a release-semantics call for the maintainer, and `release-plz` derives the bump from this prefix: **say the word and I'll amend to `fix(devsig)!`** if you'd rather the version bump advertise the behaviour change.

## Dependency

`ed25519-dalek = "2"` becomes a direct dependency of `authkestra-devsig` (production), plus `features = ["pkcs8"]` in dev-dependencies for minting a real Ed25519 test key. It adds **nothing** to the graph — `jsonwebtoken`'s `rust_crypto` backend, already enabled, resolves the same 2.2.0. The whole `Cargo.lock` diff is one line:

```
 crates/authkestra-devsig v0.5.5
 dependencies = [
   "async-trait",
   "base64 0.22.1",
+  "ed25519-dalek",
```

`cargo deny check licenses bans` → `bans ok, licenses ok`.

## Not covered here — needs a follow-up

`authkestra-resource`'s JWT path goes through the same non-strict backend. I agree with the issue that it is **mostly theoretical**: the verifying key there is resolved from a trusted OP JWKS the attacker cannot influence, and unlike devsig there is no enrolment channel through which an attacker submits a key of their choosing. The realistic prerequisite is a compromised or hostile OP, at which point strict verification is not the thing protecting you. It should still be hardened for the same defence-in-depth reason the attestation path was, but `crates/authkestra-resource/src/jwt.rs` has two PRs in flight right now, so I have deliberately **not** touched it.

For that reason there is **no auto-closing keyword** on #242 — leave it open until `authkestra-resource` is hardened too, or split that half into its own issue.

## Verification

```
cargo fmt --all -- --check                                                             # clean
cargo +1.98.0 clippy -p authkestra-devsig --all-targets --all-features -- -D warnings  # clean
cargo test -p authkestra-devsig --all-features                                         # 32 passed, 0 failed
cargo deny check licenses bans                                                         # ok
```

Scoped to `authkestra-devsig`, the only crate touched. No public API of the crate changed, so the `devsig` features in `authkestra-axum`/`authkestra-actix` are unaffected; workspace-wide CI covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
