### PR TITLE
refactor(examples): modernise examples for the unified engine (#194)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "tower-http",
  "tower-layer",
  "tower-service",
+ "tracing",
  "tracing-subscriber",
  "url",
  "uuid",

--- a/crates/authkestra/Cargo.toml
+++ b/crates/authkestra/Cargo.toml
@@ -44,6 +44,7 @@ p256 = { version = "0.13", features = ["pem", "ecdsa", "jwk"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 rand = "0.8"
 sha2 = "0.10"
+tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 async-trait = "0.1.91"
 webauthn-rs = "0.5.0"

--- a/crates/authkestra/examples/actix_basic_setup.rs
+++ b/crates/authkestra/examples/actix_basic_setup.rs
@@ -1,71 +1,118 @@
-//! # Actix Basic Setup Example
+//! # Actix Basic Setup — the smallest useful `Engine`
 //!
-//! This example demonstrates the most basic setup of Engine with Actix.
-//! It uses an in-memory session store.
+//! The Actix counterpart of `axum_basic_setup.rs`. The engine construction is
+//! byte-for-byte identical; only the adapter call differs
+//! ([`ActixExt::actix_scope`] instead of `axum_router`), which is the whole
+//! point of the framework-agnostic core.
+//!
+//! ```sh
+//! cargo run -p authkestra --example actix_basic_setup --all-features
+//! ```
+//!
+//! Set `PORT` to bind somewhere other than 3000.
 
 use actix_files::Files;
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
 use authkestra_actix::{ActixExt, ActixState, AuthSession};
-use authkestra_engine::auth::SessionStore;
-use authkestra_engine::flow::Engine;
-use authkestra_engine::SessionConfig;
+use authkestra_engine::store::memory::MemoryStore;
+use authkestra_engine::{AkWebAppEngine, Engine, SessionConfig, SessionStore};
 use serde_json::json;
 use std::sync::Arc;
 
+/// `AkWebAppEngine` is the alias for a session-configured engine. Using the
+/// alias (rather than spelling out the typestate generics) keeps the compile
+/// error legible when a required builder call is missing.
 #[derive(Clone, ActixState)]
 struct AppState {
     #[authkestra(engine)]
-    auth: authkestra_engine::AkWebAppEngine,
+    auth: AkWebAppEngine,
 }
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    // Session Store
-    let session_store: Arc<dyn SessionStore> =
-        Arc::new(authkestra_engine::store::memory::MemoryStore::default());
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
 
-    let authkestra = Engine::builder()
+    // 1. Pick a storage backend. `SessionStore` is a trait, so swapping
+    //    `MemoryStore` for `RedisStore` or `SqlKvStore` is a one-line change.
+    let session_store: Arc<dyn SessionStore> = Arc::new(MemoryStore::default());
+
+    // 2. Build the engine. The typestate builder only exposes session APIs
+    //    once `session_store` has been supplied.
+    let engine = Engine::builder()
         .session_store(session_store)
         .session_config(SessionConfig {
-            secure: false, // For local development
+            secure: false, // plain HTTP for local development
             ..Default::default()
         })
         .build();
 
-    let state = AppState {
-        auth: authkestra.clone(),
-    };
+    let state = AppState { auth: engine };
 
-    println!("🚀 Actix Basic Setup running on http://localhost:3000");
+    let port = port_from_env();
+    tracing::info!(%port, "Actix basic setup listening on http://localhost:{port}");
 
     HttpServer::new(move || {
         let app_state = state.clone();
         let config_state = app_state.clone();
         App::new()
             .app_data(web::Data::new(app_state.clone()))
+            // `configure_authkestra` (from `ActixState`) registers the session
+            // store and config as app data for the extractors to find.
             .configure(move |cfg| config_state.configure_authkestra(cfg))
             .service(get_user)
+            .service(list_providers)
+            // 3. Mount the engine's `/auth/*` scope.
             .service(app_state.auth.actix_scope())
             .service(
                 Files::new("/", concat!(env!("CARGO_MANIFEST_DIR"), "/examples/static"))
                     .index_file("index.html"),
             )
     })
-    .bind(("0.0.0.0", 3000))?
+    .bind(("0.0.0.0", port))?
     .run()
     .await
 }
 
-/// API endpoint to get current user info from session
+/// Returns the session identity, or 401 when there is no valid session.
 #[get("/api/user")]
 async fn get_user(session: Option<AuthSession>) -> impl Responder {
     match session {
-        Some(AuthSession(session)) => HttpResponse::Ok().json(json!({
-            "id": session.identity.external_id,
-            "username": session.identity.username,
-            "email": session.identity.email,
-            "provider": session.identity.provider_id,
-        })),
-        None => HttpResponse::Unauthorized().json(json!({ "error": "Not authenticated" })),
+        Some(AuthSession(session)) => {
+            tracing::debug!(user = %session.identity.external_id, "session resolved");
+            HttpResponse::Ok().json(json!({
+                "id": session.identity.external_id,
+                "username": session.identity.username,
+                "email": session.identity.email,
+                "provider": session.identity.provider_id,
+            }))
+        }
+        None => {
+            tracing::debug!("no valid session on request");
+            HttpResponse::Unauthorized().json(json!({ "error": "Not authenticated" }))
+        }
     }
+}
+
+/// Lists the OAuth providers registered on the engine so the bundled static
+/// page can render one login button per provider. Empty for this example.
+#[get("/api/providers")]
+async fn list_providers(state: web::Data<AppState>) -> impl Responder {
+    let providers: Vec<&String> = state.auth.providers.keys().collect();
+    HttpResponse::Ok().json(json!({ "providers": providers }))
+}
+
+/// Bind port, overridable via `PORT` so several examples (and the e2e test
+/// harness, which passes a port it has already confirmed to be free) can run
+/// without colliding on 3000.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000)
 }

--- a/crates/authkestra/examples/actix_oauth2_github.rs
+++ b/crates/authkestra/examples/actix_oauth2_github.rs
@@ -1,17 +1,23 @@
-//! # Actix GitHub OAuth2 Example
+//! # Actix + GitHub OAuth2 (stateful sessions)
 //!
-//! This example demonstrates how to set up Engine with Actix for GitHub OAuth2 login.
+//! The Actix counterpart of `axum_oauth2_github.rs`: an [`Engine`] with an
+//! OAuth provider *and* a session store. The callback creates a server-side
+//! session and sets a cookie.
 //!
-//! To run this example, you'll need:
-//! - `AUTHKESTRA_GITHUB_CLIENT_ID`
-//! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
+//! ```sh
+//! AUTHKESTRA_GITHUB_CLIENT_ID=... AUTHKESTRA_GITHUB_CLIENT_SECRET=... \
+//!   cargo run -p authkestra --example actix_oauth2_github --all-features
+//! ```
+//!
+//! Register `http://localhost:3000/auth/callback/github` as the OAuth callback
+//! on GitHub — that is the path [`ActixExt::actix_scope`] actually wires. Set
+//! `PORT` to bind elsewhere; the default redirect URI follows it.
 
 use actix_files::Files;
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
 use authkestra_actix::{ActixExt, ActixState, AuthSession};
-use authkestra_engine::auth::SessionStore;
-use authkestra_engine::flow::{Engine, OAuth2Flow};
-use authkestra_engine::{AkWebAppEngine, SessionConfig};
+use authkestra_engine::store::memory::MemoryStore;
+use authkestra_engine::{AkWebAppEngine, Engine, OAuth2Flow, SessionConfig, SessionStore};
 use authkestra_providers::github::GithubProvider;
 use serde_json::json;
 use std::sync::Arc;
@@ -24,9 +30,7 @@ struct AppState {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    // =========================================================================
-    // Initialize tracing subscriber for logging
-    // =========================================================================
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -34,51 +38,36 @@ async fn main() -> std::io::Result<()> {
         )
         .init();
 
-    // Load environment variables from .env file
     dotenvy::dotenv().ok();
+
+    let port = port_from_env();
 
     let client_id = std::env::var("AUTHKESTRA_GITHUB_CLIENT_ID")
         .expect("AUTHKESTRA_GITHUB_CLIENT_ID must be set");
     let client_secret = std::env::var("AUTHKESTRA_GITHUB_CLIENT_SECRET")
         .expect("AUTHKESTRA_GITHUB_CLIENT_SECRET must be set");
     let redirect_uri = std::env::var("AUTHKESTRA_GITHUB_REDIRECT_URI")
-        .unwrap_or_else(|_| "http://localhost:3000/auth/github/callback".to_string());
+        .unwrap_or_else(|_| format!("http://localhost:{port}/auth/callback/github"));
 
-    // Support E2E tests pointing to a local mock server
-    let github_provider = match std::env::var("AUTHKESTRA_GITHUB_BASE_URL") {
-        Ok(base_url) => {
-            let api_url =
-                std::env::var("AUTHKESTRA_GITHUB_API_URL").unwrap_or_else(|_| base_url.clone());
-            GithubProvider::new(client_id, client_secret, redirect_uri).with_test_urls(
-                format!("{base_url}/login/oauth/authorize"),
-                format!("{base_url}/login/oauth/access_token"),
-                format!("{api_url}/user"),
-            )
-        }
-        Err(_) => GithubProvider::new(client_id, client_secret, redirect_uri),
-    };
+    let github_provider = github_provider(client_id, client_secret, redirect_uri);
 
-    // Session Store
-    // TIP: authkestra uses traits (like `SessionStore`) for storage.
-    // This makes it easy to swap out backends! You could easily replace `MemoryStore`
-    // with `SqlKvStore` or `RedisStore` simply by changing the struct instantiated here.
-    let session_store: Arc<dyn SessionStore> =
-        Arc::new(authkestra_engine::store::memory::MemoryStore::default());
+    // `SessionStore` is a trait: swap `MemoryStore` for `RedisStore` or
+    // `SqlKvStore` without touching anything below this line.
+    let session_store: Arc<dyn SessionStore> = Arc::new(MemoryStore::default());
 
-    let authkestra = Engine::builder()
+    let engine = Engine::builder()
         .provider(OAuth2Flow::new(github_provider))
         .session_store(session_store)
         .session_config(SessionConfig {
-            secure: false,
+            secure: false, // plain HTTP for local development
             ..Default::default()
         })
         .build();
 
-    let state = AppState {
-        auth: authkestra.clone(),
-    };
+    let state = AppState { auth: engine };
 
-    println!("🚀 Actix GitHub OAuth2 running on http://localhost:3000");
+    tracing::info!(%port, "Actix GitHub OAuth2 listening on http://localhost:{port}");
+    tracing::info!("start the flow at http://localhost:{port}/auth/login/github");
 
     HttpServer::new(move || {
         let app_state = state.clone();
@@ -87,26 +76,74 @@ async fn main() -> std::io::Result<()> {
             .app_data(web::Data::new(app_state.clone()))
             .configure(move |cfg| config_state.configure_authkestra(cfg))
             .service(get_user)
+            .service(list_providers)
             .service(app_state.auth.actix_scope())
             .service(
                 Files::new("/", concat!(env!("CARGO_MANIFEST_DIR"), "/examples/static"))
                     .index_file("index.html"),
             )
     })
-    .bind(("0.0.0.0", 3000))?
+    .bind(("0.0.0.0", port))?
     .run()
     .await
 }
 
+/// Builds the provider, redirecting to a mock server when the e2e harness has
+/// set `AUTHKESTRA_GITHUB_BASE_URL`. Real deployments never set these.
+fn github_provider(
+    client_id: String,
+    client_secret: String,
+    redirect_uri: String,
+) -> GithubProvider {
+    match std::env::var("AUTHKESTRA_GITHUB_BASE_URL") {
+        Ok(base_url) => {
+            let api_url =
+                std::env::var("AUTHKESTRA_GITHUB_API_URL").unwrap_or_else(|_| base_url.clone());
+            tracing::warn!(%base_url, "using overridden GitHub endpoints (test mode)");
+            GithubProvider::new(client_id, client_secret, redirect_uri).with_test_urls(
+                format!("{base_url}/login/oauth/authorize"),
+                format!("{base_url}/login/oauth/access_token"),
+                format!("{api_url}/user"),
+            )
+        }
+        Err(_) => GithubProvider::new(client_id, client_secret, redirect_uri),
+    }
+}
+
+/// Returns the session identity, or 401 when there is no valid session.
 #[get("/api/user")]
 async fn get_user(session: Option<AuthSession>) -> impl Responder {
     match session {
-        Some(AuthSession(session)) => HttpResponse::Ok().json(json!({
-            "id": session.identity.external_id,
-            "username": session.identity.username,
-            "email": session.identity.email,
-            "provider": session.identity.provider_id,
-        })),
-        None => HttpResponse::Unauthorized().json(json!({ "error": "Not authenticated" })),
+        Some(AuthSession(session)) => {
+            tracing::debug!(user = %session.identity.external_id, "session resolved");
+            HttpResponse::Ok().json(json!({
+                "id": session.identity.external_id,
+                "username": session.identity.username,
+                "email": session.identity.email,
+                "provider": session.identity.provider_id,
+            }))
+        }
+        None => {
+            tracing::debug!("no valid session on request");
+            HttpResponse::Unauthorized().json(json!({ "error": "Not authenticated" }))
+        }
     }
+}
+
+/// Lists the registered OAuth providers so the bundled static page can render
+/// a login button per provider.
+#[get("/api/providers")]
+async fn list_providers(state: web::Data<AppState>) -> impl Responder {
+    let providers: Vec<&String> = state.auth.providers.keys().collect();
+    HttpResponse::Ok().json(json!({ "providers": providers }))
+}
+
+/// Bind port, overridable via `PORT` so several examples (and the e2e test
+/// harness, which passes a port it has already confirmed to be free) can run
+/// without colliding on 3000.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000)
 }

--- a/crates/authkestra/examples/actix_oauth_stateless.rs
+++ b/crates/authkestra/examples/actix_oauth_stateless.rs
@@ -1,20 +1,31 @@
-//! # Actix Stateless OAuth Example
+//! # Actix + GitHub OAuth2 (stateless / JWT)
 //!
-//! This example demonstrates how to set up Engine for OAuth2 in stateless mode,
-//! where the callback returns a JWT instead of creating a server-side session.
+//! The Actix counterpart of `axum_oauth_stateless.rs`. The same
+//! [`Engine::builder`] is given a `jwt_secret` instead of a `session_store`,
+//! and [`ActixStatelessExt::actix_scope_stateless`] wires a callback that
+//! returns a JWT as JSON rather than setting a session cookie.
 //!
-//! To run this example, you'll need:
-//! - `AUTHKESTRA_GITHUB_CLIENT_ID`
-//! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
+//! The typestate builder is what makes the difference safe: because no session
+//! store was configured, the session-only APIs simply do not exist on this
+//! engine, so there is no way to accidentally mix the two modes.
+//!
+//! ```sh
+//! AUTHKESTRA_GITHUB_CLIENT_ID=... AUTHKESTRA_GITHUB_CLIENT_SECRET=... \
+//!   cargo run -p authkestra --example actix_oauth_stateless --all-features
+//! ```
+//!
+//! 1. Start the flow at `/auth/login/github`.
+//! 2. The callback (`/auth/callback/github`) responds with a JWT.
+//! 3. Call `/api/user` with `Authorization: Bearer <token>`.
 
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
 use authkestra_actix::{ActixState, ActixStatelessExt, AuthToken};
-use authkestra_engine::flow::{Engine, OAuth2Flow};
-use authkestra_engine::AkApiEngine;
+use authkestra_engine::{AkApiEngine, Engine, OAuth2Flow};
 use authkestra_providers::github::GithubProvider;
 use serde_json::json;
 
-/// Engine state with support for tokens (stateless mode).
+/// `AkApiEngine` is the alias for a token-configured engine with no session
+/// store — the stateless counterpart of `AkWebAppEngine`.
 #[derive(Clone, ActixState)]
 struct AppState {
     #[authkestra(engine)]
@@ -23,21 +34,68 @@ struct AppState {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    // Load environment variables from .env file
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
+
     dotenvy::dotenv().ok();
+
+    let port = port_from_env();
 
     let client_id = std::env::var("AUTHKESTRA_GITHUB_CLIENT_ID")
         .expect("AUTHKESTRA_GITHUB_CLIENT_ID must be set");
     let client_secret = std::env::var("AUTHKESTRA_GITHUB_CLIENT_SECRET")
         .expect("AUTHKESTRA_GITHUB_CLIENT_SECRET must be set");
     let redirect_uri = std::env::var("AUTHKESTRA_GITHUB_REDIRECT_URI")
-        .unwrap_or_else(|_| "http://localhost:3000/auth/callback/github".to_string());
+        .unwrap_or_else(|_| format!("http://localhost:{port}/auth/callback/github"));
 
-    // Support E2E tests pointing to a local mock server
-    let github_provider = match std::env::var("AUTHKESTRA_GITHUB_BASE_URL") {
+    let github_provider = github_provider(client_id, client_secret, redirect_uri);
+
+    // Stateless mode: `jwt_secret` configures the token manager and leaves the
+    // session-store slot `Missing`. Load a real secret from your secret
+    // manager — this literal is only acceptable in an example.
+    let engine = Engine::builder()
+        .provider(OAuth2Flow::new(github_provider))
+        .jwt_secret(b"your-256-bit-secret-key-at-least-32-bytes-long")
+        .build();
+
+    let state = AppState { auth: engine };
+
+    tracing::info!(%port, "Actix stateless OAuth listening on http://localhost:{port}");
+    tracing::info!("1. start the flow at http://localhost:{port}/auth/login/github");
+    tracing::info!("2. the callback returns JSON containing a JWT");
+    tracing::info!("3. call /api/user with 'Authorization: Bearer <token>'");
+
+    HttpServer::new(move || {
+        let app_state = state.clone();
+        let scope_state = app_state.clone();
+        App::new()
+            .app_data(web::Data::new(app_state.clone()))
+            .configure(move |cfg| app_state.configure_authkestra(cfg))
+            .service(scope_state.auth.actix_scope_stateless())
+            .service(get_user)
+    })
+    .bind(("0.0.0.0", port))?
+    .run()
+    .await
+}
+
+/// Builds the provider, redirecting to a mock server when the e2e harness has
+/// set `AUTHKESTRA_GITHUB_BASE_URL`. Real deployments never set these.
+fn github_provider(
+    client_id: String,
+    client_secret: String,
+    redirect_uri: String,
+) -> GithubProvider {
+    match std::env::var("AUTHKESTRA_GITHUB_BASE_URL") {
         Ok(base_url) => {
             let api_url =
                 std::env::var("AUTHKESTRA_GITHUB_API_URL").unwrap_or_else(|_| base_url.clone());
+            tracing::warn!(%base_url, "using overridden GitHub endpoints (test mode)");
             GithubProvider::new(client_id, client_secret, redirect_uri).with_test_urls(
                 format!("{base_url}/login/oauth/authorize"),
                 format!("{base_url}/login/oauth/access_token"),
@@ -45,47 +103,45 @@ async fn main() -> std::io::Result<()> {
             )
         }
         Err(_) => GithubProvider::new(client_id, client_secret, redirect_uri),
-    };
-
-    // Initialize Engine in stateless mode (JWT only).
-    let authkestra = Engine::builder()
-        .provider(OAuth2Flow::new(github_provider))
-        .jwt_secret(b"your-256-bit-secret-key-at-least-32-bytes-long")
-        .build();
-
-    let state = AppState { auth: authkestra };
-
-    println!("🚀 Actix Stateless OAuth running on http://localhost:3000");
-    println!("1. Login: http://localhost:3000/auth/github");
-    println!("2. The callback will return a JSON with a JWT.");
-    println!("3. Use the JWT in the 'Authorization: Bearer <token>' header for /api/user");
-
-    HttpServer::new(move || {
-        let app_state = state.clone();
-        App::new()
-            .app_data(web::Data::new(app_state.clone()))
-            .configure(|cfg| app_state.configure_authkestra(cfg))
-            .service(app_state.auth.actix_scope_stateless())
-            .service(get_user)
-    })
-    .bind(("0.0.0.0", 3000))?
-    .run()
-    .await
+    }
 }
 
-/// Protected endpoint using `AuthToken` extractor.
+/// Protected endpoint using the `AuthToken` extractor (bearer token, no cookie).
 #[get("/api/user")]
 async fn get_user(auth: Option<AuthToken>) -> impl Responder {
     match auth {
-        Some(AuthToken(claims)) => {
-            let identity = claims.identity.as_ref().unwrap();
-            HttpResponse::Ok().json(json!({
-                "id": identity.external_id,
-                "username": identity.username,
-                "email": identity.email,
-                "provider": identity.provider_id,
-            }))
+        Some(AuthToken(claims)) => match claims.identity.as_ref() {
+            Some(identity) => {
+                tracing::debug!(user = %identity.external_id, "bearer token accepted");
+                HttpResponse::Ok().json(json!({
+                    "id": identity.external_id,
+                    "username": identity.username,
+                    "email": identity.email,
+                    "provider": identity.provider_id,
+                }))
+            }
+            // A token signed by this engine but carrying no identity claim —
+            // e.g. a client-credentials token. Report it rather than panicking.
+            None => {
+                tracing::warn!("token validated but carries no identity claim");
+                HttpResponse::Forbidden().json(json!({
+                    "error": "Token carries no user identity"
+                }))
+            }
+        },
+        None => {
+            tracing::debug!("bearer token missing or rejected");
+            HttpResponse::Unauthorized().json(json!({ "error": "Not authenticated" }))
         }
-        None => HttpResponse::Unauthorized().json(json!({ "error": "Not authenticated" })),
     }
+}
+
+/// Bind port, overridable via `PORT` so several examples (and the e2e test
+/// harness, which passes a port it has already confirmed to be free) can run
+/// without colliding on 3000.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000)
 }

--- a/crates/authkestra/examples/actix_oidc_google.rs
+++ b/crates/authkestra/examples/actix_oidc_google.rs
@@ -1,17 +1,24 @@
-//! # Actix Google OIDC Example
+//! # Actix + Google OIDC (stateful sessions)
 //!
-//! This example demonstrates how to set up Engine with Actix for Google OIDC login.
+//! Same shape as `actix_oauth2_github.rs`, with Google's OIDC provider swapped
+//! in — the point being that [`Engine::builder`] treats every provider
+//! identically: `.provider(OAuth2Flow::new(..))` and nothing else changes.
 //!
-//! To run this example, you'll need:
-//! - `AUTHKESTRA_GOOGLE_CLIENT_ID`
-//! - `AUTHKESTRA_GOOGLE_CLIENT_SECRET`
+//! ```sh
+//! AUTHKESTRA_GOOGLE_CLIENT_ID=... AUTHKESTRA_GOOGLE_CLIENT_SECRET=... \
+//!   cargo run -p authkestra --example actix_oidc_google --all-features
+//! ```
+//!
+//! Register `http://localhost:3000/auth/callback/google` as an authorised
+//! redirect URI in the Google Cloud console — that is the path
+//! [`ActixExt::actix_scope`] actually wires. Set `PORT` to bind elsewhere; the
+//! default redirect URI follows it.
 
 use actix_files::Files;
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
 use authkestra_actix::{ActixExt, ActixState, AuthSession};
-use authkestra_engine::auth::SessionStore;
-use authkestra_engine::flow::{Engine, OAuth2Flow};
-use authkestra_engine::{AkWebAppEngine, SessionConfig};
+use authkestra_engine::store::memory::MemoryStore;
+use authkestra_engine::{AkWebAppEngine, Engine, OAuth2Flow, SessionConfig, SessionStore};
 use authkestra_providers::google::GoogleProvider;
 use serde_json::json;
 use std::sync::Arc;
@@ -24,9 +31,7 @@ struct AppState {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    // =========================================================================
-    // Initialize tracing subscriber for logging
-    // =========================================================================
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -34,49 +39,36 @@ async fn main() -> std::io::Result<()> {
         )
         .init();
 
-    // Load environment variables from .env file
     dotenvy::dotenv().ok();
+
+    let port = port_from_env();
 
     let client_id = std::env::var("AUTHKESTRA_GOOGLE_CLIENT_ID")
         .expect("AUTHKESTRA_GOOGLE_CLIENT_ID must be set");
     let client_secret = std::env::var("AUTHKESTRA_GOOGLE_CLIENT_SECRET")
         .expect("AUTHKESTRA_GOOGLE_CLIENT_SECRET must be set");
     let redirect_uri = std::env::var("AUTHKESTRA_GOOGLE_REDIRECT_URI")
-        .unwrap_or_else(|_| "http://localhost:3000/auth/google/callback".to_string());
+        .unwrap_or_else(|_| format!("http://localhost:{port}/auth/callback/google"));
 
-    let mut google_provider = GoogleProvider::new(client_id, client_secret, redirect_uri);
-    // Support E2E tests pointing to a local mock server
-    if let Ok(base_url) = std::env::var("AUTHKESTRA_GOOGLE_BASE_URL") {
-        let api_url =
-            std::env::var("AUTHKESTRA_GOOGLE_API_URL").unwrap_or_else(|_| base_url.clone());
-        google_provider = google_provider.with_test_urls(
-            format!("{base_url}/login/oauth/authorize"),
-            format!("{base_url}/login/oauth/access_token"),
-            format!("{api_url}/user"),
-        );
-    }
+    let google_provider = google_provider(client_id, client_secret, redirect_uri);
 
-    // Session Store
-    // TIP: authkestra uses traits (like `SessionStore`) for storage.
-    // This makes it easy to swap out backends! You could easily replace `MemoryStore`
-    // with `SqlKvStore` or `RedisStore` simply by changing the struct instantiated here.
-    let session_store: Arc<dyn SessionStore> =
-        Arc::new(authkestra_engine::store::memory::MemoryStore::default());
+    // `SessionStore` is a trait: swap `MemoryStore` for `RedisStore` or
+    // `SqlKvStore` without touching anything below this line.
+    let session_store: Arc<dyn SessionStore> = Arc::new(MemoryStore::default());
 
-    let authkestra = Engine::builder()
+    let engine = Engine::builder()
         .provider(OAuth2Flow::new(google_provider))
         .session_store(session_store)
         .session_config(SessionConfig {
-            secure: false,
+            secure: false, // plain HTTP for local development
             ..Default::default()
         })
         .build();
 
-    let state = AppState {
-        auth: authkestra.clone(),
-    };
+    let state = AppState { auth: engine };
 
-    println!("🚀 Actix Google OIDC running on http://localhost:3000");
+    tracing::info!(%port, "Actix Google OIDC listening on http://localhost:{port}");
+    tracing::info!("start the flow at http://localhost:{port}/auth/login/google");
 
     HttpServer::new(move || {
         let app_state = state.clone();
@@ -85,26 +77,75 @@ async fn main() -> std::io::Result<()> {
             .app_data(web::Data::new(app_state.clone()))
             .configure(move |cfg| config_state.configure_authkestra(cfg))
             .service(get_user)
+            .service(list_providers)
             .service(app_state.auth.actix_scope())
             .service(
                 Files::new("/", concat!(env!("CARGO_MANIFEST_DIR"), "/examples/static"))
                     .index_file("index.html"),
             )
     })
-    .bind(("0.0.0.0", 3000))?
+    .bind(("0.0.0.0", port))?
     .run()
     .await
 }
 
+/// Builds the provider, redirecting to a mock server when the e2e harness has
+/// set `AUTHKESTRA_GOOGLE_BASE_URL`. Real deployments never set these.
+fn google_provider(
+    client_id: String,
+    client_secret: String,
+    redirect_uri: String,
+) -> GoogleProvider {
+    let provider = GoogleProvider::new(client_id, client_secret, redirect_uri);
+    match std::env::var("AUTHKESTRA_GOOGLE_BASE_URL") {
+        Ok(base_url) => {
+            let api_url =
+                std::env::var("AUTHKESTRA_GOOGLE_API_URL").unwrap_or_else(|_| base_url.clone());
+            tracing::warn!(%base_url, "using overridden Google endpoints (test mode)");
+            provider.with_test_urls(
+                format!("{base_url}/login/oauth/authorize"),
+                format!("{base_url}/login/oauth/access_token"),
+                format!("{api_url}/user"),
+            )
+        }
+        Err(_) => provider,
+    }
+}
+
+/// Returns the session identity, or 401 when there is no valid session.
 #[get("/api/user")]
 async fn get_user(session: Option<AuthSession>) -> impl Responder {
     match session {
-        Some(AuthSession(session)) => HttpResponse::Ok().json(json!({
-            "id": session.identity.external_id,
-            "username": session.identity.username,
-            "email": session.identity.email,
-            "provider": session.identity.provider_id,
-        })),
-        None => HttpResponse::Unauthorized().json(json!({ "error": "Not authenticated" })),
+        Some(AuthSession(session)) => {
+            tracing::debug!(user = %session.identity.external_id, "session resolved");
+            HttpResponse::Ok().json(json!({
+                "id": session.identity.external_id,
+                "username": session.identity.username,
+                "email": session.identity.email,
+                "provider": session.identity.provider_id,
+            }))
+        }
+        None => {
+            tracing::debug!("no valid session on request");
+            HttpResponse::Unauthorized().json(json!({ "error": "Not authenticated" }))
+        }
     }
+}
+
+/// Lists the registered OAuth providers so the bundled static page can render
+/// a login button per provider.
+#[get("/api/providers")]
+async fn list_providers(state: web::Data<AppState>) -> impl Responder {
+    let providers: Vec<&String> = state.auth.providers.keys().collect();
+    HttpResponse::Ok().json(json!({ "providers": providers }))
+}
+
+/// Bind port, overridable via `PORT` so several examples (and the e2e test
+/// harness, which passes a port it has already confirmed to be free) can run
+/// without colliding on 3000.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000)
 }

--- a/crates/authkestra/examples/actix_op_server.rs
+++ b/crates/authkestra/examples/actix_op_server.rs
@@ -6,20 +6,30 @@
 //! To run this example, you'll need:
 //! - A running Redis instance
 //! - `REDIS_URL` environment variable (e.g., `redis://127.0.0.1/`)
-use authkestra_engine::store::KvStore;
-
+//!
+//! ```sh
+//! REDIS_URL=redis://127.0.0.1/ \
+//!   cargo run -p authkestra --example actix_op_server --all-features
+//! ```
+//!
+//! Set `PORT` to bind somewhere other than 8080; `issuer` follows it, because
+//! relying parties resolve `/.well-known/openid-configuration` against the
+//! issuer URL and a mismatch breaks discovery.
 use actix_web::{App, HttpServer};
 use authkestra_actix::{ActixState, OpExt};
-use authkestra_engine::flow::Engine;
 use authkestra_engine::store::redis::RedisStore;
-use authkestra_engine::{SessionConfig, TokenManager};
+use authkestra_engine::store::KvStore;
+use authkestra_engine::{AkEngine, Engine, SessionConfig, SessionStore, TokenManager};
 use authkestra_op::{client::ClientRegistration, config::OpConfig};
 use std::sync::Arc;
 
+/// `AkEngine` is the alias for an engine with *both* a session store and a
+/// token manager — an OP needs the session to authenticate the end user at
+/// `/authorize` and the token manager to sign what it hands back.
 #[derive(Clone, ActixState)]
 struct AppState {
     #[authkestra(engine)]
-    auth: authkestra_engine::AkEngine,
+    auth: AkEngine,
 
     #[authkestra(store)]
     op_store: Arc<dyn authkestra_op::OpStore>,
@@ -30,12 +40,24 @@ struct AppState {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
+
     dotenvy::dotenv().ok();
+    let port = port_from_env();
+    let issuer = format!("http://localhost:{port}");
     let redis_url = std::env::var("REDIS_URL").expect("REDIS_URL must be set");
 
+    // The token manager's `iss` claim must equal `OpConfig::issuer` below, or
+    // relying parties will reject every id_token this OP mints.
     let token_manager = Arc::new(TokenManager::new(
         b"my-super-secret-key-that-is-32bytes-long",
-        Some("issuer".to_string()),
+        Some(issuer.clone()),
     ));
 
     // Open a single Redis client and share it across all stores via different key prefixes.
@@ -49,6 +71,8 @@ async fn main() -> std::io::Result<()> {
             ClientRegistration {
                 client_id: "test-client".to_string(),
                 client_secret_hash: None,
+                // The RP's callback, not this server's — an OP redirects back
+                // to the client application.
                 redirect_uris: vec!["http://localhost:3000/callback".to_string()],
                 require_pkce: true,
                 scopes: vec!["openid".to_string(), "profile".to_string()],
@@ -74,9 +98,10 @@ async fn main() -> std::io::Result<()> {
             device_codes,
         ));
 
-    let session_store: Arc<dyn authkestra_engine::auth::SessionStore> = Arc::new(
-        RedisStore::with_client(redis_client, "engine_session".into()),
-    );
+    let session_store: Arc<dyn SessionStore> = Arc::new(RedisStore::with_client(
+        redis_client,
+        "engine_session".into(),
+    ));
 
     let session_config = SessionConfig {
         cookie_name: "authkestra_sid".to_string(),
@@ -93,7 +118,7 @@ async fn main() -> std::io::Result<()> {
         auth,
         op_store,
         config: OpConfig {
-            issuer: "http://localhost:3000".to_string(),
+            issuer: issuer.clone(),
             scopes_supported: vec![
                 "openid".to_string(),
                 "profile".to_string(),
@@ -109,7 +134,9 @@ async fn main() -> std::io::Result<()> {
         },
     };
 
-    println!("🚀 Actix OP Server running on http://localhost:8080");
+    tracing::info!(%issuer, "Actix OP server listening on {issuer}");
+    tracing::info!("discovery: {issuer}/.well-known/openid-configuration");
+
     HttpServer::new(move || {
         let s = state.clone();
         let s2 = s.clone();
@@ -118,7 +145,16 @@ async fn main() -> std::io::Result<()> {
             .configure(move |cfg| s.configure_authkestra(cfg))
             .service(s2.op_actix_scope())
     })
-    .bind("0.0.0.0:8080")?
+    .bind(("0.0.0.0", port))?
     .run()
     .await
+}
+
+/// Bind port, overridable via `PORT`. Defaults to 8080 so an OP and a relying
+/// party (which the other examples run on 3000) can be started side by side.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(8080)
 }

--- a/crates/authkestra/examples/actix_op_server.rs
+++ b/crates/authkestra/examples/actix_op_server.rs
@@ -72,8 +72,10 @@ async fn main() -> std::io::Result<()> {
                 client_id: "test-client".to_string(),
                 client_secret_hash: None,
                 // The RP's callback, not this server's — an OP redirects back
-                // to the client application.
-                redirect_uris: vec!["http://localhost:3000/callback".to_string()],
+                // to the client application. This is the path the sibling RP
+                // examples actually serve (`/auth/callback/{provider}`), so the
+                // OP on :8080 and an RP on :3000 compose without editing either.
+                redirect_uris: vec!["http://localhost:3000/auth/callback/github".to_string()],
                 require_pkce: true,
                 scopes: vec!["openid".to_string(), "profile".to_string()],
                 grant_types: vec![authkestra_op::client::GrantType::AuthorizationCode],

--- a/crates/authkestra/examples/actix_op_server_custom_grant.rs
+++ b/crates/authkestra/examples/actix_op_server_custom_grant.rs
@@ -218,7 +218,7 @@ async fn main() -> std::io::Result<()> {
             ClientRegistration {
                 client_id: "test-client".to_string(),
                 client_secret_hash: None,
-                redirect_uris: vec!["http://localhost:3000/callback".to_string()],
+                redirect_uris: vec!["http://localhost:3000/auth/callback/github".to_string()],
                 require_pkce: true,
                 scopes: vec!["openid".to_string(), "profile".to_string()],
                 grant_types: vec![

--- a/crates/authkestra/examples/actix_op_server_custom_grant.rs
+++ b/crates/authkestra/examples/actix_op_server_custom_grant.rs
@@ -193,9 +193,22 @@ impl<
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
+
+    let port = port_from_env();
+    let issuer = format!("http://localhost:{port}");
+
+    // The token manager's `iss` claim must equal `OpConfig::issuer` below, or
+    // relying parties will reject every id_token this OP mints.
     let token_manager = Arc::new(TokenManager::new(
         b"my-super-secret-key-that-is-32bytes-long",
-        Some("issuer".to_string()),
+        Some(issuer.clone()),
     ));
 
     let clients = MemoryStore::new();
@@ -235,7 +248,7 @@ async fn main() -> std::io::Result<()> {
     });
 
     let config = OpConfig {
-        issuer: "http://localhost:8080".to_string(),
+        issuer: issuer.clone(),
         scopes_supported: vec![
             "openid".to_string(),
             "profile".to_string(),
@@ -269,7 +282,8 @@ async fn main() -> std::io::Result<()> {
         op_store,
         config,
     };
-    println!("🚀 Actix OP Server running on http://localhost:8080");
+    tracing::info!(%issuer, "Actix OP server (custom grant) listening on {issuer}");
+    tracing::info!("custom grant_type: urn:example:custom");
     HttpServer::new(move || {
         let state = app_state.clone();
         let config_state = state.clone();
@@ -278,7 +292,16 @@ async fn main() -> std::io::Result<()> {
             .configure(move |cfg| config_state.configure_authkestra(cfg))
             .service(state.op_actix_scope())
     })
-    .bind("0.0.0.0:8080")?
+    .bind(("0.0.0.0", port))?
     .run()
     .await
+}
+
+/// Bind port, overridable via `PORT`. Defaults to 8080 so an OP and a relying
+/// party (which the other examples run on 3000) can be started side by side.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(8080)
 }

--- a/crates/authkestra/examples/actix_op_server_sqlx.rs
+++ b/crates/authkestra/examples/actix_op_server_sqlx.rs
@@ -79,7 +79,7 @@ async fn main() -> std::io::Result<()> {
     .bind("test-client")
     .bind(None::<String>)
     .bind(true)
-    .bind(sqlx::types::Json(vec!["http://localhost:3000/callback"]))
+    .bind(sqlx::types::Json(vec!["http://localhost:3000/auth/callback/github"]))
     .bind(sqlx::types::Json(vec!["authorization_code"]))
     .bind(sqlx::types::Json(vec!["openid", "profile"]))
     .bind(sqlx::types::Json(Vec::<String>::new()))

--- a/crates/authkestra/examples/actix_op_server_sqlx.rs
+++ b/crates/authkestra/examples/actix_op_server_sqlx.rs
@@ -2,10 +2,22 @@
 //!
 //! This example demonstrates setting up an OpenID Connect Provider using authkestra-op and Actix.
 //! It uses the batteries-included `SqlxOpStore` for a production-ready relational database schema.
+//!
+//! Unlike `actix_op_server.rs` (which composes four `KvStore`s), `SqlxOpStore`
+//! is a single normalised schema with foreign keys and `ON DELETE CASCADE` —
+//! prefer it for OP data; `SqlKvStore` is deprecated for this purpose.
+//!
+//! ```sh
+//! cargo run -p authkestra --example actix_op_server_sqlx --all-features
+//! ```
+//!
+//! Set `PORT` to bind somewhere other than 8080; `issuer` follows it, because
+//! relying parties resolve `/.well-known/openid-configuration` against the
+//! issuer URL and a mismatch breaks discovery.
 use actix_web::{App, HttpServer};
 use authkestra_actix::{ActixState, OpExt};
-use authkestra_engine::flow::Engine;
-use authkestra_engine::TokenManager;
+use authkestra_engine::store::memory::MemoryStore;
+use authkestra_engine::{AkEngine, Engine, SessionConfig, SessionStore, TokenManager};
 use authkestra_op::config::OpConfig;
 use authkestra_op::sqlx_store::SqlxOpStore;
 use sqlx::sqlite::SqlitePoolOptions;
@@ -14,7 +26,7 @@ use std::sync::Arc;
 #[derive(Clone, ActixState)]
 struct AppState {
     #[authkestra(engine)]
-    auth: authkestra_engine::AkEngine,
+    auth: AkEngine,
 
     #[authkestra(store)]
     op_store: Arc<dyn authkestra_op::OpStore>,
@@ -25,9 +37,22 @@ struct AppState {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
+
+    let port = port_from_env();
+    let issuer = format!("http://localhost:{port}");
+
+    // The token manager's `iss` claim must equal `OpConfig::issuer` below, or
+    // relying parties will reject every id_token this OP mints.
     let token_manager = Arc::new(TokenManager::new(
         b"my-super-secret-key-that-is-32bytes-long",
-        Some("issuer".to_string()),
+        Some(issuer.clone()),
     ));
 
     // Create a SQLite connection pool (in-memory for the example, but can be a file path)
@@ -43,7 +68,10 @@ async fn main() -> std::io::Result<()> {
     // Automatically run schema migrations to create the required tables
     sqlx_store.migrate().await.unwrap();
 
-    // Seed a dummy OAuth client directly using sqlx
+    // Seed a demo OAuth client. `ClientStore` is read-only by design —
+    // registration is the deployment's business — so the example writes the
+    // row directly. `redirect_uris` is the *relying party's* callback, not
+    // this server's.
     sqlx::query(
         "INSERT INTO authkestra_oauth_clients (client_id, client_secret_hash, require_pkce, redirect_uris, grant_types, scopes, allowed_audiences) 
          VALUES (?, ?, ?, ?, ?, ?, ?)"
@@ -62,7 +90,7 @@ async fn main() -> std::io::Result<()> {
     let op_store: Arc<dyn authkestra_op::OpStore> = Arc::new(sqlx_store);
 
     let config = OpConfig {
-        issuer: "http://localhost:8080".to_string(),
+        issuer: issuer.clone(),
         scopes_supported: vec![
             "openid".to_string(),
             "profile".to_string(),
@@ -77,11 +105,13 @@ async fn main() -> std::io::Result<()> {
         token_exchange_enabled: true,
     };
 
+    // Only the OP data lives in SQL here; the end-user login session can use
+    // any `SessionStore`, so the example keeps that part dependency-free.
+    let session_store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+
     let auth = Engine::builder()
-        .session_store(Arc::new(
-            authkestra_engine::store::memory::MemoryStore::new(),
-        ))
-        .session_config(authkestra_engine::SessionConfig {
+        .session_store(session_store)
+        .session_config(SessionConfig {
             cookie_name: "authkestra_sid".to_string(),
             ..Default::default()
         })
@@ -93,7 +123,10 @@ async fn main() -> std::io::Result<()> {
         op_store,
         config,
     };
-    println!("🚀 Actix OP Server running on http://localhost:8080");
+
+    tracing::info!(%issuer, "Actix OP server (SqlxOpStore) listening on {issuer}");
+    tracing::info!("discovery: {issuer}/.well-known/openid-configuration");
+
     HttpServer::new(move || {
         let state = app_state.clone();
         let config_state = state.clone();
@@ -102,7 +135,16 @@ async fn main() -> std::io::Result<()> {
             .configure(move |cfg| config_state.configure_authkestra(cfg))
             .service(state.op_actix_scope())
     })
-    .bind("0.0.0.0:8080")?
+    .bind(("0.0.0.0", port))?
     .run()
     .await
+}
+
+/// Bind port, overridable via `PORT`. Defaults to 8080 so an OP and a relying
+/// party (which the other examples run on 3000) can be started side by side.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(8080)
 }

--- a/crates/authkestra/examples/actix_resource_server_strategy.rs
+++ b/crates/authkestra/examples/actix_resource_server_strategy.rs
@@ -1,7 +1,13 @@
-//! # Actix Resource Server Strategy Example
+//! # Actix resource server — `Guard` strategy (preferred)
 //!
-//! This example demonstrates how to use the Resource Server strategy with `Guard`
-//! and the `Auth` extractor to protect an API.
+//! Validates bearer tokens issued by *someone else* (any OIDC provider). This
+//! is the recommended shape: a [`Guard`] owns one or more strategies, and the
+//! `Auth<T>` extractor asks the guard rather than reaching for JWT internals.
+//!
+//! ```sh
+//! OIDC_ISSUER=https://accounts.google.com \
+//!   cargo run -p authkestra --example actix_resource_server_strategy --all-features
+//! ```
 
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
 use authkestra_actix::{ActixState, Auth};
@@ -27,6 +33,14 @@ struct AppState {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
+
     dotenvy::dotenv().ok();
 
     // 1. Configure the JWT Strategy
@@ -47,7 +61,8 @@ async fn main() -> std::io::Result<()> {
         guard: Arc::new(guard),
     };
 
-    println!("📡 Resource Server Strategy listening on http://0.0.0.0:3000");
+    let port = port_from_env();
+    tracing::info!(%port, "Actix resource server (Guard strategy) listening on http://localhost:{port}");
 
     HttpServer::new(move || {
         let app_state = state.clone();
@@ -56,9 +71,18 @@ async fn main() -> std::io::Result<()> {
             .service(index)
             .service(protected)
     })
-    .bind(("0.0.0.0", 3000))?
+    .bind(("0.0.0.0", port))?
     .run()
     .await
+}
+
+/// Bind port, overridable via `PORT` so several examples can run without
+/// colliding on 3000.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000)
 }
 
 #[get("/")]
@@ -72,12 +96,18 @@ async fn index() -> impl Responder {
 #[get("/api/protected")]
 async fn protected(auth: Option<Auth<UserIdentity>>) -> impl Responder {
     match auth {
-        Some(Auth(user)) => HttpResponse::Ok().json(json!({
-            "message": "Access granted via Resource Server Strategy!",
-            "user": user,
-        })),
-        None => HttpResponse::Unauthorized().json(json!({
-            "error": "Authentication failed or token missing/invalid",
-        })),
+        Some(Auth(user)) => {
+            tracing::debug!(sub = %user.sub, "bearer token accepted by guard");
+            HttpResponse::Ok().json(json!({
+                "message": "Access granted via Resource Server Strategy!",
+                "user": user,
+            }))
+        }
+        None => {
+            tracing::debug!("bearer token missing or rejected by guard");
+            HttpResponse::Unauthorized().json(json!({
+                "error": "Authentication failed or token missing/invalid",
+            }))
+        }
     }
 }

--- a/crates/authkestra/examples/axum_basic_setup.rs
+++ b/crates/authkestra/examples/axum_basic_setup.rs
@@ -1,13 +1,25 @@
-//! # Axum Basic Setup Example
+//! # Axum Basic Setup — the smallest useful `Engine`
 //!
-//! This example demonstrates the most basic setup of Engine with Axum.
-//! It uses an in-memory session store and a mock authentication provider.
+//! The "golden path" starting point (RFC-001): build an [`Engine`] with
+//! [`Engine::builder()`], hand it a [`SessionStore`], and let
+//! [`AxumExt::axum_router`] wire the `/auth/*` routes for you.
+//!
+//! No OAuth provider is registered here on purpose — this example is about the
+//! *session* half of the engine. See `axum_oauth2_github.rs` for the same
+//! wiring with a provider attached.
+//!
+//! ```sh
+//! cargo run -p authkestra --example axum_basic_setup --all-features
+//! ```
+//!
+//! Set `PORT` to bind somewhere other than 3000.
 
 use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
-use authkestra_engine::auth::SessionStore;
-use authkestra_engine::flow::Engine;
-use authkestra_engine::{AkWebAppEngine, SessionConfig};
+use authkestra_engine::store::memory::MemoryStore;
+use authkestra_engine::{AkWebAppEngine, Engine, SessionConfig, SessionStore};
 use axum::{
+    extract::State,
+    http::StatusCode,
     response::{IntoResponse, Json},
     routing::get,
     Router,
@@ -17,7 +29,9 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// Engine state with support for session only.
+/// `AkWebAppEngine` is the alias for a session-configured engine. Using the
+/// alias (rather than spelling out the typestate generics) keeps the compile
+/// error legible when a required builder call is missing.
 #[derive(Clone, AxumState)]
 struct AppState {
     #[authkestra(engine)]
@@ -26,48 +40,97 @@ struct AppState {
 
 #[tokio::main]
 async fn main() {
-    // Session Store
-    let session_store: Arc<dyn SessionStore> =
-        Arc::new(authkestra_engine::store::memory::MemoryStore::default());
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
 
-    let authkestra = Engine::builder()
+    // 1. Pick a storage backend. `SessionStore` is a trait, so swapping
+    //    `MemoryStore` for `RedisStore` or `SqlKvStore` is a one-line change
+    //    (see `axum_session_redis.rs` / `axum_sql_store.rs`).
+    let session_store: Arc<dyn SessionStore> = Arc::new(MemoryStore::default());
+
+    // 2. Build the engine. The typestate builder only exposes session APIs
+    //    once `session_store` has been supplied.
+    let engine = Engine::builder()
         .session_store(session_store)
         .session_config(SessionConfig {
-            secure: false, // For local development
+            secure: false, // plain HTTP for local development
             ..Default::default()
         })
         .build();
 
     let state = AppState {
-        auth: authkestra.clone(),
+        auth: engine.clone(),
     };
 
+    // 3. Merge the engine's routes into your own router.
     let app = Router::new()
-        // Serve static files from the 'static' directory
+        .route("/api/user", get(get_user))
+        .route("/api/providers", get(list_providers))
+        .merge(engine.axum_router())
         .fallback_service(ServeDir::new(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/examples/static"
         )))
-        // API for checking current user status
-        .route("/api/user", get(get_user))
-        .merge(authkestra.axum_router())
+        // The engine reads and writes cookies, so the cookie layer must wrap
+        // the merged routes.
         .layer(CookieManagerLayer::new())
         .with_state(state);
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-    println!("🚀 Axum Basic Setup running on http://localhost:3000");
+    let port = port_from_env();
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port))
+        .await
+        .expect("failed to bind example server");
+
+    tracing::info!(%port, "Axum basic setup listening on http://localhost:{port}");
     axum::serve(listener, app).await.unwrap();
 }
 
-/// API endpoint to get current user info from session
+/// Returns the session identity, or 401 when there is no valid session.
+///
+/// Returning a real 401 (rather than a 200 carrying an `error` field) is what
+/// lets `examples/static/index.html` tell the two states apart.
 async fn get_user(session: Result<AuthSession, AxumError>) -> impl IntoResponse {
     match session {
-        Ok(AuthSession(session)) => Json(json!({
-            "id": session.identity.external_id,
-            "username": session.identity.username,
-            "email": session.identity.email,
-            "provider": session.identity.provider_id,
-        })),
-        Err(_) => Json(json!({ "error": "Not authenticated" })),
+        Ok(AuthSession(session)) => {
+            tracing::debug!(user = %session.identity.external_id, "session resolved");
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "id": session.identity.external_id,
+                    "username": session.identity.username,
+                    "email": session.identity.email,
+                    "provider": session.identity.provider_id,
+                })),
+            )
+        }
+        Err(err) => {
+            tracing::debug!(%err, "no valid session on request");
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "Not authenticated" })),
+            )
+        }
     }
+}
+
+/// Lists the OAuth providers registered on the engine so the bundled static
+/// page can render one login button per provider. Empty for this example.
+async fn list_providers(State(state): State<AppState>) -> impl IntoResponse {
+    let providers: Vec<&String> = state.auth.providers.keys().collect();
+    Json(json!({ "providers": providers }))
+}
+
+/// Bind port, overridable via `PORT` so several examples (and the e2e test
+/// harness, which passes a port it has already confirmed to be free) can run
+/// without colliding on 3000.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000)
 }

--- a/crates/authkestra/examples/axum_data_layer_macros.rs
+++ b/crates/authkestra/examples/axum_data_layer_macros.rs
@@ -1,59 +1,83 @@
+// The derive delegates to `SqlKvStore`, which is deprecated *for OP-specific
+// data* but remains the supported choice for generic KV/session storage — the
+// only thing it is used for here. The attribute cannot distinguish the two.
 #![allow(deprecated)]
-//! # Axum Data Layer Macros Example
+//! # Axum + the `KvStore` derive macro
 //!
-//! This example demonstrates how to use the `KvStore`
-//! derive macro to eliminate SQL boilerplate.
+//! Same engine wiring as `axum_sql_store.rs`, but the session store is your
+//! own newtype rather than authkestra's. `#[derive(KvStore)]` generates the
+//! whole data-layer trait impl by delegating to the wrapped store, so a
+//! custom store costs one line instead of a screen of boilerplate.
 //!
-//! By wrapping a `sqlx::Pool` in a tuple struct and decorating it with the macros,
-//! it automatically generates the implementations for the data layer traits by delegating
-//! to the internal unified `SqlKvStore`.
+//! Use this when you want your own type (for a custom table name, extra
+//! instrumentation, or a differently-shaped backend) without reimplementing
+//! [`SessionStore`] by hand.
+//!
+//! ```sh
+//! cargo run -p authkestra --example axum_data_layer_macros --all-features
+//! ```
+//!
+//! Set `PORT` to bind somewhere other than 3000.
 
-use authkestra_axum::{AxumExt, AxumState};
-use authkestra_engine::auth::SessionStore;
-use authkestra_engine::flow::Engine;
-use authkestra_engine::SessionConfig;
+use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
+use authkestra_engine::store::sql::SqlKvStore;
+use authkestra_engine::{AkWebAppEngine, Engine, SessionConfig, SessionStore};
 use authkestra_macros::KvStore;
-use axum::Router;
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Json},
+    routing::get,
+    Router,
+};
+use serde_json::json;
 use sqlx::sqlite::SqlitePoolOptions;
 use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
 // ============================================================================
-// 1. Zero-Boilerplate Data Layer
+// 1. Zero-boilerplate data layer
 // ============================================================================
 
-/// A custom session store derived via macro, wrapping an existing KvStore implementation.
-/// The macro delegates all KvStore methods to the internal `SqlKvStore`.
+/// A custom session store. The derive forwards every `KvStore` method to the
+/// wrapped `SqlKvStore`, and the blanket impl in `authkestra-engine` turns any
+/// `KvStore` into a [`SessionStore`].
 #[derive(KvStore)]
-pub struct MySqliteSessionStore(authkestra_engine::store::sql::SqlKvStore<sqlx::Sqlite>);
+pub struct MySqliteSessionStore(SqlKvStore<sqlx::Sqlite>);
 
 // ============================================================================
-// 2. Zero-Boilerplate Application State Extraction
+// 2. Zero-boilerplate state extraction
 // ============================================================================
 
-/// The State macro generates all the axum FromRef implementations.
+/// `AxumState` generates the `FromRef` impls the extractors need.
 #[derive(Clone, AxumState)]
 struct AppState {
-    // Automatically extracts SessionStore and SessionConfig
     #[authkestra(engine)]
-    auth: authkestra_engine::AkWebAppEngine,
+    auth: AkWebAppEngine,
 }
 
 // ============================================================================
-// 3. Application Setup
+// 3. Application setup
 // ============================================================================
 
 #[tokio::main]
 async fn main() {
-    // Initialize an in-memory database
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
+
     let pool = SqlitePoolOptions::new()
         .connect("sqlite::memory:")
         .await
-        .expect("Failed to connect to SQLite");
+        .expect("failed to connect to SQLite");
 
-    // Because the derive macro uses the internal `SqlKvStore` implementation,
-    // we must ensure the schema exists.
+    // This example picks a non-default table name to show that the newtype
+    // controls the schema, so it creates the table itself rather than calling
+    // `SqlKvStore::migrate()` (which targets `authkestra_kv`).
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS user_sessions (
             key TEXT PRIMARY KEY,
@@ -63,39 +87,78 @@ async fn main() {
     )
     .execute(&pool)
     .await
-    .unwrap();
+    .expect("failed to create session table");
 
-    // Initialize our generated stores
-    let sql_store = authkestra_engine::store::sql::SqlKvStore::with_table_name(
+    let session_store = MySqliteSessionStore(SqlKvStore::with_table_name(
         pool,
         "user_sessions".to_string(),
-    );
-    let session_store = MySqliteSessionStore(sql_store);
+    ));
+    let session_store: Arc<dyn SessionStore> = Arc::new(session_store);
 
-    let session_store_arc: Arc<dyn SessionStore> = Arc::new(session_store);
-
-    let authkestra = Engine::builder()
-        .session_store(session_store_arc)
+    let engine = Engine::builder()
+        .session_store(session_store)
         .session_config(SessionConfig {
-            secure: false,
+            secure: false, // plain HTTP for local development
             ..Default::default()
         })
         .build();
 
     let state = AppState {
-        auth: authkestra.clone(),
+        auth: engine.clone(),
     };
 
     let app = Router::new()
+        .route("/api/user", get(get_user))
+        .merge(engine.axum_router::<AppState>())
         .fallback_service(ServeDir::new(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/examples/static"
         )))
-        .merge(authkestra.axum_router::<AppState>())
         .layer(CookieManagerLayer::new())
         .with_state(state);
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-    println!("🚀 Axum Data Layer Macros Example running on http://localhost:3000");
+    let port = port_from_env();
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port))
+        .await
+        .expect("failed to bind example server");
+
+    tracing::info!(%port, "Axum data-layer macros example listening on http://localhost:{port}");
     axum::serve(listener, app).await.unwrap();
+}
+
+/// Returns the session identity, or 401 when there is no valid session.
+///
+/// Present so the bundled static page has an endpoint to poll — it also proves
+/// the derived store round-trips a session.
+async fn get_user(session: Result<AuthSession, AxumError>) -> impl IntoResponse {
+    match session {
+        Ok(AuthSession(session)) => {
+            tracing::debug!(user = %session.identity.external_id, "session resolved from derived store");
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "id": session.identity.external_id,
+                    "username": session.identity.username,
+                    "email": session.identity.email,
+                    "provider": session.identity.provider_id,
+                })),
+            )
+        }
+        Err(err) => {
+            tracing::debug!(%err, "no valid session on request");
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "Not authenticated" })),
+            )
+        }
+    }
+}
+
+/// Bind port, overridable via `PORT` so several examples can run without
+/// colliding on 3000.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000)
 }

