### PR TITLE
feat(resource): resolve JWKS per issuer for multi-issuer resource servers

### DIFF
--- a/crates/authkestra-oidc/src/error.rs
+++ b/crates/authkestra-oidc/src/error.rs
@@ -66,6 +66,18 @@ impl From<authkestra_resource::jwt::ValidationError> for OidcError {
             authkestra_resource::jwt::ValidationError::MissingKid => {
                 OidcError::ValidationError("Token is missing a required 'kid' header".to_string())
             }
+            // Multi-issuer resolution (#243). Both are validation failures from
+            // an RP's point of view: the token names an issuer this verifier
+            // holds no JWKS for, or names none at all so no JWKS can be picked.
+            authkestra_resource::jwt::ValidationError::UntrustedIssuer(issuer) => {
+                OidcError::ValidationError(format!(
+                    "Token issuer {issuer:?} is not in the configured trust map"
+                ))
+            }
+            authkestra_resource::jwt::ValidationError::MissingIssuer => OidcError::ValidationError(
+                "Token is missing a required 'iss' claim; an issuer is needed to select a JWKS"
+                    .to_string(),
+            ),
             authkestra_resource::jwt::ValidationError::Paseto(e) => OidcError::ValidationError(e),
             authkestra_resource::jwt::ValidationError::Validation(e) => {
                 OidcError::ValidationError(e)

--- a/crates/authkestra-resource/README.md
+++ b/crates/authkestra-resource/README.md
@@ -44,6 +44,30 @@ let config = ValidationConfig::builder()
 let strategy = JwtStrategy::new(config);
 ```
 
+### Trusting several issuers
+
+One verifier can accept tokens from several issuers, each with its own JWKS
+endpoint. The token's `iss` claim selects which JWKS verifies it:
+
+```rust
+use authkestra_resource::jwt::{JwtStrategy, ValidationConfig};
+
+let config = ValidationConfig::builder()
+    .trusted_issuer("https://tenant-a.example", "https://tenant-a.example/.well-known/jwks.json")
+    .trusted_issuer("https://tenant-b.example", "https://tenant-b.example/.well-known/jwks.json")
+    .audience("my-app")
+    .build();
+
+let strategy = JwtStrategy::new(config);
+```
+
+An `iss` that is not in the trust map is rejected: there is deliberately no
+fallback endpoint, because a default JWKS for unknown issuers is issuer
+confusion. A token with no `iss` at all is rejected too, since nothing names a
+key. For issuers that are only known at runtime, implement `JwksResolver` and
+pass it to `JwtStrategy::with_resolver` — the same rule applies, an
+implementation must reject issuers it does not recognise.
+
 ## Related Crates
 
 - `authkestra-engine`: Foundational types and the Engine orchestrator.

--- a/crates/authkestra-resource/src/jwt.rs
+++ b/crates/authkestra-resource/src/jwt.rs
@@ -458,7 +458,7 @@ impl<I> JwtStrategy<I> {
         let resolver = build_resolver(&config);
         Self {
             resolver,
-            validation: build_validation(&config),
+            validation: build_validation(&config, !config.trusted_issuers.is_empty()),
             require_cert_binding: config.require_cert_binding,
             _marker: std::marker::PhantomData,
         }
@@ -477,7 +477,9 @@ impl<I> JwtStrategy<I> {
     pub fn with_resolver(config: ValidationConfig, resolver: Box<dyn JwksResolver>) -> Self {
         Self {
             resolver,
-            validation: build_validation(&config),
+            // Unconditionally multi-issuer: supplying your own resolver *is* the
+            // multi-issuer case, whether or not a static trust map accompanies it.
+            validation: build_validation(&config, true),
             require_cert_binding: config.require_cert_binding,
             _marker: std::marker::PhantomData,
         }
@@ -532,7 +534,7 @@ fn build_resolver(config: &ValidationConfig) -> Box<dyn JwksResolver> {
 }
 
 /// Builds the claim-validation half of a [`JwtStrategy`] from a config.
-fn build_validation(config: &ValidationConfig) -> Validation {
+fn build_validation(config: &ValidationConfig, multi_issuer: bool) -> Validation {
     let mut validation = Validation::new(config.algorithms[0]);
     validation.algorithms = config.algorithms.clone();
 
@@ -552,11 +554,17 @@ fn build_validation(config: &ValidationConfig) -> Validation {
         validation.set_issuer(&accepted_issuers);
     }
 
-    if !config.trusted_issuers.is_empty() {
+    if multi_issuer {
         // In multi-issuer mode `iss` selects the key, so a token without one must
         // never reach the decode step. The resolver already refuses it; requiring
         // the claim here means a custom resolver that is laxer than it should be
         // still cannot let an `iss`-less token through.
+        //
+        // Gated on `multi_issuer` rather than on `trusted_issuers` being
+        // non-empty: a `with_resolver` caller resolves issuers dynamically and so
+        // configures no trust map at all, which is exactly the case this backstop
+        // was written for. Inferring it from the map left that path with neither
+        // `set_issuer` nor this check -- raised in review of #254.
         validation.required_spec_claims.insert("iss".to_string());
     }
 

--- a/crates/authkestra-resource/src/jwt.rs
+++ b/crates/authkestra-resource/src/jwt.rs
@@ -7,9 +7,12 @@ use authkestra_engine::{
         Claims,
     },
 };
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use http::request::Parts;
 use jsonwebtoken::{decode, decode_header, Algorithm, Validation};
 use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use thiserror::Error;
 use tokio::sync::RwLock;
@@ -31,6 +34,12 @@ pub enum ValidationError {
         "Token is missing a 'kid' header, which is required by this JWKS cache's strict validation policy"
     )]
     MissingKid,
+    #[error("Token issuer {0:?} is not in the configured trust map; no JWKS is trusted for it")]
+    UntrustedIssuer(String),
+    #[error(
+        "Token carries no string 'iss' claim, which is required to resolve a signing key when more than one issuer is trusted"
+    )]
+    MissingIssuer,
     #[error("PASETO error: {0}")]
     Paseto(String),
     #[error("Discovery error: {0}")]
@@ -125,6 +134,126 @@ impl JwksCache {
     }
 }
 
+/// Resolves *which* JWKS a token must be verified against, from the token's own
+/// `iss` claim.
+///
+/// This is the seam that lets one resource server trust several issuers (issue
+/// #243). `JwtStrategy` uses a built-in implementation for the two configured
+/// shapes — [`SingleJwksResolver`] for the classic one-issuer/one-JWKS setup and
+/// [`IssuerTrustMap`] for a fixed set of issuers — and
+/// [`JwtStrategy::with_resolver`] accepts any other implementation, which is
+/// what issuers discovered at runtime (per-tenant, from a registry) need.
+///
+/// # Security contract for implementors
+///
+/// An implementation MUST return an error for an issuer it does not recognise.
+/// It must **never** fall back to some default JWKS for an unknown `iss`: that
+/// turns multi-issuer support into issuer confusion, because any issuer whose
+/// keys the fallback endpoint publishes could then mint tokens claiming to come
+/// from any other issuer.
+///
+/// Returning `Arc<JwksCache>` rather than a borrow is deliberate: a dynamic
+/// resolver needs to hand out caches it created and stored behind its own lock,
+/// which it cannot do by reference.
+#[async_trait]
+pub trait JwksResolver: Send + Sync {
+    /// Resolve the JWKS cache for `issuer`, the token's *not yet verified* `iss`
+    /// claim (`None` when the token carries no usable string `iss`).
+    async fn resolve(&self, issuer: Option<&str>) -> Result<Arc<JwksCache>, ValidationError>;
+}
+
+/// A [`JwksResolver`] that always resolves to a single JWKS, whatever the token
+/// claims as its `iss`.
+///
+/// This is the pre-#243 behaviour and what `JwtStrategy::new` uses when no trust
+/// map is configured: enforcing `iss` (if configured at all) is left entirely to
+/// `Validation::set_issuer`, exactly as before. It is only safe *because* there
+/// is one endpoint and therefore nothing to confuse — do not reuse it as the
+/// default arm of a multi-issuer resolver.
+pub struct SingleJwksResolver {
+    cache: Arc<JwksCache>,
+}
+
+impl SingleJwksResolver {
+    /// Wrap an existing cache as a resolver.
+    pub fn new(cache: Arc<JwksCache>) -> Self {
+        Self { cache }
+    }
+}
+
+#[async_trait]
+impl JwksResolver for SingleJwksResolver {
+    async fn resolve(&self, _issuer: Option<&str>) -> Result<Arc<JwksCache>, ValidationError> {
+        Ok(self.cache.clone())
+    }
+}
+
+/// A fixed trust map of `iss` -> [`JwksCache`], for a resource server that
+/// accepts tokens from a known set of issuers.
+///
+/// Lookup is exact-match on the `iss` string and has **no default arm**: an
+/// unknown issuer yields [`ValidationError::UntrustedIssuer`] and a token with
+/// no `iss` yields [`ValidationError::MissingIssuer`]. Each issuer keeps its own
+/// cache, so JWKS fetching, TTL and rotation-triggered refresh stay per-endpoint
+/// while remaining managed by this crate rather than duplicated by the caller.
+///
+/// A `BTreeMap` (rather than a `HashMap`) is used so the derived accepted-issuer
+/// list handed to `Validation::set_issuer` — and anything logged from it — has a
+/// stable order, which keeps failures reproducible.
+#[derive(Default)]
+pub struct IssuerTrustMap {
+    caches: BTreeMap<String, Arc<JwksCache>>,
+}
+
+impl IssuerTrustMap {
+    /// Create an empty trust map. An empty map trusts nobody and rejects every
+    /// token.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Trust `issuer`, verifying its tokens against `cache`.
+    pub fn with_issuer(mut self, issuer: impl Into<String>, cache: Arc<JwksCache>) -> Self {
+        self.caches.insert(issuer.into(), cache);
+        self
+    }
+
+    /// The issuers this map trusts, in sorted order.
+    pub fn issuers(&self) -> impl Iterator<Item = &str> {
+        self.caches.keys().map(String::as_str)
+    }
+}
+
+impl FromIterator<(String, Arc<JwksCache>)> for IssuerTrustMap {
+    fn from_iter<T: IntoIterator<Item = (String, Arc<JwksCache>)>>(iter: T) -> Self {
+        Self {
+            caches: iter.into_iter().collect(),
+        }
+    }
+}
+
+#[async_trait]
+impl JwksResolver for IssuerTrustMap {
+    async fn resolve(&self, issuer: Option<&str>) -> Result<Arc<JwksCache>, ValidationError> {
+        let Some(issuer) = issuer else {
+            tracing::warn!("rejecting token with no 'iss' claim: cannot select a signing key");
+            return Err(ValidationError::MissingIssuer);
+        };
+
+        match self.caches.get(issuer) {
+            Some(cache) => {
+                tracing::debug!(issuer, "resolved JWKS for token issuer");
+                Ok(cache.clone())
+            }
+            None => {
+                // Deliberately no fallback: see the `JwksResolver` security contract.
+                tracing::warn!(issuer, "rejecting token from an issuer that is not trusted");
+                Err(ValidationError::UntrustedIssuer(issuer.to_string()))
+            }
+        }
+    }
+}
+
 /// A builder for configuring offline JWT validation.
 /// Configuration for JWT validation.
 pub struct ValidationConfig {
@@ -143,6 +272,12 @@ pub struct ValidationConfig {
     /// bearer token, same as before this option existed. See
     /// [`JwtStrategy`] and issue #224.
     pub require_cert_binding: bool,
+    /// Trust map of `iss` -> JWKS endpoint, for a resource server that accepts
+    /// tokens from several issuers. Empty by default, which keeps the
+    /// single-issuer `jwks_url` path unchanged. When non-empty, an `iss` absent
+    /// from this map is rejected outright and never falls back to `jwks_url`.
+    /// See [`IssuerTrustMap`] and issue #243.
+    pub trusted_issuers: BTreeMap<String, String>,
 }
 
 impl ValidationConfig {
@@ -162,10 +297,15 @@ pub struct ValidationConfigBuilder {
     algorithms: Vec<Algorithm>,
     require_kid: bool,
     require_cert_binding: bool,
+    trusted_issuers: BTreeMap<String, String>,
 }
 
 impl ValidationConfigBuilder {
     /// Set the JWKS URL.
+    ///
+    /// Required unless at least one [`trusted_issuer`](Self::trusted_issuer) is
+    /// configured, in which case each issuer brings its own endpoint and this
+    /// one applies only to the issuer named by [`issuer`](Self::issuer).
     pub fn jwks_url(mut self, jwks_url: impl Into<String>) -> Self {
         self.jwks_url = Some(jwks_url.into());
         self
@@ -177,9 +317,46 @@ impl ValidationConfigBuilder {
         self
     }
 
-    /// Set the expected issuer.
+    /// Set the expected issuer for the single JWKS set with
+    /// [`jwks_url`](Self::jwks_url).
+    ///
+    /// This is the one-issuer form and is unchanged. Combined with
+    /// [`trusted_issuer`](Self::trusted_issuer) entries it simply becomes one
+    /// more entry of the trust map (`issuer` -> `jwks_url`).
     pub fn issuer(mut self, issuer: impl Into<String>) -> Self {
         self.issuer = Some(issuer.into());
+        self
+    }
+
+    /// Trust `issuer` and verify its tokens against the JWKS published at
+    /// `jwks_url`. May be called several times to trust several issuers; a
+    /// repeated issuer replaces its previous endpoint.
+    ///
+    /// Once any entry is present the verifier is in multi-issuer mode: the
+    /// token's `iss` claim selects the JWKS, an `iss` outside this map is
+    /// rejected with [`ValidationError::UntrustedIssuer`], and a token with no
+    /// `iss` at all is rejected with [`ValidationError::MissingIssuer`]. There
+    /// is deliberately no fallback endpoint — see [`JwksResolver`].
+    pub fn trusted_issuer(
+        mut self,
+        issuer: impl Into<String>,
+        jwks_url: impl Into<String>,
+    ) -> Self {
+        self.trusted_issuers.insert(issuer.into(), jwks_url.into());
+        self
+    }
+
+    /// Trust several `(issuer, jwks_url)` pairs at once. Equivalent to calling
+    /// [`trusted_issuer`](Self::trusted_issuer) for each pair.
+    pub fn trusted_issuers(
+        mut self,
+        entries: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) -> Self {
+        self.trusted_issuers.extend(
+            entries
+                .into_iter()
+                .map(|(issuer, url)| (issuer.into(), url.into())),
+        );
         self
     }
 
@@ -221,11 +398,28 @@ impl ValidationConfigBuilder {
     }
 
     /// Build a `ValidationConfig`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if neither a [`jwks_url`](Self::jwks_url) nor any
+    /// [`trusted_issuer`](Self::trusted_issuer) was set, since there would then
+    /// be no key material at all. A trust-map-only config leaves `jwks_url`
+    /// empty; an empty `jwks_url` is never fetched from, it just means "no
+    /// single-issuer endpoint".
     pub fn build(self) -> ValidationConfig {
+        let jwks_url = match self.jwks_url {
+            Some(jwks_url) => jwks_url,
+            None => {
+                assert!(
+                    !self.trusted_issuers.is_empty(),
+                    "JWKS URL must be set for ValidationConfig (or at least one trusted_issuer)"
+                );
+                String::new()
+            }
+        };
+
         ValidationConfig {
-            jwks_url: self
-                .jwks_url
-                .expect("JWKS URL must be set for ValidationConfig"),
+            jwks_url,
             refresh_interval: self
                 .refresh_interval
                 .unwrap_or_else(|| Duration::from_secs(3600)),
@@ -238,13 +432,14 @@ impl ValidationConfigBuilder {
             },
             require_kid: self.require_kid,
             require_cert_binding: self.require_cert_binding,
+            trusted_issuers: self.trusted_issuers,
         }
     }
 }
 
 /// A JWT authentication strategy that performs offline JWT validation using JWKS.
 pub struct JwtStrategy<I> {
-    cache: JwksCache,
+    resolver: Box<dyn JwksResolver>,
     validation: Validation,
     require_cert_binding: bool,
     _marker: std::marker::PhantomData<I>,
@@ -252,27 +447,124 @@ pub struct JwtStrategy<I> {
 
 impl<I> JwtStrategy<I> {
     /// Create a new `JwtStrategy` with the given `ValidationConfig`.
+    ///
+    /// With an empty [`ValidationConfig::trusted_issuers`] this is the classic
+    /// single-issuer verifier and behaves exactly as it did before #243: one
+    /// JWKS at `jwks_url`, and `iss` checked only if `issuer` was set.
+    ///
+    /// With a non-empty trust map it becomes a multi-issuer verifier — see
+    /// [`ValidationConfigBuilder::trusted_issuer`].
     pub fn new(config: ValidationConfig) -> Self {
-        let cache = JwksCache::new(config.jwks_url, config.refresh_interval)
-            .require_kid(config.require_kid);
-        let mut validation = Validation::new(config.algorithms[0]);
-        validation.algorithms = config.algorithms;
-
-        if let Some(iss) = config.issuer {
-            validation.set_issuer(&[iss]);
-        }
-
-        if !config.audience.is_empty() {
-            validation.set_audience(&config.audience);
-        }
-
+        let resolver = build_resolver(&config);
         Self {
-            cache,
-            validation,
+            resolver,
+            validation: build_validation(&config),
             require_cert_binding: config.require_cert_binding,
             _marker: std::marker::PhantomData,
         }
     }
+
+    /// Create a `JwtStrategy` that resolves signing keys through a
+    /// caller-supplied [`JwksResolver`], for issuers that are not known up front
+    /// (per-tenant, fetched from a registry, ...).
+    ///
+    /// `config`'s `jwks_url` and `trusted_issuers` are ignored — the resolver
+    /// owns key resolution entirely — but the rest of the config still applies,
+    /// including the accepted-`iss` set fed to `Validation`. Note that if
+    /// `config` names no issuers at all, `iss` is not checked by `Validation`
+    /// and the resolver alone is the trust decision, so it must reject unknown
+    /// issuers rather than defaulting.
+    pub fn with_resolver(config: ValidationConfig, resolver: Box<dyn JwksResolver>) -> Self {
+        Self {
+            resolver,
+            validation: build_validation(&config),
+            require_cert_binding: config.require_cert_binding,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+/// Builds the key-resolution half of a [`JwtStrategy`] from a config.
+///
+/// The two shapes are kept apart on purpose: with no trust map the resolver is
+/// the identity-like [`SingleJwksResolver`], so the pre-#243 path keeps byte-for-byte
+/// the same behaviour (including "no `iss` configured" meaning "`iss` not checked").
+fn build_resolver(config: &ValidationConfig) -> Box<dyn JwksResolver> {
+    let cache_for = |jwks_url: &str| {
+        Arc::new(
+            JwksCache::new(jwks_url.to_string(), config.refresh_interval)
+                .require_kid(config.require_kid),
+        )
+    };
+
+    if config.trusted_issuers.is_empty() {
+        return Box::new(SingleJwksResolver::new(cache_for(&config.jwks_url)));
+    }
+
+    let mut caches: BTreeMap<String, Arc<JwksCache>> = config
+        .trusted_issuers
+        .iter()
+        .map(|(issuer, jwks_url)| (issuer.clone(), cache_for(jwks_url)))
+        .collect();
+
+    // The single-issuer pair is folded in as one more trust-map entry, which is
+    // what makes `issuer` + `jwks_url` "the one-entry case" rather than a second,
+    // parallel mechanism. Without an `issuer` to name it, a `jwks_url` cannot be
+    // folded in at all: using it as a default arm is exactly the issuer confusion
+    // the trust map exists to prevent, so it is dropped loudly instead.
+    match &config.issuer {
+        Some(issuer) if !config.jwks_url.is_empty() => {
+            caches
+                .entry(issuer.clone())
+                .or_insert_with(|| cache_for(&config.jwks_url));
+        }
+        None if !config.jwks_url.is_empty() => {
+            tracing::warn!(
+                jwks_url = %config.jwks_url,
+                "ignoring jwks_url: with a trusted_issuers map configured and no issuer naming it, \
+                 it could only act as a fallback for untrusted issuers, which is never allowed"
+            );
+        }
+        _ => {}
+    }
+
+    Box::new(caches.into_iter().collect::<IssuerTrustMap>())
+}
+
+/// Builds the claim-validation half of a [`JwtStrategy`] from a config.
+fn build_validation(config: &ValidationConfig) -> Validation {
+    let mut validation = Validation::new(config.algorithms[0]);
+    validation.algorithms = config.algorithms.clone();
+
+    // `set_issuer` has always taken a slice; the pre-#243 config simply had no
+    // way to express more than one name. Every trusted issuer goes in, so a
+    // token verified with issuer B's key still has to *say* it came from B.
+    let mut accepted_issuers: Vec<&String> = config.trusted_issuers.keys().collect();
+    if let Some(issuer) = config
+        .issuer
+        .as_ref()
+        .filter(|issuer| !config.trusted_issuers.contains_key(*issuer))
+    {
+        accepted_issuers.push(issuer);
+    }
+
+    if !accepted_issuers.is_empty() {
+        validation.set_issuer(&accepted_issuers);
+    }
+
+    if !config.trusted_issuers.is_empty() {
+        // In multi-issuer mode `iss` selects the key, so a token without one must
+        // never reach the decode step. The resolver already refuses it; requiring
+        // the claim here means a custom resolver that is laxer than it should be
+        // still cannot let an `iss`-less token through.
+        validation.required_spec_claims.insert("iss".to_string());
+    }
+
+    if !config.audience.is_empty() {
+        validation.set_audience(&config.audience);
+    }
+
+    validation
 }
 
 #[async_trait]
@@ -282,7 +574,22 @@ where
 {
     async fn authenticate(&self, parts: &Parts) -> Result<Option<I>, AuthError> {
         if let Some(token) = utils::extract_bearer_token(&parts.headers) {
-            match validate_jwt_generic::<I>(token, &self.cache, &self.validation).await {
+            // Resolve once and reuse the same cache below: which JWKS applies is
+            // a property of the token, so re-resolving for the `cnf` re-decode
+            // could only introduce a discrepancy.
+            let cache = match resolve_cache(token, self.resolver.as_ref()).await {
+                Ok(cache) => cache,
+                Err(e @ (ValidationError::InvalidToken(_) | ValidationError::Jwt(_))) => {
+                    tracing::debug!(error = %e, "could not read the token's issuer; no identity");
+                    return Ok(None);
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "could not resolve a JWKS for the token's issuer; rejecting token");
+                    return Err(AuthError::Token(e.to_string()));
+                }
+            };
+
+            match validate_jwt_generic::<I>(token, &cache, &self.validation).await {
                 Ok(claims) => {
                     if self.require_cert_binding {
                         // Re-decode as `CnfClaim` to read `cnf.x5t#S256`
@@ -297,7 +604,7 @@ where
                         // other verification failure: reject.
                         let cnf_claim = match validate_jwt_generic::<CnfClaim>(
                             token,
-                            &self.cache,
+                            &cache,
                             &self.validation,
                         )
                         .await
@@ -374,6 +681,73 @@ pub fn verify_cert_binding(
         )),
         (_, None) => Ok(()),
     }