--- a/crates/authkestra/examples/axum_mfa_server.rs
+++ b/crates/authkestra/examples/axum_mfa_server.rs
@@ -1,12 +1,36 @@
-use authkestra_engine::auth::{totp::TotpAuthMethod, webauthn::WebAuthnAuthMethod};
-use authkestra_engine::auth::{AuthInput, AuthResult, CredentialStore};
-use authkestra_engine::engine::Engine;
-use axum::{routing::post, Json, Router};
+//! # Axum + multi-factor authentication
+//!
+//! Where the OAuth examples plug *providers* into [`Engine::builder`], this one
+//! plugs in *auth methods*: the same unified engine drives first-factor and
+//! step-up authentication through one call, [`Engine::authenticate`].
+//!
+//! The return type is the whole design. `AuthResult::MfaRequired` is a value
+//! your handler must deal with, not an error — so "we forgot to challenge for
+//! the second factor" is not a reachable state.
+//!
+//! `with_auth_method` registers a first factor; `with_mfa_method` registers a
+//! method usable *only* to satisfy a step-up challenge. Both delegate to the
+//! same [`AuthMethod`] plugin interface, so a custom factor drops in the same
+//! way the built-in TOTP and WebAuthn ones do.
+//!
+//! ```sh
+//! cargo run -p authkestra --example axum_mfa_server --all-features
+//! ```
+//!
+//! Set `PORT` to bind somewhere other than 3000.
+
+use authkestra_engine::auth::{AuthError, AuthInput, AuthResult, CredentialStore};
+use authkestra_engine::Engine;
+use axum::{extract::State, routing::post, Json, Router};
 use std::sync::Arc;
 use url::Url;
 use webauthn_rs::prelude::WebauthnBuilder;
 
-/// A simple in-memory credential store for the example.
+/// A stub credential store so the example needs no database.
+///
+/// It reports no enrolled credentials, which is enough to exercise the
+/// `MfaRequired` branch below; a real implementation would persist these via
+/// whatever backend you already use (see `authkestra_engine::store`).
 #[derive(Clone, Default)]
 struct MemoryCredentialStore;
 
@@ -16,8 +40,8 @@ impl CredentialStore for MemoryCredentialStore {
         &self,
         _user_id: &str,
         _cred_type: &str,
-    ) -> Result<Vec<serde_json::Value>, authkestra_engine::auth::AuthError> {
-        Ok(vec![]) // Simulate no credentials for the example
+    ) -> Result<Vec<serde_json::Value>, AuthError> {
+        Ok(vec![])
     }
 
     async fn save_credential(
@@ -25,7 +49,7 @@ impl CredentialStore for MemoryCredentialStore {
         _user_id: &str,
         _cred_type: &str,
         _data: serde_json::Value,
-    ) -> Result<(), authkestra_engine::auth::AuthError> {
+    ) -> Result<(), AuthError> {
         Ok(())
     }
 
@@ -33,100 +57,133 @@ impl CredentialStore for MemoryCredentialStore {
         &self,
         _credential_id: &str,
         _data: serde_json::Value,
-    ) -> Result<(), authkestra_engine::auth::AuthError> {
+    ) -> Result<(), AuthError> {
         Ok(())
     }
 }
 