+}
+
+/// Reads the `iss` claim out of a JWT payload **without verifying the
+/// signature**, returning `None` if there is no `iss` or it is not a string.
+///
+/// Only ever used to *select* which key to verify with, never to make a trust
+/// decision on its own. That is safe because the value is re-checked after
+/// verification: the payload this reads is the same signature-covered payload
+/// `decode` parses, and `Validation`'s accepted-issuer set (populated from the
+/// trust map by [`build_validation`]) rejects the token if its `iss` is not one
+/// of the trusted names. So an attacker choosing `iss` only chooses which
+/// issuer's key their signature must satisfy.
+///
+/// The payload is decoded by hand rather than via `jsonwebtoken`'s
+/// signature-disabled decode path, which would need a dummy key and a second
+/// `Validation` whose knobs could drift from the real one.
+fn unverified_issuer(token: &str) -> Result<Option<String>, ValidationError> {
+    let mut segments = token.split('.');
+    let payload = match (segments.next(), segments.next(), segments.next()) {
+        (Some(_), Some(payload), Some(_)) => payload,
+        _ => {
+            return Err(ValidationError::InvalidToken(
+                "token is not a well-formed JWS compact serialization".to_string(),
+            ))
+        }
+    };
+
+    let payload = URL_SAFE_NO_PAD.decode(payload).map_err(|e| {
+        ValidationError::InvalidToken(format!("token payload is not valid base64url: {e}"))
+    })?;
+    let claims: serde_json::Value = serde_json::from_slice(&payload).map_err(|e| {
+        ValidationError::InvalidToken(format!("token payload is not a JSON object: {e}"))
+    })?;
+
+    Ok(claims
+        .get("iss")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string))
+}
+
+/// Resolves the JWKS cache a token must be verified against, from its own `iss`.
+async fn resolve_cache(
+    token: &str,
+    resolver: &dyn JwksResolver,
+) -> Result<Arc<JwksCache>, ValidationError> {
+    let issuer = unverified_issuer(token)?;
+    resolver.resolve(issuer.as_deref()).await
+}
+
+/// Validates a JWT, resolving the JWKS to verify it against from the token's
+/// `iss` claim via `resolver`.
+///
+/// This is the multi-issuer counterpart of [`validate_jwt_generic`], for callers
+/// that verify tokens outside a [`JwtStrategy`]. `validation` must still carry
+/// the accepted-issuer set (see [`ValidationConfigBuilder::trusted_issuer`]):
+/// the resolver decides *which key*, `validation` decides *which names are
+/// acceptable*, and both must agree for a token to be accepted.
+pub async fn validate_jwt_with_resolver<T>(
+    token: &str,
+    resolver: &dyn JwksResolver,
+    validation: &Validation,
+) -> Result<T, ValidationError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let cache = resolve_cache(token, resolver).await?;
+    validate_jwt_generic::<T>(token, &cache, validation).await
 }
 
 /// Validates a JWT against the cached JWKS.