-// Shared App State
+/// No session store and no token manager: this example stops at "who are
+/// you?", so the engine stays in its default `Missing`/`Missing` typestate.
+/// Issuing a session or a JWT afterwards is what the other examples cover.
+#[derive(Clone)]
 struct AppState {
-    engine: Engine, // Using stateless engine for this example
+    engine: Engine,
 }
 
 #[tokio::main]
 async fn main() {
-    // 1. Setup Data Store
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
+
+    let port = port_from_env();
     let store = MemoryCredentialStore;
 
-    // 2. Setup WebAuthn
-    let rp_id = "localhost";
-    let origin = Url::parse("http://localhost:3000").unwrap();
-    let webauthn = WebauthnBuilder::new(rp_id, &origin)
-        .unwrap()
-        .rp_name("Engine MFA Demo")
+    // The relying-party origin must match the URL the browser actually uses,
+    // so it follows `PORT` too.
+    let origin = Url::parse(&format!("http://localhost:{port}")).expect("valid origin URL");
+    let webauthn = WebauthnBuilder::new("localhost", &origin)
+        .expect("valid relying party")
+        .rp_name("Authkestra MFA Demo")
         .build()
-        .unwrap();
+        .expect("valid WebAuthn configuration");
 
-    // 3. Build Unified Engine
+    // `with_totp` / `with_webauthn` are the shorthands for the built-in
+    // methods; both are thin wrappers over `with_auth_method`, so a custom
+    // `AuthMethod` registers exactly the same way.
     let engine = Engine::builder()
-        .with_mfa_method(TotpAuthMethod::new(store.clone()))
-        .with_auth_method(WebAuthnAuthMethod::new(Arc::new(webauthn), store.clone()))
-        // In a real app, you would also add a password AuthMethod here
+        .with_webauthn(Arc::new(webauthn), store.clone())
+        // TOTP is registered as step-up only: it cannot be used as a first
+        // factor on its own, only to answer an `MfaRequired` challenge.
+        .with_mfa_method(authkestra_engine::auth::totp::TotpAuthMethod::new(store))
+        // A real app would also register a password method here.
         .build();
 
-    let state = Arc::new(AppState { engine });
-
-    // 4. Create Axum Router
     let app = Router::new()
         .route("/login", post(login_handler))
         .route("/mfa-verify", post(mfa_verify_handler))
-        .with_state(state);
+        .with_state(AppState { engine });
 
-    println!("Starting server on http://localhost:3000");
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port))
+        .await
+        .expect("failed to bind example server");
+
+    tracing::info!(%port, "Axum MFA server listening on http://localhost:{port}");
     axum::serve(listener, app).await.unwrap();
 }
 
-/// The unified login endpoint.
+/// First-factor login. Returns either a completed identity or an MFA challenge.
 async fn login_handler(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
+    State(state): State<AppState>,
     Json(input): Json<AuthInput>,
 ) -> Json<serde_json::Value> {
     match state.engine.authenticate(input).await {
         Ok(AuthResult::Success(identity)) => {
-            // Give them a session/token!
-            Json(serde_json::json!({
-                "status": "success",
-                "identity": identity,
-            }))
+            tracing::info!(user = %identity.external_id, "first factor sufficient");
+            // A real app would mint a session or JWT here.
+            Json(serde_json::json!({ "status": "success", "identity": identity }))
         }
         Ok(AuthResult::MfaRequired {
             mfa_token,
             allowed_methods,
             ..
         }) => {
-            // Ask the client for their second factor!
+            tracing::info!(?allowed_methods, "step-up authentication required");
+            // `mfa_token` is a short-lived JWT the client must echo back to
+            // `/mfa-verify`; it is what binds the two requests together.
             Json(serde_json::json!({
                 "status": "mfa_required",
                 "mfa_token": mfa_token,
                 "allowed_methods": allowed_methods,
             }))
         }
-        Err(e) => Json(serde_json::json!({
-            "status": "error",
-            "message": e.to_string(),
-        })),
+        Err(err) => {
+            tracing::warn!(%err, "authentication failed");
+            Json(serde_json::json!({ "status": "error", "message": err.to_string() }))
+        }
     }
 }
 
-/// The endpoint for completing MFA.
+/// Second-factor verification. Expects an `AuthInput::MfaChallenge` carrying
+/// the `mfa_token` issued by `/login`.
 async fn mfa_verify_handler(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-    Json(input): Json<AuthInput>, // Should be AuthInput::MfaChallenge
+    State(state): State<AppState>,
+    Json(input): Json<AuthInput>,
 ) -> Json<serde_json::Value> {
     match state.engine.authenticate(input).await {
-        Ok(AuthResult::Success(identity)) => Json(serde_json::json!({
-            "status": "success",
-            "message": "MFA verified!",
-            "identity": identity,
-        })),
-        Ok(AuthResult::MfaRequired { .. }) => {
-            // Technically shouldn't happen unless triple-factor is enabled!
-            Json(serde_json::json!({"status": "error", "message": "Unexpected MFA state"}))
+        Ok(AuthResult::Success(identity)) => {
+            tracing::info!(user = %identity.external_id, "step-up verified");
+            Json(serde_json::json!({
+                "status": "success",
+                "message": "MFA verified!",
+                "identity": identity,
+            }))
         }
-        Err(e) => Json(serde_json::json!({
-            "status": "error",
-            "message": e.to_string(),
-        })),
+        // Only reachable if a third factor were configured; surfaced rather
+        // than swallowed so the state is visible if that ever changes.
+        Ok(AuthResult::MfaRequired { .. }) => {
+            tracing::warn!("a further factor was requested after step-up");
+            Json(serde_json::json!({
+                "status": "error",
+                "message": "Unexpected MFA state",
+            }))
+        }
+        Err(err) => {
+            tracing::warn!(%err, "step-up verification failed");
+            Json(serde_json::json!({ "status": "error", "message": err.to_string() }))
+        }
     }
+}
+
+/// Bind port, overridable via `PORT` so several examples can run without
+/// colliding on 3000.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000)
 }

--- a/crates/authkestra/examples/axum_oauth2_github.rs
+++ b/crates/authkestra/examples/axum_oauth2_github.rs
@@ -1,17 +1,25 @@
-//! # Axum GitHub OAuth2 Example
+//! # Axum + GitHub OAuth2 (stateful sessions)
 //!
-//! This example demonstrates how to set up Engine with Axum for GitHub OAuth2 login.
+//! The golden path for a server-rendered web app: an [`Engine`] with an OAuth
+//! provider *and* a session store. The callback creates a server-side session
+//! and sets a cookie.
 //!
-//! To run this example, you'll need:
-//! - `AUTHKESTRA_GITHUB_CLIENT_ID`
-//! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
+//! ```sh
+//! AUTHKESTRA_GITHUB_CLIENT_ID=... AUTHKESTRA_GITHUB_CLIENT_SECRET=... \
+//!   cargo run -p authkestra --example axum_oauth2_github --all-features
+//! ```
+//!
+//! Register `http://localhost:3000/auth/callback/github` as the OAuth callback
+//! on GitHub — that is the path [`AxumExt::axum_router`] actually wires. Set
+//! `PORT` to bind elsewhere; the default redirect URI follows it.
 
 use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
-use authkestra_engine::auth::SessionStore;
-use authkestra_engine::flow::{Engine, OAuth2Flow};
-use authkestra_engine::{AkWebAppEngine, SessionConfig};
+use authkestra_engine::store::memory::MemoryStore;
+use authkestra_engine::{AkWebAppEngine, Engine, OAuth2Flow, SessionConfig, SessionStore};
 use authkestra_providers::github::GithubProvider;
 use axum::{
+    extract::State,
+    http::StatusCode,
     response::{IntoResponse, Json},
     routing::get,
     Router,
@@ -21,7 +29,6 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// Engine state with support for session only.
 #[derive(Clone, AxumState)]
 struct AppState {
     #[authkestra(engine)]
@@ -30,14 +37,7 @@ struct AppState {
 
 #[tokio::main]
 async fn main() {
-    // =========================================================================
-    // Initialize tracing subscriber for logging
-    // =========================================================================
-    // This allows the user to capture logs emitted by Engine via `tracing`.
-    // You can customize the log level by setting the `RUST_LOG` environment
-    // variable (e.g., `RUST_LOG=debug`, `RUST_LOG=authkestra=info,my_app=debug`).
-    // `tracing_subscriber::fmt::init()` installs a global default subscriber
-    // that formats logs to standard output.
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -45,21 +45,68 @@ async fn main() {
         )
         .init();
 
-    // Load environment variables from .env file
     dotenvy::dotenv().ok();
+
+    let port = port_from_env();
 
     let client_id = std::env::var("AUTHKESTRA_GITHUB_CLIENT_ID")
         .expect("AUTHKESTRA_GITHUB_CLIENT_ID must be set");
     let client_secret = std::env::var("AUTHKESTRA_GITHUB_CLIENT_SECRET")
         .expect("AUTHKESTRA_GITHUB_CLIENT_SECRET must be set");
     let redirect_uri = std::env::var("AUTHKESTRA_GITHUB_REDIRECT_URI")
-        .unwrap_or_else(|_| "http://localhost:3000/auth/github/callback".to_string());
+        .unwrap_or_else(|_| format!("http://localhost:{port}/auth/callback/github"));
 
-    // Support E2E tests pointing to a local mock server
-    let github_provider = match std::env::var("AUTHKESTRA_GITHUB_BASE_URL") {
+    let github_provider = github_provider(client_id, client_secret, redirect_uri);
+
+    // `SessionStore` is a trait: swap `MemoryStore` for `RedisStore` or
+    // `SqlKvStore` without touching anything below this line.
+    let session_store: Arc<dyn SessionStore> = Arc::new(MemoryStore::default());
+
+    let engine = Engine::builder()
+        .provider(OAuth2Flow::new(github_provider))
+        .session_store(session_store)
+        .session_config(SessionConfig {
+            secure: false, // plain HTTP for local development
+            ..Default::default()
+        })
+        .build();
+
+    let state = AppState {
+        auth: engine.clone(),
+    };
+
+    let app = Router::new()
+        .route("/api/user", get(get_user))
+        .route("/api/providers", get(list_providers))
+        .merge(engine.axum_router())
+        .fallback_service(ServeDir::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/examples/static"
+        )))
+        .layer(CookieManagerLayer::new())
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port))
+        .await
+        .expect("failed to bind example server");
+
+    tracing::info!(%port, "Axum GitHub OAuth2 listening on http://localhost:{port}");
+    tracing::info!("start the flow at http://localhost:{port}/auth/login/github");
+    axum::serve(listener, app).await.unwrap();
+}
+
+/// Builds the provider, redirecting to a mock server when the e2e harness has
+/// set `AUTHKESTRA_GITHUB_BASE_URL`. Real deployments never set these.
+fn github_provider(
+    client_id: String,
+    client_secret: String,
+    redirect_uri: String,
+) -> GithubProvider {
+    match std::env::var("AUTHKESTRA_GITHUB_BASE_URL") {
         Ok(base_url) => {
             let api_url =
                 std::env::var("AUTHKESTRA_GITHUB_API_URL").unwrap_or_else(|_| base_url.clone());
+            tracing::warn!(%base_url, "using overridden GitHub endpoints (test mode)");
             GithubProvider::new(client_id, client_secret, redirect_uri).with_test_urls(
                 format!("{base_url}/login/oauth/authorize"),
                 format!("{base_url}/login/oauth/access_token"),
@@ -67,51 +114,47 @@ async fn main() {
             )
         }
         Err(_) => GithubProvider::new(client_id, client_secret, redirect_uri),
-    };
-
-    // Session Store
-    // TIP: authkestra uses traits (like `SessionStore`) for storage.
-    // This makes it easy to swap out backends! You could easily replace `MemoryStore`
-    // with `SqlKvStore` or `RedisStore` simply by changing the struct instantiated here.
-    let session_store: Arc<dyn SessionStore> =
-        Arc::new(authkestra_engine::store::memory::MemoryStore::default());
-
-    let authkestra = Engine::builder()
-        .provider(OAuth2Flow::new(github_provider))
-        .session_store(session_store)
-        .session_config(SessionConfig {
-            secure: false,
-            ..Default::default()
-        })
-        .build();
-
-    let state = AppState {
-        auth: authkestra.clone(),
-    };
-
-    let app = Router::new()
-        .fallback_service(ServeDir::new(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/examples/static"
-        )))
-        .route("/api/user", get(get_user))
-        .merge(authkestra.axum_router())
-        .layer(CookieManagerLayer::new())
-        .with_state(state);
-
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-    println!("🚀 Axum GitHub OAuth2 running on http://localhost:3000");
-    axum::serve(listener, app).await.unwrap();
+    }
 }
 
+/// Returns the session identity, or 401 when there is no valid session.
 async fn get_user(session: Result<AuthSession, AxumError>) -> impl IntoResponse {
     match session {
-        Ok(AuthSession(session)) => Json(json!({
-            "id": session.identity.external_id,
-            "username": session.identity.username,
-            "email": session.identity.email,
-            "provider": session.identity.provider_id,
-        })),
-        Err(_) => Json(json!({ "error": "Not authenticated" })),
+        Ok(AuthSession(session)) => {
+            tracing::debug!(user = %session.identity.external_id, "session resolved");
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "id": session.identity.external_id,
+                    "username": session.identity.username,
+                    "email": session.identity.email,
+                    "provider": session.identity.provider_id,
+                })),
+            )
+        }
+        Err(err) => {
+            tracing::debug!(%err, "no valid session on request");
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "Not authenticated" })),
+            )
+        }
     }
+}
+
+/// Lists the registered OAuth providers so the bundled static page can render
+/// a login button per provider.
+async fn list_providers(State(state): State<AppState>) -> impl IntoResponse {
+    let providers: Vec<&String> = state.auth.providers.keys().collect();
+    Json(json!({ "providers": providers }))
+}
+
+/// Bind port, overridable via `PORT` so several examples (and the e2e test
+/// harness, which passes a port it has already confirmed to be free) can run
+/// without colliding on 3000.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000)
 }

--- a/crates/authkestra/examples/axum_oauth_stateless.rs
+++ b/crates/authkestra/examples/axum_oauth_stateless.rs
@@ -1,15 +1,25 @@
-//! # Axum Stateless OAuth Example
+//! # Axum + GitHub OAuth2 (stateless / JWT)
 //!
-//! This example demonstrates how to set up Engine for OAuth2 in stateless mode,
-//! where the callback returns a JWT instead of creating a server-side session.
+//! The golden path for an API with no server-side session state. The same
+//! [`Engine::builder`] is given a `jwt_secret` instead of a `session_store`,
+//! and [`AxumStatelessExt::axum_router_stateless`] wires a callback that
+//! returns a JWT as JSON rather than setting a cookie.
 //!
-//! To run this example, you'll need:
-//! - `AUTHKESTRA_GITHUB_CLIENT_ID`
-//! - `AUTHKESTRA_GITHUB_CLIENT_SECRET`
+//! The typestate builder is what makes the difference safe: because no session
+//! store was configured, the session-only APIs simply do not exist on this
+//! engine, so there is no way to accidentally mix the two modes.
+//!
+//! ```sh
+//! AUTHKESTRA_GITHUB_CLIENT_ID=... AUTHKESTRA_GITHUB_CLIENT_SECRET=... \
+//!   cargo run -p authkestra --example axum_oauth_stateless --all-features
+//! ```
+//!
+//! 1. Start the flow at `/auth/login/github`.
+//! 2. The callback (`/auth/callback/github`) responds with a JWT.
+//! 3. Call `/api/user` with `Authorization: Bearer <token>`.
 
 use authkestra_axum::{AuthToken, AxumError, AxumState, AxumStatelessExt};
-use authkestra_engine::flow::{Engine, OAuth2Flow};
-use authkestra_engine::AkApiEngine;
+use authkestra_engine::{AkApiEngine, Engine, OAuth2Flow};
 use authkestra_providers::github::GithubProvider;
 use axum::{
     http::StatusCode,
@@ -19,7 +29,8 @@ use axum::{
 };
 use serde_json::json;
 
-/// Engine state with support for tokens (stateless mode).
+/// `AkApiEngine` is the alias for a token-configured engine with no session
+/// store — the stateless counterpart of `AkWebAppEngine`.
 #[derive(Clone, AxumState)]
 struct AppState {
     #[authkestra(engine)]
@@ -28,21 +39,68 @@ struct AppState {
 
 #[tokio::main]
 async fn main() {
-    // Load environment variables from .env file
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
+
     dotenvy::dotenv().ok();
+
+    let port = port_from_env();
 
     let client_id = std::env::var("AUTHKESTRA_GITHUB_CLIENT_ID")
         .expect("AUTHKESTRA_GITHUB_CLIENT_ID must be set");
     let client_secret = std::env::var("AUTHKESTRA_GITHUB_CLIENT_SECRET")
         .expect("AUTHKESTRA_GITHUB_CLIENT_SECRET must be set");
     let redirect_uri = std::env::var("AUTHKESTRA_GITHUB_REDIRECT_URI")
-        .unwrap_or_else(|_| "http://localhost:3000/auth/callback/github".to_string());
+        .unwrap_or_else(|_| format!("http://localhost:{port}/auth/callback/github"));
 
-    // Support E2E tests pointing to a local mock server
-    let github_provider = match std::env::var("AUTHKESTRA_GITHUB_BASE_URL") {
+    let github_provider = github_provider(client_id, client_secret, redirect_uri);
+
+    // Stateless mode: `jwt_secret` configures the token manager and leaves the
+    // session-store slot `Missing`. Load a real secret from your secret
+    // manager — this literal is only acceptable in an example.
+    let engine = Engine::builder()
+        .provider(OAuth2Flow::new(github_provider))
+        .jwt_secret(b"your-256-bit-secret-key-at-least-32-bytes-long")
+        .build();
+
+    let state = AppState { auth: engine };
+
+    let app = Router::new()
+        .route("/api/user", get(get_user))
+        .merge(state.auth.axum_router_stateless())
+        // The OAuth `state`/`nonce` round-trip rides in encrypted cookies even
+        // in stateless mode, so the cookie layer is still required.
+        .layer(tower_cookies::CookieManagerLayer::new())
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port))
+        .await
+        .expect("failed to bind example server");
+
+    tracing::info!(%port, "Axum stateless OAuth listening on http://localhost:{port}");
+    tracing::info!("1. start the flow at http://localhost:{port}/auth/login/github");
+    tracing::info!("2. the callback returns JSON containing a JWT");
+    tracing::info!("3. call /api/user with 'Authorization: Bearer <token>'");
+    axum::serve(listener, app).await.unwrap();
+}
+
+/// Builds the provider, redirecting to a mock server when the e2e harness has
+/// set `AUTHKESTRA_GITHUB_BASE_URL`. Real deployments never set these.
+fn github_provider(
+    client_id: String,
+    client_secret: String,
+    redirect_uri: String,
+) -> GithubProvider {
+    match std::env::var("AUTHKESTRA_GITHUB_BASE_URL") {
         Ok(base_url) => {
             let api_url =
                 std::env::var("AUTHKESTRA_GITHUB_API_URL").unwrap_or_else(|_| base_url.clone());
+            tracing::warn!(%base_url, "using overridden GitHub endpoints (test mode)");
             GithubProvider::new(client_id, client_secret, redirect_uri).with_test_urls(
                 format!("{base_url}/login/oauth/authorize"),
                 format!("{base_url}/login/oauth/access_token"),
@@ -50,49 +108,51 @@ async fn main() {
             )
         }
         Err(_) => GithubProvider::new(client_id, client_secret, redirect_uri),
-    };
-
-    // Initialize Engine in stateless mode (JWT only).
-    let authkestra = Engine::builder()
-        .provider(OAuth2Flow::new(github_provider))
-        .jwt_secret(b"your-256-bit-secret-key-at-least-32-bytes-long")
-        .build();
-
-    let state = AppState { auth: authkestra };
-
-    let app = Router::new()
-        .route("/api/user", get(get_user))
-        // Login and Callback routes automatically wired to return a JWT
-        .merge(state.auth.axum_router_stateless())
-        .layer(tower_cookies::CookieManagerLayer::new())
-        .with_state(state);
-
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-    println!("🚀 Axum Stateless OAuth running on http://localhost:3000");
-    println!("1. Login: http://localhost:3000/auth/github");
-    println!("2. The callback will return a JSON with a JWT.");
-    println!("3. Use the JWT in the 'Authorization: Bearer <token>' header for /api/user");
-    axum::serve(listener, app).await.unwrap();
+    }
 }
 
-/// Protected endpoint using `AuthToken` extractor.
+/// Protected endpoint using the `AuthToken` extractor (bearer token, no cookie).
 async fn get_user(auth: Result<AuthToken, AxumError>) -> impl IntoResponse {
     match auth {
-        Ok(AuthToken(claims)) => {
-            let identity = claims.identity.as_ref().unwrap();
+        Ok(AuthToken(claims)) => match claims.identity.as_ref() {
+            Some(identity) => {
+                tracing::debug!(user = %identity.external_id, "bearer token accepted");
+                (
+                    StatusCode::OK,
+                    Json(json!({
+                        "id": identity.external_id,
+                        "username": identity.username,
+                        "email": identity.email,
+                        "provider": identity.provider_id,
+                    })),
+                )
+            }
+            // A token signed by this engine but carrying no identity claim —
+            // e.g. a client-credentials token. Report it rather than panicking.
+            None => {
+                tracing::warn!("token validated but carries no identity claim");
+                (
+                    StatusCode::FORBIDDEN,
+                    Json(json!({ "error": "Token carries no user identity" })),
+                )
+            }
+        },
+        Err(err) => {
+            tracing::debug!(%err, "bearer token rejected");
             (
-                StatusCode::OK,
-                Json(json!({
-                    "id": identity.external_id,
-                    "username": identity.username,
-                    "email": identity.email,
-                    "provider": identity.provider_id,
-                })),
+                StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "Not authenticated" })),
             )
         }
-        Err(_) => (
-            StatusCode::UNAUTHORIZED,
-            Json(json!({ "error": "Not authenticated" })),
-        ),
     }
+}
+
+/// Bind port, overridable via `PORT` so several examples (and the e2e test
+/// harness, which passes a port it has already confirmed to be free) can run
+/// without colliding on 3000.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000)
 }

--- a/crates/authkestra/examples/axum_oidc_google.rs
+++ b/crates/authkestra/examples/axum_oidc_google.rs
@@ -1,17 +1,26 @@
-//! # Axum Google OIDC Example
+//! # Axum + Google OIDC (stateful sessions)
 //!
-//! This example demonstrates how to set up Engine with Axum for Google OIDC login.
+//! Same shape as `axum_oauth2_github.rs`, with Google's OIDC provider swapped
+//! in — the point being that [`Engine::builder`] treats every provider
+//! identically: `.provider(OAuth2Flow::new(..))` and nothing else changes.
 //!