@@ -478,5 +852,70 @@ mod tests {
         let cnf = serde_json::json!({ "jkt": "some-other-thumbprint" });
         assert!(verify_cert_binding(None, Some(&cnf)).is_ok());
         assert!(verify_cert_binding(Some(b"cert"), Some(&cnf)).is_ok());
+    }
+
+    /// Builds a JWS-shaped string with an arbitrary (unsigned) payload — enough
+    /// for the pre-verification `iss` read, which never looks at the signature.
+    fn token_with_payload(payload: serde_json::Value) -> String {
+        format!(
+            "{}.{}.{}",
+            URL_SAFE_NO_PAD.encode(br#"{"alg":"RS256"}"#),
+            URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap()),
+            URL_SAFE_NO_PAD.encode(b"not-a-real-signature"),
+        )
+    }
+
+    #[test]
+    fn reads_the_issuer_out_of_an_unverified_payload() {
+        let token =
+            token_with_payload(serde_json::json!({ "iss": "https://a.example", "sub": "u" }));
+        assert_eq!(
+            unverified_issuer(&token).unwrap().as_deref(),
+            Some("https://a.example")
+        );
+    }
+
+    #[test]
+    fn reports_no_issuer_when_the_claim_is_absent_or_not_a_string() {
+        let no_iss = token_with_payload(serde_json::json!({ "sub": "u" }));
+        assert_eq!(unverified_issuer(&no_iss).unwrap(), None);
+
+        // RFC 7519 `iss` is a StringOrURI. `jsonwebtoken` tolerates an array
+        // here, but an array names no single key to verify with, so it is
+        // treated as "no issuer" and rejected by the resolver rather than
+        // silently resolving to one of its members.
+        let array_iss = token_with_payload(serde_json::json!({ "iss": ["a", "b"] }));
+        assert_eq!(unverified_issuer(&array_iss).unwrap(), None);
+    }
+
+    #[test]
+    fn rejects_a_token_that_is_not_a_well_formed_jws() {
+        assert!(matches!(
+            unverified_issuer("not.a-jwt"),
+            Err(ValidationError::InvalidToken(_))
+        ));
+        assert!(matches!(
+            unverified_issuer("aaa.!!!not-base64!!!.ccc"),
+            Err(ValidationError::InvalidToken(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn trust_map_rejects_unknown_and_missing_issuers_without_falling_back() {
+        let known = Arc::new(JwksCache::new(
+            "https://a.example/jwks.json".to_string(),
+            Duration::from_secs(60),
+        ));
+        let map = IssuerTrustMap::new().with_issuer("https://a.example", known);
+
+        assert!(map.resolve(Some("https://a.example")).await.is_ok());
+        assert!(matches!(
+            map.resolve(Some("https://evil.example")).await,
+            Err(ValidationError::UntrustedIssuer(iss)) if iss == "https://evil.example"
+        ));
+        assert!(matches!(
+            map.resolve(None).await,
+            Err(ValidationError::MissingIssuer)
+        ));
     }
 }

--- a/crates/authkestra-resource/tests/jwt_test.rs
+++ b/crates/authkestra-resource/tests/jwt_test.rs
@@ -2,6 +2,7 @@
 //! - multi-value audience support on `ValidationConfig` / `ValidationConfigBuilder`
 //! - backward compatibility of the single-value `.audience(...)` builder method
 //! - opt-in strict `kid` enforcement on `JwksCache`
+//! - per-issuer JWKS resolution for a multi-issuer resource server (issue #243)
 //!
 //! JWKS is served via a local `wiremock` server and tokens are signed with
 //! freshly generated RSA keys so the full offline-validation path (JWKS fetch,
@@ -11,15 +12,17 @@ use authkestra_engine::strategy::AuthenticationStrategy;
 use authkestra_engine::token::cert_binding::{x5t_s256_thumbprint, ClientCertificateDer};
 use authkestra_engine::token::jwk::Jwk;
 use authkestra_resource::jwt::{
-    validate_jwt_generic, JwksCache, JwtStrategy, ValidationConfig, ValidationError,
+    validate_jwt_generic, validate_jwt_with_resolver, IssuerTrustMap, JwksCache, JwtStrategy,
+    ValidationConfig, ValidationError,
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use http::{header::AUTHORIZATION, Request};
-use jsonwebtoken::{encode, Algorithm, EncodingKey, Header, Validation};
+use jsonwebtoken::{encode, errors::ErrorKind, Algorithm, EncodingKey, Header, Validation};
 use rsa::pkcs8::{EncodePrivateKey, LineEnding};
 use rsa::traits::PublicKeyParts;
 use rsa::RsaPrivateKey;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -482,4 +485,352 @@ async fn cert_binding_is_not_enforced_when_require_cert_binding_is_false() {
             "without require_cert_binding, a certificate-bound token is still a valid bearer token",
         );
     assert_eq!(result.sub, "service-a");
+}
+
+// --- Multi-issuer JWKS resolution (issue #243) ---------------------------
+//
+// A single resource verifier trusting several issuers at once. The security
+// property under test is that the token's `iss` selects *which* JWKS verifies
+// it, with no default arm: an `iss` outside the trust map is rejected rather
+// than falling through to some other issuer's keys.
+
+const ISS_A: &str = "https://issuer-a.example";
+const ISS_B: &str = "https://issuer-b.example";
+const ISS_UNTRUSTED: &str = "https://issuer-c.example";
+
+/// Claims carrying an `iss`, kept separate from `TestClaims` so the
+/// single-issuer tests above stay exactly as they were.
+#[derive(Debug, Serialize, Deserialize)]
+struct IssuedClaims {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    iss: Option<String>,
+    sub: String,
+    exp: usize,
+}
+
+fn issued_claims(iss: Option<&str>, sub: &str) -> IssuedClaims {
+    IssuedClaims {
+        iss: iss.map(|s| s.to_string()),
+        sub: sub.to_string(),
+        exp: future_exp(),
+    }
+}
+
+fn cache_for(server: &MockServer) -> Arc<JwksCache> {
+    Arc::new(JwksCache::new(jwks_url(server), Duration::from_secs(3600)))
+}
+
+/// A `Validation` matching what `JwtStrategy` derives for a trust map, for the
+/// tests that exercise `validate_jwt_with_resolver` directly.
+fn multi_issuer_validation(accepted: &[&str]) -> Validation {
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.set_issuer(accepted);
+    validation.required_spec_claims.insert("iss".to_string());
+    validation.validate_aud = false;
+    validation
+}
+
+#[tokio::test]
+async fn multi_issuer_verifies_each_token_against_its_own_issuers_jwks() {
+    let key_a = generate_rsa_key(Some("a-key"));
+    let key_b = generate_rsa_key(Some("b-key"));
+    let server_a = start_jwks_server(vec![key_a.jwk.clone()]).await;
+    let server_b = start_jwks_server(vec![key_b.jwk.clone()]).await;
+
+    let config = ValidationConfig::builder()
+        .trusted_issuer(ISS_A, jwks_url(&server_a))
+        .trusted_issuer(ISS_B, jwks_url(&server_b))
+        .build();
+    assert_eq!(config.trusted_issuers.len(), 2);
+    let strategy: JwtStrategy<IssuedClaims> = JwtStrategy::new(config);
+
+    for (iss, key, kid) in [
+        (ISS_A, &key_a, "a-key"),
+        // The point of the test: issuer B's token is verified with keys fetched
+        // from B's endpoint, which A's JWKS does not contain.
+        (ISS_B, &key_b, "b-key"),
+    ] {
+        let token = sign_token(
+            &key.encoding_key,
+            Some(kid),
+            &issued_claims(Some(iss), "user-1"),
+        );
+        let identity = strategy
+            .authenticate(&bearer_request_parts(&token, None))
+            .await
+            .unwrap_or_else(|e| panic!("authenticate should not error for {iss}: {e}"))
+            .unwrap_or_else(|| panic!("a valid token from trusted issuer {iss} must be accepted"));
+        assert_eq!(identity.iss.as_deref(), Some(iss));
+    }
+}
+
+#[tokio::test]
+async fn multi_issuer_rejects_a_token_whose_issuer_is_not_in_the_trust_map() {
+    let key_a = generate_rsa_key(Some("a-key"));
+    let key_b = generate_rsa_key(Some("b-key"));
+    let server_a = start_jwks_server(vec![key_a.jwk.clone()]).await;
+    let server_b = start_jwks_server(vec![key_b.jwk.clone()]).await;
+
+    // Signed by a key that IS published on a trusted endpoint, so the only
+    // reason to reject is the issuer name itself.
+    let token = sign_token(
+        &key_a.encoding_key,
+        Some("a-key"),
+        &issued_claims(Some(ISS_UNTRUSTED), "user-1"),
+    );
+
+    let trust_map = IssuerTrustMap::new()
+        .with_issuer(ISS_A, cache_for(&server_a))
+        .with_issuer(ISS_B, cache_for(&server_b));
+
+    // Rejected *for being untrusted*, not incidentally by signature or audience.
+    let err = validate_jwt_with_resolver::<IssuedClaims>(
+        &token,
+        &trust_map,
+        &multi_issuer_validation(&[ISS_A, ISS_B]),
+    )
+    .await
+    .expect_err("a token from an issuer outside the trust map must be rejected");
+    assert!(
+        matches!(&err, ValidationError::UntrustedIssuer(iss) if iss == ISS_UNTRUSTED),
+        "expected UntrustedIssuer({ISS_UNTRUSTED}), got {err:?}"
+    );
+
+    // And the same through the strategy, which must not silently accept it.
+    let config = ValidationConfig::builder()
+        .trusted_issuer(ISS_A, jwks_url(&server_a))
+        .trusted_issuer(ISS_B, jwks_url(&server_b))
+        .build();
+    let strategy: JwtStrategy<IssuedClaims> = JwtStrategy::new(config);
+    let err = strategy
+        .authenticate(&bearer_request_parts(&token, None))
+        .await
+        .expect_err("an untrusted issuer must surface as an error, not as an identity");
+    assert!(
+        err.to_string()
+            .contains("is not in the configured trust map"),
+        "rejection must name the untrusted issuer as the reason, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn multi_issuer_never_falls_back_to_the_single_issuer_jwks_url() {
+    // `jwks_url` is set but no `issuer` names it, so it cannot be folded into
+    // the trust map. It must NOT become a default arm for unknown issuers.
+    let key_a = generate_rsa_key(Some("a-key"));
+    let key_b = generate_rsa_key(Some("b-key"));
+    let server_a = start_jwks_server(vec![key_a.jwk.clone()]).await;
+    let server_b = start_jwks_server(vec![key_b.jwk.clone()]).await;
+
+    let config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server_a))
+        .trusted_issuer(ISS_B, jwks_url(&server_b))
+        .build();
+    let strategy: JwtStrategy<IssuedClaims> = JwtStrategy::new(config);
+
+    // Signed by the key published at the dangling `jwks_url`, claiming an
+    // issuer nobody trusts. If `jwks_url` were used as a fallback this would
+    // verify — that is precisely the issuer-confusion vulnerability.
+    let token = sign_token(
+        &key_a.encoding_key,
+        Some("a-key"),
+        &issued_claims(Some(ISS_UNTRUSTED), "user-1"),
+    );
+    let err = strategy
+        .authenticate(&bearer_request_parts(&token, None))
+        .await
+        .expect_err("an unnamed jwks_url must never verify a token from an untrusted issuer");
+    assert!(
+        err.to_string()
+            .contains("is not in the configured trust map"),
+        "expected an untrusted-issuer rejection, got: {err}"
+    );
+
+    // The trust map itself still works.
+    let token = sign_token(
+        &key_b.encoding_key,
+        Some("b-key"),
+        &issued_claims(Some(ISS_B), "user-1"),
+    );
+    assert!(strategy
+        .authenticate(&bearer_request_parts(&token, None))
+        .await
+        .expect("authenticate should not error")
+        .is_some());
+}
+
+#[tokio::test]
+async fn multi_issuer_rejects_a_token_claiming_issuer_a_but_signed_with_issuer_bs_key() {
+    // Both issuers publish a key under the SAME `kid`, so `kid` lookup cannot be
+    // what saves us: the resolver has to pick A's JWKS from `iss`, and the
+    // signature then has to fail against A's key.
+    let key_a = generate_rsa_key(Some("shared-kid"));
+    let key_b = generate_rsa_key(Some("shared-kid"));
+    let server_a = start_jwks_server(vec![key_a.jwk.clone()]).await;
+    let server_b = start_jwks_server(vec![key_b.jwk.clone()]).await;
+
+    let token = sign_token(
+        &key_b.encoding_key,
+        Some("shared-kid"),
+        &issued_claims(Some(ISS_A), "attacker"),
+    );
+
+    let trust_map = IssuerTrustMap::new()
+        .with_issuer(ISS_A, cache_for(&server_a))
+        .with_issuer(ISS_B, cache_for(&server_b));
+
+    let err = validate_jwt_with_resolver::<IssuedClaims>(
+        &token,
+        &trust_map,
+        &multi_issuer_validation(&[ISS_A, ISS_B]),
+    )
+    .await
+    .expect_err("a token claiming issuer A but signed with B's key must be rejected");
+    match err {
+        ValidationError::Jwt(e) => assert!(
+            matches!(e.kind(), ErrorKind::InvalidSignature),
+            "expected an invalid-signature rejection, got {:?}",
+            e.kind()
+        ),
+        other => panic!("expected a signature failure against issuer A's key, got {other:?}"),
+    }
+
+    // Same token, same trust map, through the strategy: no identity.
+    let config = ValidationConfig::builder()
+        .trusted_issuer(ISS_A, jwks_url(&server_a))
+        .trusted_issuer(ISS_B, jwks_url(&server_b))
+        .build();
+    let strategy: JwtStrategy<IssuedClaims> = JwtStrategy::new(config);
+    assert!(
+        strategy
+            .authenticate(&bearer_request_parts(&token, None))
+            .await
+            .expect("authenticate should not error")
+            .is_none(),
+        "cross-issuer key confusion must never yield an identity"
+    );
+}
+
+#[tokio::test]
+async fn multi_issuer_rejects_a_token_with_no_issuer_claim() {
+    let key_a = generate_rsa_key(Some("a-key"));
+    let server_a = start_jwks_server(vec![key_a.jwk.clone()]).await;
+
+    // No `iss` at all: nothing names a key, and there is no default.
+    let token = sign_token(
+        &key_a.encoding_key,
+        Some("a-key"),
+        &issued_claims(None, "user-1"),
+    );
+
+    let trust_map = IssuerTrustMap::new().with_issuer(ISS_A, cache_for(&server_a));
+    let err = validate_jwt_with_resolver::<IssuedClaims>(
+        &token,
+        &trust_map,
+        &multi_issuer_validation(&[ISS_A]),
+    )
+    .await
+    .expect_err("a token with no iss must be rejected in multi-issuer mode");
+    assert!(
+        matches!(err, ValidationError::MissingIssuer),
+        "expected MissingIssuer, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn the_single_issuer_pair_is_folded_into_the_trust_map_as_one_more_entry() {
+    let key_a = generate_rsa_key(Some("a-key"));
+    let key_b = generate_rsa_key(Some("b-key"));
+    let server_a = start_jwks_server(vec![key_a.jwk.clone()]).await;
+    let server_b = start_jwks_server(vec![key_b.jwk.clone()]).await;
+
+    let config = ValidationConfig::builder()
+        .issuer(ISS_A)
+        .jwks_url(jwks_url(&server_a))
+        .trusted_issuer(ISS_B, jwks_url(&server_b))
+        .build();
+    let strategy: JwtStrategy<IssuedClaims> = JwtStrategy::new(config);
+
+    for (iss, key, kid) in [(ISS_A, &key_a, "a-key"), (ISS_B, &key_b, "b-key")] {
+        let token = sign_token(
+            &key.encoding_key,
+            Some(kid),
+            &issued_claims(Some(iss), "user-1"),
+        );
+        assert!(
+            strategy
+                .authenticate(&bearer_request_parts(&token, None))
+                .await
+                .unwrap_or_else(|e| panic!("authenticate should not error for {iss}: {e}"))
+                .is_some(),
+            "the issuer/jwks_url pair must keep working alongside a trust map"
+        );
+    }
+}
+
+#[tokio::test]
+async fn single_issuer_configuration_is_unchanged_by_multi_issuer_support() {
+    // Regression guard: with no trust map this is exactly the pre-#243
+    // verifier — one JWKS, one accepted issuer.
+    let key_a = generate_rsa_key(Some("a-key"));
+    let server_a = start_jwks_server(vec![key_a.jwk.clone()]).await;
+
+    let config = ValidationConfig::builder()
+        .issuer(ISS_A)
+        .jwks_url(jwks_url(&server_a))
+        .build();
+    assert!(
+        config.trusted_issuers.is_empty(),
+        "no trust map may be configured unless the caller asked for one"
+    );
+    let strategy: JwtStrategy<IssuedClaims> = JwtStrategy::new(config);
+
+    let token = sign_token(
+        &key_a.encoding_key,
+        Some("a-key"),
+        &issued_claims(Some(ISS_A), "user-1"),
+    );
+    let identity = strategy
+        .authenticate(&bearer_request_parts(&token, None))
+        .await
+        .expect("authenticate should not error")
+        .expect("a token from the configured issuer must still be accepted");
+    assert_eq!(identity.sub, "user-1");
+
+    // A different `iss`, signed by the very key this config trusts, is still
+    // rejected by `Validation` — and still as `Ok(None)`, not an error, exactly
+    // as before.
+    let token = sign_token(
+        &key_a.encoding_key,
+        Some("a-key"),
+        &issued_claims(Some(ISS_UNTRUSTED), "user-1"),
+    );
+    assert!(
+        strategy
+            .authenticate(&bearer_request_parts(&token, None))
+            .await
+            .expect("authenticate should not error")
+            .is_none(),
+        "a mismatched iss must still be rejected in single-issuer mode"
+    );
+
+    // Pre-existing `jsonwebtoken` semantics, unchanged here and pinned so that
+    // changing it later is a deliberate act: `iss` is only checked when the
+    // claim is present, so a token omitting it entirely is still accepted in
+    // single-issuer mode. Multi-issuer mode does NOT inherit this (see
+    // `multi_issuer_rejects_a_token_with_no_issuer_claim`), because there `iss`
+    // is added to `required_spec_claims`.
+    let token = sign_token(
+        &key_a.encoding_key,
+        Some("a-key"),
+        &issued_claims(None, "user-1"),
+    );
+    assert!(
+        strategy
+            .authenticate(&bearer_request_parts(&token, None))
+            .await
+            .expect("authenticate should not error")
+            .is_some(),
+        "single-issuer behaviour must be unchanged, including this pre-existing laxity"
+    );
 }

--- a/crates/authkestra-resource/tests/jwt_test.rs
+++ b/crates/authkestra-resource/tests/jwt_test.rs
@@ -834,3 +834,48 @@ async fn single_issuer_configuration_is_unchanged_by_multi_issuer_support() {
         "single-issuer behaviour must be unchanged, including this pre-existing laxity"
     );
 }
+
+/// A `with_resolver` strategy must still reject a token with no `iss`, even
+/// when no static trust map is configured.
+///
+/// Raised in review of #254. `build_validation` inferred "multi-issuer" from
+/// `trusted_issuers` being non-empty, but a `with_resolver` caller resolves
+/// issuers dynamically and so configures no map at all — leaving that path with
+/// neither `set_issuer` nor `iss` in `required_spec_claims`. Both backstops were
+/// off precisely where the docs said they applied, so a resolver lax about
+/// `None` would authenticate an issuer-less token.
+///
+/// The resolver here is deliberately maximally lax: it hands back the same
+/// cache whatever the issuer, including `None`. The rejection must therefore
+/// come from `Validation`, not from the resolver.
+#[tokio::test]
+async fn with_resolver_rejects_an_issuerless_token_even_with_no_trust_map() {
+    struct AlwaysSame(Arc<JwksCache>);
+
+    #[async_trait::async_trait]
+    impl authkestra_resource::jwt::JwksResolver for AlwaysSame {
+        async fn resolve(&self, _issuer: Option<&str>) -> Result<Arc<JwksCache>, ValidationError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    let key = generate_rsa_key(Some("a-key"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+
+    // No `iss` at all, signed by a key the resolver will happily hand over.
+    let token = sign_token(&key.encoding_key, Some("a-key"), &issued_claims(None, "u"));
+
+    let config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .build();
+    let strategy: JwtStrategy<IssuedClaims> =
+        JwtStrategy::with_resolver(config, Box::new(AlwaysSame(cache_for(&server))));
+
+    let result = strategy
+        .authenticate(&bearer_request_parts(&token, None))
+        .await;
+    assert!(
+        result.is_err() || result.as_ref().is_ok_and(|id| id.is_none()),
+        "an iss-less token must not authenticate through a custom resolver, got: {result:?}"
+    );
+}


### PR DESCRIPTION
Refs #243. **Deliberately does not close it** — two design questions in it are maintainer calls and are left open below.

`ValidationConfig` bound one JWKS endpoint to one issuer, so a resource server that legitimately trusts several issuers had to build and dispatch between separate validators by hand — which also duplicated the JWKS cache/refresh machinery per issuer, the concrete complaint in the issue (`vaam-store/platform`'s `MultiIssuerJwksVerifier`).

## The seam

The issue offers two shapes ("map of `issuer -> jwks_url`" or "a resolver hook") and notes the second composes better for runtime-discovered issuers. This implements the resolver as the *mechanism* and the map as the *configured case*, so neither is a second parallel path:

| Item | Kind |
| --- | --- |
| `trait JwksResolver` — resolve a `JwksCache` from the token's `iss` (`Box<dyn>` on the I/O path, per `AGENTS.md`) | new |
| `IssuerTrustMap` — fixed `iss` -> `JwksCache` map; one cache per issuer, so TTL/rotation refresh stays per-endpoint but stays managed by this crate | new |
| `SingleJwksResolver` — one endpoint for any `iss`; the pre-existing behaviour, unchanged | new |
| `ValidationConfig::trusted_issuers: BTreeMap<String, String>` | new field |
| `ValidationConfigBuilder::trusted_issuer(iss, url)` / `trusted_issuers(pairs)` | new |
| `JwtStrategy::with_resolver(config, Box<dyn JwksResolver>)` — for issuers only known at runtime | new |
| `validate_jwt_with_resolver` — multi-issuer counterpart of `validate_jwt_generic` | new |
| `ValidationError::UntrustedIssuer` / `::MissingIssuer` | new variants |

`JwtStrategy` now holds a `Box<dyn JwksResolver>` instead of a `JwksCache` (private field; no API impact).

## Security: no fallback, ever

An `iss` outside a non-empty trust map is rejected with `UntrustedIssuer`; a token with no usable string `iss` is rejected with `MissingIssuer`. There is deliberately **no** fallback to `jwks_url` — a default JWKS for unknown issuers is exactly issuer confusion, and this is stated in the `JwksResolver` doc comment as a contract for third-party implementors.

Three defences, in order:

1. The resolver picks the JWKS from `iss`, with no default arm.
2. Every trusted issuer name is passed to `Validation::set_issuer` — which always took a slice; the config simply had no way to express more than one name (limitation 1 in the issue). So a token verified with B's key still has to *say* it came from B.
3. Multi-issuer mode adds `iss` to `required_spec_claims`, so even a lax custom resolver cannot let an `iss`-less token through.

The `iss` used to select a key is read **before** verification (`unverified_issuer`, a hand-rolled base64url payload read). That is safe because the same claim is re-checked after verification against the trusted set, and the payload is signature-covered — an attacker choosing `iss` only chooses whose key their signature must satisfy. The reasoning is written out on the function.

If `jwks_url` is set alongside a trust map, it is folded in as one more entry **only** when `issuer` names it. Without an `issuer` it is dropped with a `tracing::warn!` rather than becoming a default arm.

## Additive vs breaking

**Additive.** With an empty `trusted_issuers` map, `JwtStrategy::new` builds exactly the previous verifier: one JWKS, `iss` checked only if `issuer` was set, `iss` not required, same `Ok(None)` rejection semantics. Pinned by `single_issuer_configuration_is_unchanged_by_multi_issuer_support`, which also pins the *pre-existing* laxity that a token omitting `iss` entirely is still accepted in single-issuer mode (see "left open" #3).

All construction goes through `ValidationConfigBuilder` — no struct literal is added anywhere outside the defining crate — so this is compatible with #250 making `ValidationConfig` `#[non_exhaustive]`.

**Two things that are technically breaking under strict semver**, neither of which affects anything in-tree:

- `ValidationError` gains two variants. It is not `#[non_exhaustive]`, so a downstream exhaustive `match` would stop compiling. Making it `#[non_exhaustive]` is the same class of decision as #250 and is **not** done here.
- `ValidationConfig` gains a field, which is the exact hazard #247/#250 is about. Unavoidable for this feature; the builder covers it.

Nothing here touches `Cargo.toml`, the version, or `release-plz.toml`. The commit is a plain `feat`, which lands on the same `0.6.0` #250 already argues for.

## Expected conflict with #250

Both touch `crates/authkestra-resource/src/jwt.rs` and `tests/jwt_test.rs`. **A conflict is expected and the coordinator will resolve it.** This branch is deliberately *not* rebased onto #250.

The edit to the `ValidationConfig` struct definition itself is 6 added lines, appended after the last field, so #250's `#[non_exhaustive]` (added above the struct) should merge around it:

```rust
     pub require_cert_binding: bool,
+    /// Trust map of `iss` -> JWKS endpoint, for a resource server that accepts
+    /// tokens from several issuers. Empty by default, which keeps the
+    /// single-issuer `jwks_url` path unchanged. When non-empty, an `iss` absent
+    /// from this map is rejected outright and never falls back to `jwks_url`.
+    /// See [`IssuerTrustMap`] and issue #243.
+    pub trusted_issuers: BTreeMap<String, String>,
 }
```

The other in-file edits are away from that struct: the error enum, a new resolver section after `JwksCache`, the builder impl, `JwtStrategy` + two new free functions, and appended tests. Tests are appended at the end of `jwt_test.rs`, where #250 also appends one — a mechanical conflict.

## Left as a maintainer decision

1. **`jwks_url: String` vs `Option<String>`.** A trust-map-only config has no single endpoint, so `build()` leaves `jwks_url` empty (and an empty `jwks_url` is never fetched from — `build_resolver` skips it). `Option<String>` would model this honestly but changes a public field's type, which is breaking. Not done. `build()` still panics if neither a `jwks_url` nor any `trusted_issuer` was set.
2. **Should `ValidationError` become `#[non_exhaustive]`?** See above. Related to #247; not decided here.
3. **Should single-issuer mode also require `iss`?** Today, with `issuer` configured, `jsonwebtoken` only checks `iss` when the claim is present, so a token omitting it is accepted. That is pre-existing behaviour, unchanged here and now pinned by a test with a comment saying so. Multi-issuer mode does *not* inherit it. Tightening single-issuer mode would be a behavioural break for deployed verifiers — a maintainer call, not mine.
4. **`UntrustedIssuer` surfaces as `Err(AuthError::Token)` from `JwtStrategy::authenticate`, not `Ok(None)`**, matching how `MissingKid` already behaves (there is an existing test blessing that). Under `AuthPolicy::FirstSuccess` this aborts the strategy chain instead of falling through to, say, an API-key strategy. Only reachable when a trust map is configured, so no existing deployment changes. Flagging it in case `Ok(None)` is preferred.

## Verification

Ran on the toolchain CI resolves `stable` to (1.98.0), scoped to the touched crate:

| Command | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo +1.98.0 clippy -p authkestra-resource --all-targets --all-features -- -D warnings` | pass |
| `cargo test -p authkestra-resource --all-features` | 9 unit + 19 integration, all pass |

No `#[allow]` was added anywhere.

### The multi-issuer tests are load-bearing (measured, not asserted)

**(a) Reverted the per-issuer resolution** — made `build_resolver` hand every issuer the same single JWKS, i.e. the pre-#243 shape:

```
test multi_issuer_verifies_each_token_against_its_own_issuers_jwks ... FAILED
test multi_issuer_rejects_a_token_whose_issuer_is_not_in_the_trust_map ... FAILED
test multi_issuer_never_falls_back_to_the_single_issuer_jwks_url ... FAILED

authenticate should not error for https://issuer-b.example: Token error: Key not found in JWKS
an untrusted issuer must surface as an error, not as an identity: None
expected an untrusted-issuer rejection, got: Token error: Key not found in JWKS
```

**(b) Introduced the actual vulnerability** — gave `IssuerTrustMap::resolve` a default arm returning the first cache for an unknown issuer:

```
test multi_issuer_rejects_a_token_whose_issuer_is_not_in_the_trust_map ... FAILED
test multi_issuer_never_falls_back_to_the_single_issuer_jwks_url ... FAILED

expected UntrustedIssuer(https://issuer-c.example), got Jwt(Error(InvalidIssuer))
expected an untrusted-issuer rejection, got: Token error: Key not found in JWKS
```

Worth reading precisely what (b) shows: with the fallback in place the token was *still* ultimately rejected — by layer 2, the accepted-issuer list. That is exactly the "rejected incidentally" failure mode, and the tests demand the specific `UntrustedIssuer` reason so they cannot pass on luck.

Both experiments were reverted; the final tree is the green one above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