-//! To run this example, you'll need:
-//! - `AUTHKESTRA_GOOGLE_CLIENT_ID`
-//! - `AUTHKESTRA_GOOGLE_CLIENT_SECRET`
+//! ```sh
+//! AUTHKESTRA_GOOGLE_CLIENT_ID=... AUTHKESTRA_GOOGLE_CLIENT_SECRET=... \
+//!   cargo run -p authkestra --example axum_oidc_google --all-features
+//! ```
+//!
+//! Register `http://localhost:3000/auth/callback/google` as an authorised
+//! redirect URI in the Google Cloud console — that is the path
+//! [`AxumExt::axum_router`] actually wires. Set `PORT` to bind elsewhere; the
+//! default redirect URI follows it.
 
 use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
-use authkestra_engine::auth::SessionStore;
-use authkestra_engine::flow::{Engine, OAuth2Flow};
-use authkestra_engine::{AkWebAppEngine, SessionConfig};
+use authkestra_engine::store::memory::MemoryStore;
+use authkestra_engine::{AkWebAppEngine, Engine, OAuth2Flow, SessionConfig, SessionStore};
 use authkestra_providers::google::GoogleProvider;
 use axum::{
+    extract::State,
+    http::StatusCode,
     response::{IntoResponse, Json},
     routing::get,
     Router,
@@ -21,7 +30,6 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// Engine state with support for session only.
 #[derive(Clone, AxumState)]
 struct AppState {
     #[authkestra(engine)]
@@ -30,71 +38,125 @@ struct AppState {
 
 #[tokio::main]
 async fn main() {
-    // Load environment variables from .env file
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
+
     dotenvy::dotenv().ok();
+
+    let port = port_from_env();
 
     let client_id = std::env::var("AUTHKESTRA_GOOGLE_CLIENT_ID")
         .expect("AUTHKESTRA_GOOGLE_CLIENT_ID must be set");
     let client_secret = std::env::var("AUTHKESTRA_GOOGLE_CLIENT_SECRET")
         .expect("AUTHKESTRA_GOOGLE_CLIENT_SECRET must be set");
     let redirect_uri = std::env::var("AUTHKESTRA_GOOGLE_REDIRECT_URI")
-        .unwrap_or_else(|_| "http://localhost:3000/auth/google/callback".to_string());
+        .unwrap_or_else(|_| format!("http://localhost:{port}/auth/callback/google"));
 
-    let mut google_provider = GoogleProvider::new(client_id, client_secret, redirect_uri);
-    // Support E2E tests pointing to a local mock server
-    if let Ok(base_url) = std::env::var("AUTHKESTRA_GOOGLE_BASE_URL") {
-        let api_url =
-            std::env::var("AUTHKESTRA_GOOGLE_API_URL").unwrap_or_else(|_| base_url.clone());
-        google_provider = google_provider.with_test_urls(
-            format!("{base_url}/login/oauth/authorize"),
-            format!("{base_url}/login/oauth/access_token"),
-            format!("{api_url}/user"),
-        );
-    }
+    let google_provider = google_provider(client_id, client_secret, redirect_uri);
 
-    // Session Store
-    // TIP: authkestra uses traits (like `SessionStore`) for storage.
-    // This makes it easy to swap out backends! You could easily replace `MemoryStore`
-    // with `SqlKvStore` or `RedisStore` simply by changing the struct instantiated here.
-    let session_store: Arc<dyn SessionStore> =
-        Arc::new(authkestra_engine::store::memory::MemoryStore::default());
+    // `SessionStore` is a trait: swap `MemoryStore` for `RedisStore` or
+    // `SqlKvStore` without touching anything below this line.
+    let session_store: Arc<dyn SessionStore> = Arc::new(MemoryStore::default());
 
-    let authkestra = Engine::builder()
+    let engine = Engine::builder()
         .provider(OAuth2Flow::new(google_provider))
         .session_store(session_store)
         .session_config(SessionConfig {
-            secure: false,
+            secure: false, // plain HTTP for local development
             ..Default::default()
         })
         .build();
 
     let state = AppState {
-        auth: authkestra.clone(),
+        auth: engine.clone(),
     };
 
     let app = Router::new()
+        .route("/api/user", get(get_user))
+        .route("/api/providers", get(list_providers))
+        .merge(engine.axum_router())
         .fallback_service(ServeDir::new(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/examples/static"
         )))
-        .route("/api/user", get(get_user))
-        .merge(authkestra.axum_router())
         .layer(CookieManagerLayer::new())
         .with_state(state);
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-    println!("🚀 Axum Google OIDC running on http://localhost:3000");
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port))
+        .await
+        .expect("failed to bind example server");
+
+    tracing::info!(%port, "Axum Google OIDC listening on http://localhost:{port}");
+    tracing::info!("start the flow at http://localhost:{port}/auth/login/google");
     axum::serve(listener, app).await.unwrap();
 }
 
+/// Builds the provider, redirecting to a mock server when the e2e harness has
+/// set `AUTHKESTRA_GOOGLE_BASE_URL`. Real deployments never set these.
+fn google_provider(
+    client_id: String,
+    client_secret: String,
+    redirect_uri: String,
+) -> GoogleProvider {
+    let provider = GoogleProvider::new(client_id, client_secret, redirect_uri);
+    match std::env::var("AUTHKESTRA_GOOGLE_BASE_URL") {
+        Ok(base_url) => {
+            let api_url =
+                std::env::var("AUTHKESTRA_GOOGLE_API_URL").unwrap_or_else(|_| base_url.clone());
+            tracing::warn!(%base_url, "using overridden Google endpoints (test mode)");
+            provider.with_test_urls(
+                format!("{base_url}/login/oauth/authorize"),
+                format!("{base_url}/login/oauth/access_token"),
+                format!("{api_url}/user"),
+            )
+        }
+        Err(_) => provider,
+    }
+}
+
+/// Returns the session identity, or 401 when there is no valid session.
 async fn get_user(session: Result<AuthSession, AxumError>) -> impl IntoResponse {
     match session {
-        Ok(AuthSession(session)) => Json(json!({
-            "id": session.identity.external_id,
-            "username": session.identity.username,
-            "email": session.identity.email,
-            "provider": session.identity.provider_id,
-        })),
-        Err(_) => Json(json!({ "error": "Not authenticated" })),
+        Ok(AuthSession(session)) => {
+            tracing::debug!(user = %session.identity.external_id, "session resolved");
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "id": session.identity.external_id,
+                    "username": session.identity.username,
+                    "email": session.identity.email,
+                    "provider": session.identity.provider_id,
+                })),
+            )
+        }
+        Err(err) => {
+            tracing::debug!(%err, "no valid session on request");
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "Not authenticated" })),
+            )
+        }
     }
+}
+
+/// Lists the registered OAuth providers so the bundled static page can render
+/// a login button per provider.
+async fn list_providers(State(state): State<AppState>) -> impl IntoResponse {
+    let providers: Vec<&String> = state.auth.providers.keys().collect();
+    Json(json!({ "providers": providers }))
+}
+
+/// Bind port, overridable via `PORT` so several examples (and the e2e test
+/// harness, which passes a port it has already confirmed to be free) can run
+/// without colliding on 3000.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000)
 }

--- a/crates/authkestra/examples/axum_op_server.rs
+++ b/crates/authkestra/examples/axum_op_server.rs
@@ -72,8 +72,10 @@ async fn main() {
                 client_id: "test-client".to_string(),
                 client_secret_hash: None,
                 // The RP's callback, not this server's — an OP redirects back
-                // to the client application.
-                redirect_uris: vec!["http://localhost:3000/callback".to_string()],
+                // to the client application. This is the path the sibling RP
+                // examples actually serve (`/auth/callback/{provider}`), so the
+                // OP on :8080 and an RP on :3000 compose without editing either.
+                redirect_uris: vec!["http://localhost:3000/auth/callback/github".to_string()],
                 require_pkce: true,
                 scopes: vec!["openid".to_string(), "profile".to_string()],
                 grant_types: vec![authkestra_op::client::GrantType::AuthorizationCode],

--- a/crates/authkestra/examples/axum_op_server.rs
+++ b/crates/authkestra/examples/axum_op_server.rs
@@ -6,17 +6,26 @@
 //! To run this example, you'll need:
 //! - A running Redis instance
 //! - `REDIS_URL` environment variable (e.g., `redis://127.0.0.1/`)
-use authkestra_engine::store::KvStore;
-
-use authkestra_axum::OpExt;
+//!
+//! ```sh
+//! REDIS_URL=redis://127.0.0.1/ \
+//!   cargo run -p authkestra --example axum_op_server --all-features
+//! ```
+//!
+//! Set `PORT` to bind somewhere other than 8080; `issuer` follows it, because
+//! relying parties resolve `/.well-known/openid-configuration` against the
+//! issuer URL and a mismatch breaks discovery.
+use authkestra_axum::{AxumState, OpExt};
 use authkestra_engine::store::redis::RedisStore;
-use authkestra_engine::{AkEngine, SessionConfig, TokenManager};
+use authkestra_engine::store::KvStore;
+use authkestra_engine::{AkEngine, Engine, SessionConfig, SessionStore, TokenManager};
 use authkestra_op::{client::ClientRegistration, config::OpConfig};
 use axum::Router;
 use std::sync::Arc;
 
-use authkestra_axum::AxumState;
-
+/// `AkEngine` is the alias for an engine with *both* a session store and a
+/// token manager — an OP needs the session to authenticate the end user at
+/// `/authorize` and the token manager to sign what it hands back.
 #[derive(Clone, AxumState)]
 struct AppState {
     #[authkestra(engine)]
@@ -31,12 +40,24 @@ struct AppState {
 
 #[tokio::main]
 async fn main() {
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
+
     dotenvy::dotenv().ok();
+    let port = port_from_env();
+    let issuer = format!("http://localhost:{port}");
     let redis_url = std::env::var("REDIS_URL").expect("REDIS_URL must be set");
 
+    // The token manager's `iss` claim must equal `OpConfig::issuer` below, or
+    // relying parties will reject every id_token this OP mints.
     let token_manager = Arc::new(TokenManager::new(
         b"my-super-secret-key-that-is-32bytes-long",
-        Some("issuer".to_string()),
+        Some(issuer.clone()),
     ));
 
     // Open a single Redis client and share it across all stores via different key prefixes.
@@ -50,6 +71,8 @@ async fn main() {
             ClientRegistration {
                 client_id: "test-client".to_string(),
                 client_secret_hash: None,
+                // The RP's callback, not this server's — an OP redirects back
+                // to the client application.
                 redirect_uris: vec!["http://localhost:3000/callback".to_string()],
                 require_pkce: true,
                 scopes: vec!["openid".to_string(), "profile".to_string()],
@@ -75,16 +98,17 @@ async fn main() {
             device_codes,
         ));
 
-    let session_store: Arc<dyn authkestra_engine::auth::SessionStore> = Arc::new(
-        RedisStore::with_client(redis_client, "engine_session".into()),
-    );
+    let session_store: Arc<dyn SessionStore> = Arc::new(RedisStore::with_client(
+        redis_client,
+        "engine_session".into(),
+    ));
 
     let session_config = SessionConfig {
         cookie_name: "authkestra_sid".to_string(),
         ..Default::default()
     };
 
-    let auth = authkestra_engine::Engine::builder()
+    let auth = Engine::builder()
         .session_store(session_store)
         .session_config(session_config)
         .token_manager(token_manager)
@@ -94,7 +118,7 @@ async fn main() {
         auth,
         op_store,
         config: OpConfig {
-            issuer: "http://localhost:3000".to_string(),
+            issuer: issuer.clone(),
             scopes_supported: vec![
                 "openid".to_string(),
                 "profile".to_string(),
@@ -114,7 +138,20 @@ async fn main() {
         .merge(state.op_axum_router())
         .with_state(state);
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await.unwrap();
-    println!("🚀 Axum OP Server running on http://localhost:8080");
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port))
+        .await
+        .expect("failed to bind example server");
+
+    tracing::info!(%issuer, "Axum OP server listening on {issuer}");
+    tracing::info!("discovery: {issuer}/.well-known/openid-configuration");
     axum::serve(listener, app).await.unwrap();
+}
+
+/// Bind port, overridable via `PORT`. Defaults to 8080 so an OP and a relying
+/// party (which the other examples run on 3000) can be started side by side.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(8080)
 }

--- a/crates/authkestra/examples/axum_op_server_custom_grant.rs
+++ b/crates/authkestra/examples/axum_op_server_custom_grant.rs
@@ -194,9 +194,22 @@ impl<
 
 #[tokio::main]
 async fn main() {
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
+
+    let port = port_from_env();
+    let issuer = format!("http://localhost:{port}");
+
+    // The token manager's `iss` claim must equal `OpConfig::issuer` below, or
+    // relying parties will reject every id_token this OP mints.
     let token_manager = Arc::new(TokenManager::new(
         b"my-super-secret-key-that-is-32bytes-long",
-        Some("issuer".to_string()),
+        Some(issuer.clone()),
     ));
 
     let clients = MemoryStore::new();
@@ -255,7 +268,7 @@ async fn main() {
         auth,
         op_store,
         config: OpConfig {
-            issuer: "http://localhost:3000".to_string(),
+            issuer: issuer.clone(),
             scopes_supported: vec![
                 "openid".to_string(),
                 "profile".to_string(),
@@ -275,7 +288,20 @@ async fn main() {
         .merge(state.op_axum_router())
         .with_state(state);
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await.unwrap();
-    println!("🚀 Axum OP Server running on http://localhost:8080");
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port))
+        .await
+        .expect("failed to bind example server");
+
+    tracing::info!(%issuer, "Axum OP server (custom grant) listening on {issuer}");
+    tracing::info!("custom grant_type: urn:example:custom");
     axum::serve(listener, app).await.unwrap();
+}
+
+/// Bind port, overridable via `PORT`. Defaults to 8080 so an OP and a relying
+/// party (which the other examples run on 3000) can be started side by side.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(8080)
 }

--- a/crates/authkestra/examples/axum_op_server_custom_grant.rs
+++ b/crates/authkestra/examples/axum_op_server_custom_grant.rs
@@ -219,7 +219,7 @@ async fn main() {
             ClientRegistration {
                 client_id: "test-client".to_string(),
                 client_secret_hash: None,
-                redirect_uris: vec!["http://localhost:3000/callback".to_string()],
+                redirect_uris: vec!["http://localhost:3000/auth/callback/github".to_string()],
                 require_pkce: true,
                 scopes: vec!["openid".to_string(), "profile".to_string()],
                 grant_types: vec![

--- a/crates/authkestra/examples/axum_op_server_sqlx.rs
+++ b/crates/authkestra/examples/axum_op_server_sqlx.rs
@@ -2,15 +2,26 @@
 //!
 //! This example demonstrates setting up an OpenID Connect Provider using authkestra-op and Axum.
 //! It uses the batteries-included `SqlxOpStore` for a production-ready relational database schema.
-use authkestra_axum::OpExt;
-use authkestra_engine::{AkEngine, TokenManager};
+//!
+//! Unlike `axum_op_server.rs` (which composes four `KvStore`s), `SqlxOpStore`
+//! is a single normalised schema with foreign keys and `ON DELETE CASCADE` —
+//! prefer it for OP data; `SqlKvStore` is deprecated for this purpose.
+//!
+//! ```sh
+//! cargo run -p authkestra --example axum_op_server_sqlx --all-features
+//! ```
+//!
+//! Set `PORT` to bind somewhere other than 8080; `issuer` follows it, because
+//! relying parties resolve `/.well-known/openid-configuration` against the
+//! issuer URL and a mismatch breaks discovery.
+use authkestra_axum::{AxumState, OpExt};
+use authkestra_engine::store::memory::MemoryStore;
+use authkestra_engine::{AkEngine, Engine, SessionConfig, SessionStore, TokenManager};
 use authkestra_op::config::OpConfig;
 use authkestra_op::sqlx_store::SqlxOpStore;
 use axum::Router;
 use sqlx::sqlite::SqlitePoolOptions;
 use std::sync::Arc;
-
-use authkestra_axum::AxumState;
 
 #[derive(Clone, AxumState)]
 struct AppState {
@@ -26,9 +37,22 @@ struct AppState {
 
 #[tokio::main]
 async fn main() {
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
+
+    let port = port_from_env();
+    let issuer = format!("http://localhost:{port}");
+
+    // The token manager's `iss` claim must equal `OpConfig::issuer` below, or
+    // relying parties will reject every id_token this OP mints.
     let token_manager = Arc::new(TokenManager::new(
         b"my-super-secret-key-that-is-32bytes-long",
-        Some("issuer".to_string()),
+        Some(issuer.clone()),
     ));
 
     // Create a SQLite connection pool (in-memory for the example, but can be a file path)
@@ -44,8 +68,10 @@ async fn main() {
     // Automatically run schema migrations to create the required tables
     sqlx_store.migrate().await.unwrap();
 
-    // Seed a dummy OAuth client directly using sqlx (since SqlxOpStore abstracts the trait away)
-    // You could also use `sqlx_store.store_client(...)` if that method existed, but ClientRegistration is fetched via ClientStore trait
+    // Seed a demo OAuth client. `ClientStore` is read-only by design —
+    // registration is the deployment's business — so the example writes the
+    // row directly. `redirect_uris` is the *relying party's* callback, not
+    // this server's.
     sqlx::query(
         "INSERT INTO authkestra_oauth_clients (client_id, client_secret_hash, require_pkce, redirect_uris, grant_types, scopes, allowed_audiences) 
          VALUES (?, ?, ?, ?, ?, ?, ?)"
@@ -63,14 +89,15 @@ async fn main() {
 
     let op_store: Arc<dyn authkestra_op::OpStore> = Arc::new(sqlx_store);
 
-    let session_store: Arc<dyn authkestra_engine::auth::SessionStore> =
-        Arc::new(authkestra_engine::store::memory::MemoryStore::new());
-    let session_config = authkestra_engine::SessionConfig {
+    // Only the OP data lives in SQL here; the end-user login session can use
+    // any `SessionStore`, so the example keeps that part dependency-free.
+    let session_store: Arc<dyn SessionStore> = Arc::new(MemoryStore::new());
+    let session_config = SessionConfig {
         cookie_name: "authkestra_sid".to_string(),
         ..Default::default()
     };
 
-    let auth = authkestra_engine::Engine::builder()
+    let auth = Engine::builder()
         .session_store(session_store)
         .session_config(session_config)
         .token_manager(token_manager)
@@ -80,7 +107,7 @@ async fn main() {
         auth,
         op_store,
         config: OpConfig {
-            issuer: "http://localhost:3000".to_string(),
+            issuer: issuer.clone(),
             scopes_supported: vec![
                 "openid".to_string(),
                 "profile".to_string(),
@@ -100,7 +127,20 @@ async fn main() {
         .merge(state.op_axum_router())
         .with_state(state);
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await.unwrap();
-    println!("🚀 Axum OP Server running on http://localhost:8080");
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port))
+        .await
+        .expect("failed to bind example server");
+
+    tracing::info!(%issuer, "Axum OP server (SqlxOpStore) listening on {issuer}");
+    tracing::info!("discovery: {issuer}/.well-known/openid-configuration");
     axum::serve(listener, app).await.unwrap();
+}
+
+/// Bind port, overridable via `PORT`. Defaults to 8080 so an OP and a relying
+/// party (which the other examples run on 3000) can be started side by side.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(8080)
 }

--- a/crates/authkestra/examples/axum_op_server_sqlx.rs
+++ b/crates/authkestra/examples/axum_op_server_sqlx.rs
@@ -79,7 +79,7 @@ async fn main() {
     .bind("test-client")
     .bind(None::<String>)
     .bind(true)
-    .bind(sqlx::types::Json(vec!["http://localhost:3000/callback"]))
+    .bind(sqlx::types::Json(vec!["http://localhost:3000/auth/callback/github"]))
     .bind(sqlx::types::Json(vec!["authorization_code"]))
     .bind(sqlx::types::Json(vec!["openid", "profile"]))
     .bind(sqlx::types::Json(Vec::<String>::new()))

--- a/crates/authkestra/examples/axum_resource_server.rs
+++ b/crates/authkestra/examples/axum_resource_server.rs
@@ -1,3 +1,18 @@
+//! # Axum resource server — manual JWKS wiring (lower level)
+//!
+//! Protects endpoints with JWTs issued by an external OIDC provider, wiring
+//! [`JwksCache`] and `jsonwebtoken::Validation` into the state by hand and
+//! extracting with `Jwt<T>`.
+//!
+//! Reach for this when you need direct control over `Validation`. For the
+//! common case prefer `axum_resource_server_strategy.rs`, which hides all of
+//! the below behind a `Guard`.
+//!
+//! ```sh
+//! OIDC_ISSUER=https://accounts.google.com OIDC_AUDIENCE=my-api \
+//!   cargo run -p authkestra --example axum_resource_server --all-features
+//! ```
+
 use authkestra_axum::Jwt;
 use authkestra_resource::jwt::{JwksCache, ValidationConfig};
 use axum::{
@@ -9,9 +24,6 @@ use axum::{
 use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
-
-/// This example demonstrates an Axum resource server that protects its endpoints
-/// using JWTs validated against an external OIDC provider's JWKS.
 
 #[derive(Debug, Deserialize)]
 struct MyClaims {
@@ -60,6 +72,14 @@ impl Config {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
+
     dotenvy::dotenv().ok();
     let config = Config::from_env();
 
@@ -95,9 +115,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/api/protected", get(protected))
         .with_state(state);
 
-    let addr = format!("0.0.0.0:{}", config.port);
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
-    println!("📡 Listening on http://{addr}");
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", config.port)).await?;
+    tracing::info!(
+        port = config.port,
+        issuer = %config.issuer,
+        "Axum resource server listening on http://localhost:{}",
+        config.port
+    );
 
     axum::serve(listener, app).await?;
 
@@ -109,6 +133,7 @@ async fn index() -> impl IntoResponse {
 }
 
 async fn protected(Jwt(claims): Jwt<MyClaims>) -> impl IntoResponse {
+    tracing::debug!(sub = %claims.sub, "bearer token accepted");
     Json(json!({
         "message": "You have access to this protected resource.",
         "user_id": claims.sub,

--- a/crates/authkestra/examples/axum_resource_server_strategy.rs
+++ b/crates/authkestra/examples/axum_resource_server_strategy.rs
@@ -1,7 +1,17 @@
-//! # Axum Resource Server Strategy Example
+//! # Axum resource server — `Guard` strategy (preferred)
 //!
-//! This example demonstrates how to use the Resource Server strategy with `Guard`
-//! and the `Auth` extractor to protect an API.
+//! Validates bearer tokens issued by *someone else* (any OIDC provider). This
+//! is the recommended shape: a [`Guard`] owns one or more strategies, and the
+//! `Auth<T>` extractor asks the guard rather than reaching for JWT internals.
+//!
+//! `axum_resource_server.rs` shows the lower-level alternative (wiring
+//! `JwksCache` and `jsonwebtoken::Validation` yourself); prefer this one unless
+//! you need that control.
+//!
+//! ```sh
+//! OIDC_ISSUER=https://accounts.google.com \
+//!   cargo run -p authkestra --example axum_resource_server_strategy --all-features
+//! ```
 
 use authkestra_axum::{Auth, AxumState};
 use authkestra_resource::{jwt::JwtStrategy, jwt::ValidationConfig, Guard};
@@ -31,6 +41,14 @@ struct AppState {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
+
     dotenvy::dotenv().ok();
 
     // 1. Configure the JWT Strategy
@@ -57,18 +75,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/api/protected", get(protected))
         .with_state(state);
 
-    let port = std::env::var("PORT")
-        .ok()
-        .and_then(|p| p.parse().ok())
-        .unwrap_or(3000);
-
-    let addr = format!("0.0.0.0:{}", port);
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
-    println!("📡 Resource Server Strategy listening on http://{addr}");
+    let port = port_from_env();
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port)).await?;
+    tracing::info!(%port, "Axum resource server (Guard strategy) listening on http://localhost:{port}");
 
     axum::serve(listener, app).await?;
 
     Ok(())
+}
+
+/// Bind port, overridable via `PORT` so several examples can run without
+/// colliding on 3000.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000)
 }
 
 async fn index() -> impl IntoResponse {
@@ -78,6 +100,7 @@ async fn index() -> impl IntoResponse {
 /// Protected endpoint using the `Auth` extractor.
 /// This extractor uses the `Guard` from the state to validate the request.
 async fn protected(Auth(user): Auth<UserIdentity>) -> impl IntoResponse {
+    tracing::debug!(sub = %user.sub, "bearer token accepted by guard");
     Json(json!({
         "message": "Access granted via Resource Server Strategy!",
         "user": user,

--- a/crates/authkestra/examples/axum_session_redis.rs
+++ b/crates/authkestra/examples/axum_session_redis.rs
@@ -1,17 +1,22 @@
-//! # Axum Redis Session Example
+//! # Axum + Redis session store
 //!
-//! This example demonstrates how to use Redis as a session store with Axum.
+//! `axum_basic_setup.rs` with one line changed: `MemoryStore` becomes
+//! `RedisStore`. Everything downstream — the builder call, the state struct,
+//! the router, the extractors — is untouched, which is the payoff of defining
+//! storage as the [`SessionStore`] trait rather than a concrete type.
 //!
-//! To run this example, you'll need:
-//! - A running Redis instance
-//! - `REDIS_URL` environment variable (e.g., `redis://127.0.0.1/`)
+//! ```sh
+//! REDIS_URL=redis://127.0.0.1/ \
+//!   cargo run -p authkestra --example axum_session_redis --all-features
+//! ```
+//!
+//! Set `PORT` to bind somewhere other than 3000.
 
 use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
-use authkestra_engine::auth::SessionStore;
-use authkestra_engine::flow::Engine;
 use authkestra_engine::store::redis::RedisStore;
-use authkestra_engine::{AkWebAppEngine, SessionConfig};
+use authkestra_engine::{AkWebAppEngine, Engine, SessionConfig, SessionStore};
 use axum::{
+    http::StatusCode,
     response::{IntoResponse, Json},
     routing::get,
     Router,
@@ -21,7 +26,6 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// Engine state with support for session only.
 #[derive(Clone, AxumState)]
 struct AppState {
     #[authkestra(engine)]
@@ -30,52 +34,86 @@ struct AppState {
 
 #[tokio::main]
 async fn main() {
-    // Load environment variables from .env file
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
+
     dotenvy::dotenv().ok();
 
     let redis_url = std::env::var("REDIS_URL").expect("REDIS_URL must be set");
 
-    // Redis Session Store
+    // The key prefix namespaces this app's sessions so one Redis instance can
+    // back several stores (see `axum_op_server.rs`, which does exactly that).
     let session_store: Arc<dyn SessionStore> = Arc::new(
         RedisStore::new(&redis_url, "authkestra_example".into())
-            .expect("Failed to connect to Redis"),
+            .expect("failed to connect to Redis"),
     );
 
-    let authkestra = Engine::builder()
+    let engine = Engine::builder()
         .session_store(session_store)
         .session_config(SessionConfig {
-            secure: false,
+            secure: false, // plain HTTP for local development
             ..Default::default()
         })
         .build();
 
     let state = AppState {
-        auth: authkestra.clone(),
+        auth: engine.clone(),
     };
 
     let app = Router::new()
+        .route("/api/user", get(get_user))
+        .merge(engine.axum_router())
         .fallback_service(ServeDir::new(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/examples/static"
         )))
-        .route("/api/user", get(get_user))
-        .merge(authkestra.axum_router())
         .layer(CookieManagerLayer::new())
         .with_state(state);
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-    println!("🚀 Axum Redis Session Example running on http://localhost:3000");
+    let port = port_from_env();
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port))
+        .await
+        .expect("failed to bind example server");
+
+    tracing::info!(%port, "Axum Redis session example listening on http://localhost:{port}");
     axum::serve(listener, app).await.unwrap();
 }
 
+/// Returns the session identity, or 401 when there is no valid session.
 async fn get_user(session: Result<AuthSession, AxumError>) -> impl IntoResponse {
     match session {
-        Ok(AuthSession(session)) => Json(json!({
-            "id": session.identity.external_id,
-            "username": session.identity.username,
-            "email": session.identity.email,
-            "provider": session.identity.provider_id,
-        })),
-        Err(_) => Json(json!({ "error": "Not authenticated" })),
+        Ok(AuthSession(session)) => {
+            tracing::debug!(user = %session.identity.external_id, "session resolved from Redis");
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "id": session.identity.external_id,
+                    "username": session.identity.username,
+                    "email": session.identity.email,
+                    "provider": session.identity.provider_id,
+                })),
+            )
+        }
+        Err(err) => {
+            tracing::debug!(%err, "no valid session on request");
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "Not authenticated" })),
+            )
+        }
     }
+}
+
+/// Bind port, overridable via `PORT` so several examples can run without
+/// colliding on 3000.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000)
 }

--- a/crates/authkestra/examples/axum_sql_store.rs
+++ b/crates/authkestra/examples/axum_sql_store.rs
@@ -1,15 +1,24 @@
+// `SqlKvStore` is deprecated *for OP-specific data* (use `SqlxOpStore` for
+// that — see `axum_op_server_sqlx.rs`), but is still the supported choice for
+// generic KV/session storage, which is all this example uses it for. The
+// deprecation attribute cannot distinguish the two, hence the blanket allow.
 #![allow(deprecated)]
-//! # Axum SQL Store Example
+//! # Axum + SQL session store (SQLite)
 //!
-//! This example demonstrates how to use `SqlKvStore` (with SQLite) as a session store with Axum.
-//! It also demonstrates how to manage the database table lifecycle by calling `.migrate().await`.
+//! `axum_basic_setup.rs` with `MemoryStore` swapped for `SqlKvStore`, plus the
+//! one extra step SQL needs: `migrate()` to create the backing table.
+//!
+//! ```sh
+//! cargo run -p authkestra --example axum_sql_store --all-features
+//! ```
+//!
+//! Set `PORT` to bind somewhere other than 3000.
 
 use authkestra_axum::{AuthSession, AxumError, AxumExt, AxumState};
-use authkestra_engine::auth::SessionStore;
-use authkestra_engine::flow::Engine;
 use authkestra_engine::store::sql::SqlKvStore;
-use authkestra_engine::{AkWebAppEngine, SessionConfig};
+use authkestra_engine::{AkWebAppEngine, Engine, SessionConfig, SessionStore};
 use axum::{
+    http::StatusCode,
     response::{IntoResponse, Json},
     routing::get,
     Router,
@@ -20,7 +29,6 @@ use std::sync::Arc;
 use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 
-/// Engine state with support for session only.
 #[derive(Clone, AxumState)]
 struct AppState {
     #[authkestra(engine)]
@@ -29,64 +37,95 @@ struct AppState {
 
 #[tokio::main]
 async fn main() {
-    // 1. Create a SQLite connection pool.
-    // For this example, we use an in-memory database to avoid needing local setup,
-    // but in a real app, this would be a file path (e.g. "sqlite://session.db")
-    // or a Postgres/MySQL URL.
+    // `RUST_LOG=authkestra=debug` surfaces the engine's own instrumentation.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,authkestra=debug".into()),
+        )
+        .init();
+
+    // 1. Connect. In-memory keeps the example dependency-free; a real app
+    //    would pass a file path or a Postgres/MySQL URL here instead.
     let pool = SqlitePoolOptions::new()
         .connect("sqlite::memory:")
         .await
-        .expect("Failed to create SQLite connection pool");
+        .expect("failed to create SQLite connection pool");
 
-    // 2. Initialize the SqlKvStore with the pool.
     let sql_store = SqlKvStore::new(pool);
 
-    // 3. Migrate the database.
-    // This explicitly creates the `authkestra_kv` table and indexes if they do not exist.
-    // It is fully idempotent, so you can call it safely on every startup.
+    // 2. Create the `authkestra_kv` table and indexes. Idempotent, so calling
+    //    it on every startup is safe — authkestra never assumes a schema it
+    //    did not create.
     sql_store
         .migrate()
         .await
-        .expect("Failed to run database migrations");
+        .expect("failed to run database migrations");
 
-    // 4. Wrap the store in an Arc and provide it to the Engine.
+    // 3. From here on it is identical to every other session example.
     let session_store: Arc<dyn SessionStore> = Arc::new(sql_store);
 
-    let authkestra = Engine::builder()
+    let engine = Engine::builder()
         .session_store(session_store)
         .session_config(SessionConfig {
-            secure: false, // For local development
+            secure: false, // plain HTTP for local development
             ..Default::default()
         })
         .build();
 
     let state = AppState {
-        auth: authkestra.clone(),
+        auth: engine.clone(),
     };
 
     let app = Router::new()
+        .route("/api/user", get(get_user))
+        .merge(engine.axum_router())
         .fallback_service(ServeDir::new(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/examples/static"
         )))
-        .route("/api/user", get(get_user))
-        .merge(authkestra.axum_router())
         .layer(CookieManagerLayer::new())
         .with_state(state);
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-    println!("🚀 Axum SQL Store Example running on http://localhost:3000");
+    let port = port_from_env();
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port))
+        .await
+        .expect("failed to bind example server");
+
+    tracing::info!(%port, "Axum SQL store example listening on http://localhost:{port}");
     axum::serve(listener, app).await.unwrap();
 }
 
+/// Returns the session identity, or 401 when there is no valid session.
 async fn get_user(session: Result<AuthSession, AxumError>) -> impl IntoResponse {
     match session {
-        Ok(AuthSession(session)) => Json(json!({
-            "id": session.identity.external_id,
-            "username": session.identity.username,
-            "email": session.identity.email,
-            "provider": session.identity.provider_id,
-        })),
-        Err(_) => Json(json!({ "error": "Not authenticated" })),
+        Ok(AuthSession(session)) => {
+            tracing::debug!(user = %session.identity.external_id, "session resolved from SQL");
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "id": session.identity.external_id,
+                    "username": session.identity.username,
+                    "email": session.identity.email,
+                    "provider": session.identity.provider_id,
+                })),
+            )
+        }
+        Err(err) => {
+            tracing::debug!(%err, "no valid session on request");
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "Not authenticated" })),
+            )
+        }
     }
+}
+
+/// Bind port, overridable via `PORT` so several examples can run without
+/// colliding on 3000.
+fn port_from_env() -> u16 {
+    std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000)
 }

--- a/crates/authkestra/examples/static/index.html
+++ b/crates/authkestra/examples/static/index.html
@@ -23,14 +23,19 @@
         // example which providers its engine actually has rather than
         // hardcoding one. Examples that register none (e.g. *_basic_setup)
         // legitimately have nothing to link to.
+        // Returns `null` when the endpoint is absent, as opposed to `[]` for an
+        // example that genuinely registers no providers. Several examples serve
+        // this page without mounting `/api/providers`; collapsing both cases to
+        // `[]` made the page assert "registers no OAuth providers", which it
+        // cannot actually know. Raised in review of #194.
         async function fetchProviders() {
             try {
                 const res = await fetch('/api/providers');
-                if (!res.ok) return [];
+                if (!res.ok) return null;
                 const body = await res.json();
                 return body.providers || [];
             } catch (err) {
-                return [];
+                return null;
             }
         }
 
@@ -51,14 +56,18 @@
                 }
 
                 const providers = await fetchProviders();
-                const buttons = providers
+                const buttons = (providers || [])
                     .map(p => `<a href="/auth/login/${p}" class="btn">Login with ${p}</a>`)
                     .join(' ');
+                const empty = providers === null
+                    ? '<p><em>This example does not expose <code>/api/providers</code>, so the ' +
+                      'available providers are unknown.</em></p>'
+                    : '<p><em>This example registers no OAuth providers.</em></p>';
                 app.innerHTML = `
                     <h2>Not Authenticated</h2>
                     <p>Please log in to continue.</p>
                     <div id="login-methods">
-                        ${buttons || '<p><em>This example registers no OAuth providers.</em></p>'}
+                        ${buttons || empty}
                     </div>
                 `;
             } catch (err) {

--- a/crates/authkestra/examples/static/index.html
+++ b/crates/authkestra/examples/static/index.html
@@ -19,10 +19,25 @@
     </div>
 
     <script>
+        // The login route is `/auth/login/{provider}`, so the page asks the
+        // example which providers its engine actually has rather than
+        // hardcoding one. Examples that register none (e.g. *_basic_setup)
+        // legitimately have nothing to link to.
+        async function fetchProviders() {
+            try {
+                const res = await fetch('/api/providers');
+                if (!res.ok) return [];
+                const body = await res.json();
+                return body.providers || [];
+            } catch (err) {
+                return [];
+            }
+        }
+
         async function checkStatus() {
+            const app = document.getElementById('app');
             try {
                 const res = await fetch('/api/user');
-                const app = document.getElementById('app');
                 if (res.ok) {
                     const user = await res.json();
                     app.innerHTML = `
@@ -32,17 +47,23 @@
                         <pre>${JSON.stringify(user, null, 2)}</pre>
                         <a href="/auth/logout" class="btn">Logout</a>
                     `;
-                } else {
-                    app.innerHTML = `
-                        <h2>Not Authenticated</h2>
-                        <p>Please log in to continue.</p>
-                        <div id="login-methods">
-                             <a href="/auth/login" class="btn">Login</a>
-                        </div>
-                    `;
+                    return;
                 }
+
+                const providers = await fetchProviders();
+                const buttons = providers
+                    .map(p => `<a href="/auth/login/${p}" class="btn">Login with ${p}</a>`)
+                    .join(' ');
+                app.innerHTML = `
+                    <h2>Not Authenticated</h2>
+                    <p>Please log in to continue.</p>
+                    <div id="login-methods">
+                        ${buttons || '<p><em>This example registers no OAuth providers.</em></p>'}
+                    </div>
+                `;
             } catch (err) {
                 console.error(err);
+                app.innerHTML = '<h2>Error</h2><p>Could not reach the example server.</p>';
             }
         }
         checkStatus();

--- a/crates/authkestra/tests/examples_e2e.rs
+++ b/crates/authkestra/tests/examples_e2e.rs
@@ -130,6 +130,24 @@ async fn run_oauth_example(package: &str, example_bin: &str, provider: &str, log
         location
     );
 
+    // Pin the callback path the example advertises to the provider.
+    //
+    // Four examples used to send `redirect_uri=.../auth/{provider}/callback`
+    // while both adapters wire `/auth/callback/{provider}`
+    // (authkestra-axum/src/lib.rs:245, authkestra-actix/src/lib.rs:56+63), so
+    // anyone copying them got a 404 on the way back. Fixing that is the point
+    // of this change — but the assertion above only checks the redirect's
+    // *prefix*, so reverting the fix left this suite green. Raised in review;
+    // the authorization URL already carries the answer, so pinning it is
+    // nearly free.
+    assert!(
+        location.contains("redirect_uri=") && location.contains("%2Fauth%2Fcallback%2F"),
+        "{} must advertise the adapter's real callback path \
+         (/auth/callback/{{provider}}, url-encoded), got: {}",
+        example_bin,
+        location
+    );
+
     // `_guard` kills the example here (and on any panic above).
 }
 

--- a/crates/authkestra/tests/examples_e2e.rs
+++ b/crates/authkestra/tests/examples_e2e.rs
@@ -1,9 +1,46 @@
-use std::process::Command;
+//! End-to-end smoke tests for the OAuth examples.
+//!
+//! Each test spawns a real example binary against a wiremock stand-in for the
+//! upstream provider and asserts that `/auth/login/{provider}` redirects to it.
+//! That is deliberately the *whole* assertion: it proves the example wires the
+//! engine, the adapter routes and the provider together correctly, which is
+//! what an example is documentation for.
+
+use std::net::TcpListener;
+use std::process::{Child, Command};
 use std::time::Duration;
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, ResponseTemplate,
 };
+
+/// Kills the spawned example on drop.
+///
+/// Without this, a failed assertion unwinds past the manual `kill()` and
+/// leaves the example (and its `cargo run` parent) holding the port, which
+/// then makes every subsequent run fail with `AddrInUse` for reasons that look
+/// nothing like the original failure.
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Reserves a free port from the OS and releases it immediately.
+///
+/// There is an unavoidable race between releasing and the example binding, but
+/// it is far smaller than the near-certainty of collision on a hardcoded 3000
+/// when tests, other examples and stray processes all want the same port.
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("failed to reserve a port")
+        .local_addr()
+        .expect("listener has no local address")
+        .port()
+}
 
 async fn run_oauth_example(package: &str, example_bin: &str, provider: &str, login_path: &str) {
     let mock_server = MockServer::start().await;
@@ -39,7 +76,9 @@ async fn run_oauth_example(package: &str, example_bin: &str, provider: &str, log
     let env_client_id = format!("AUTHKESTRA_{}_CLIENT_ID", provider);
     let env_client_secret = format!("AUTHKESTRA_{}_CLIENT_SECRET", provider);
 
-    let mut child = Command::new("cargo")
+    let port = free_port();
+
+    let child = Command::new("cargo")
         .args([
             "run",
             "-p",
@@ -52,24 +91,26 @@ async fn run_oauth_example(package: &str, example_bin: &str, provider: &str, log
         .env(env_api_url, mock_server.uri())
         .env(env_client_id, "test_id")
         .env(env_client_secret, "test_secret")
+        // Every example reads `PORT`, so the harness never has to assume a
+        // fixed port is free.
+        .env("PORT", port.to_string())
         .spawn()
         .unwrap_or_else(|_| panic!("Failed to start {}", example_bin));
+    let _guard = ChildGuard(child);
 
-    let mut attempt = 0;
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .build()
         .unwrap();
 
+    let url = format!("http://127.0.0.1:{port}{login_path}");
     let mut resp = None;
-    while attempt < 180 {
+    for _ in 0..180 {
         tokio::time::sleep(Duration::from_secs(1)).await;
-        let url = format!("http://127.0.0.1:3000{}", login_path);
         if let Ok(r) = client.get(&url).send().await {
             resp = Some(r);
             break;
         }
-        attempt += 1;
     }
 
     let resp = resp.unwrap_or_else(|| panic!("{} failed to start after 180s", example_bin));
@@ -89,11 +130,7 @@ async fn run_oauth_example(package: &str, example_bin: &str, provider: &str, log
         location
     );
 
-    child.kill().expect("Failed to kill child process");
-    child.wait().expect("Failed to wait on child");
-
-    // Give the OS a moment to release the port
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    // `_guard` kills the example here (and on any panic above).
 }
 
 #[tokio::test]


### PR DESCRIPTION
Refactors the examples in `crates/authkestra/examples` **in place** around the `Engine::builder()` / unified-engine surface (RFC-001). Nothing was relocated — see the dependency-graph section for the evidence.

## Dependency graph: examples stay in the facade crate

I did not take the issue's `[!WARNING]` on faith; I reproduced the failure. Adding `authkestra-axum` as a dev-dependency of `authkestra-engine`:

- **builds fine locally** — `cargo check -p authkestra-engine --all-features` succeeds, because cargo tolerates dev-dependency cycles, and `cargo tree` shows the cycle plainly (`authkestra-engine [dev-dependencies] -> authkestra-axum v0.5.5 -> authkestra-engine v0.5.5 (*)`);
- **breaks the release**, which is the part that matters. Simulating a release-plz version bump to 0.5.6 and running `cargo publish --dry-run -p authkestra-engine`:

```
error: failed to prepare local package for uploading

Caused by:
  failed to select a version for the requirement `authkestra-axum = "^0.5.6"`
  candidate versions found which didn't match: 0.5.5, 0.5.4, 0.5.3, ...
  location searched: crates.io index
  required by package `authkestra-engine v0.5.6`
```

`authkestra-engine` cannot be published before `authkestra-axum`, which cannot be published before `authkestra-engine`. This is exactly the deadlock that 7f9ea0d ("fix: move examples to root crate to permanently resolve cyclic publish failures") already fixed by moving these examples *into* the facade. Relocating them would re-introduce a solved bug, so **nothing was moved**. The experiment was reverted; no `Cargo.toml` outside `crates/authkestra` is touched by this PR.

## Per-example status

| Example | Status |
| --- | --- |
| `axum_basic_setup.rs` | **Migrated** — canonical imports, tracing, `PORT`, 401 on no session, `/api/providers` |
| `axum_oauth2_github.rs` | **Migrated** — as above; **fixed** wrong default `redirect_uri` |
| `axum_oidc_google.rs` | **Migrated** — as above; **fixed** wrong default `redirect_uri` |
| `axum_oauth_stateless.rs` | **Migrated** — as above; **fixed** advertised login path and an `unwrap()` panic |
| `actix_basic_setup.rs` | **Migrated** — Actix counterpart, kept deliberately parallel to the Axum file |
| `actix_oauth2_github.rs` | **Migrated** — as above; **fixed** wrong default `redirect_uri` |
| `actix_oidc_google.rs` | **Migrated** — as above; **fixed** wrong default `redirect_uri` |
| `actix_oauth_stateless.rs` | **Migrated** — as above; **fixed** advertised login path and an `unwrap()` panic |
| `axum_session_redis.rs` | **Migrated** — reframed as "basic_setup with one line changed" |
| `axum_sql_store.rs` | **Migrated** — same; documented *why* the pre-existing `#![allow(deprecated)]` is legitimate |
| `axum_data_layer_macros.rs` | **Migrated** — same; added `/api/user` so the bundled page works |
| `axum_mfa_server.rs` | **Migrated** — gained a module doc (it had none), `with_webauthn` shorthand, tracing |
| `axum_op_server.rs` | **Migrated** — **fixed** `issuer`/bind-port mismatch and the literal `"issuer"` `iss` claim |
| `actix_op_server.rs` | **Migrated** — same fixes |
| `axum_op_server_sqlx.rs` | **Migrated** — same fixes |
| `actix_op_server_sqlx.rs` | **Migrated** — same fixes |
| `axum_op_server_custom_grant.rs` | **Migrated** — same fixes |
| `actix_op_server_custom_grant.rs` | **Migrated** — same fixes |
| `axum_resource_server.rs` | **Migrated** — module doc, tracing; now points at the `Guard` example as preferred |
| `axum_resource_server_strategy.rs` | **Migrated** — module doc, tracing, `PORT` |
| `actix_resource_server_strategy.rs` | **Migrated** — module doc, tracing, `PORT` |
| `axum_op_server_attestation.rs` | **Left as-is** — already on current patterns, already binds port 0, already has a thorough module doc. |
| `actix_op_server_attestation.rs` | **Left as-is** — out of scope for this PR. *(Correction, raised in review: it does **not** already bind port 0 — it hardcodes `127.0.0.1:8092`. Both attestation examples also still use `println!` rather than `tracing`, so "nothing to migrate" was wrong for this pair.)* |
| `axum_devsig/` | **Left as-is** — out of scope for this PR. *(Correction, raised in review: the stated reason — that editing these would collide with #242 — does **not** hold. PR #253 touches only `Cargo.lock` and eight files under `crates/authkestra-devsig/`, none under `examples/`. Deferring is still fine; there is no dependency to wait on.)* |
| `actix_devsig/` | **Left as-is** — same, and it hardcodes `127.0.0.1:8090`. These two are the least modernised examples in the tree. |

**Nothing deleted.**

## Bugs found and fixed

These were not cosmetic — an example that documents a wrong URL is worse than an outdated one:

1. `axum/actix_oauth2_github` and `axum/actix_oidc_google` defaulted `redirect_uri` to `/auth/{provider}/callback`. The adapters wire `/auth/callback/{provider}`. Copying these examples gave you a callback that 404s.
2. The stateless examples printed `/auth/github` as the login URL; the route is `/auth/login/github`.
3. `examples/static/index.html` linked to `/auth/login`, which is not a route at all. It now queries a new `/api/providers` endpoint and links `/auth/login/{provider}` per configured provider (and says so honestly when an example configures none).
4. The Axum session examples returned **200** with an `error` body when unauthenticated, so `res.ok` was true and the static page rendered "Welcome, undefined". Now 401, matching the Actix side.
5. Every OP example set `OpConfig::issuer` to `http://localhost:3000` (or a literal 8080) while binding elsewhere, **and** signed tokens with the literal `iss` claim `"issuer"`. Both now derive from the bind port, so discovery and the id_token `iss` agree.
6. The stateless examples called `claims.identity.as_ref().unwrap()` — a panic on any validated token without an identity (e.g. client credentials). Now a 403.

## Ports and the `AddrInUse` landmine

- Every example reads `PORT` (default 3000; 8080 for OP servers) and derives its default redirect URI from it.
- `examples_e2e.rs` reserves a free port from the OS (`127.0.0.1:0`) and passes it via `PORT`, instead of assuming 3000 is free.
- `examples_e2e.rs` now kills the spawned example from a **`Drop` guard**. This is the actual orphan source: a failed assertion unwound past the manual `kill()`, leaving the example and its `cargo run` parent holding the port, so the *next* run failed with `AddrInUse` for reasons that looked nothing like the original failure.

The e2e test still asserts exactly what it asserted before (redirect status + redirect target is the wiremock URI). No test was weakened and no `#[allow]` was added.

## Verification

```
cargo fmt --all -- --check                                                  # clean
cargo +1.98.0 clippy -p authkestra --all-targets --all-features -- -D warnings  # clean
cargo build -p authkestra --examples --all-features                         # 25/25 build
cargo test -p authkestra --all-features -- --test-threads=2                 # 4 passed, 0 failed
```

`examples_e2e` passes in 18s, with the log showing each example on an OS-assigned port (40057, 39633, 40055, 44715, ...) rather than 3000.

Refs #194. Not auto-closing: four examples are intentionally left unmigrated (two already current, two owned by concurrent work).




---

## Corrections and review fixes

Two claims in the table above were wrong; both are corrected inline, and both were caught by adversarial review rather than by me.

Findings fixed since this PR was opened:

- **`5d67ada`** — the callback-path fix this PR is *named for* had no regression coverage. Reverting it left the e2e suite green, because the assertion only checked the redirect's prefix. The authorization URL already carries `redirect_uri`, so pinning it cost one assert.
- **`c916864`** — `index.html` collapsed "endpoint absent" and "no providers registered" into the same empty list, so it asserted "This example registers no OAuth providers" on three examples that never mount `/api/providers`. True for all three, but only by luck — the page cannot know it. It now distinguishes the two.
- **`c916864`** — the OP examples registered `redirect_uris` of `http://localhost:3000/callback`, a path no sibling example serves. Same defect class as the bug this PR exists to fix, left unfixed in the OP half. They now point at `/auth/callback/github`, so an OP on :8080 and an RP on :3000 compose without editing either.
