### PR TITLE
fix(resource): gracefully reject untrusted issuers and strictly enforce iss

### DIFF
--- a/crates/authkestra-resource/src/jwt.rs
+++ b/crates/authkestra-resource/src/jwt.rs
@@ -579,17 +579,10 @@ fn build_validation(config: &ValidationConfig, multi_issuer: bool) -> Validation
         validation.set_issuer(&accepted_issuers);
     }
 
-    if multi_issuer {
-        // In multi-issuer mode `iss` selects the key, so a token without one must
-        // never reach the decode step. The resolver already refuses it; requiring
-        // the claim here means a custom resolver that is laxer than it should be
-        // still cannot let an `iss`-less token through.
-        //
-        // Gated on `multi_issuer` rather than on `trusted_issuers` being
-        // non-empty: a `with_resolver` caller resolves issuers dynamically and so
-        // configures no trust map at all, which is exactly the case this backstop
-        // was written for. Inferring it from the map left that path with neither
-        // `set_issuer` nor this check -- raised in review of #254.
+    // In multi-issuer mode `iss` selects the key. In single-issuer mode, we now also
+    // strictly require the `iss` claim if an issuer was configured, closing the legacy
+    // laxity where an `iss`-less token was accepted.
+    if multi_issuer || !accepted_issuers.is_empty() {
         validation.required_spec_claims.insert("iss".to_string());
     }
 
@@ -612,8 +605,13 @@ where
             // could only introduce a discrepancy.
             let cache = match resolve_cache(token, self.resolver.as_ref()).await {
                 Ok(cache) => cache,
-                Err(e @ (ValidationError::InvalidToken(_) | ValidationError::Jwt(_))) => {
-                    tracing::debug!(error = %e, "could not read the token's issuer; no identity");
+                Err(
+                    e @ (ValidationError::InvalidToken(_)
+                    | ValidationError::Jwt(_)
+                    | ValidationError::UntrustedIssuer(_)
+                    | ValidationError::MissingIssuer),
+                ) => {
+                    tracing::debug!(error = %e, "could not read or trust the token's issuer; no identity");
                     return Ok(None);
                 }
                 Err(e) => {

--- a/crates/authkestra-resource/tests/jwt_test.rs
+++ b/crates/authkestra-resource/tests/jwt_test.rs
@@ -603,14 +603,13 @@ async fn multi_issuer_rejects_a_token_whose_issuer_is_not_in_the_trust_map() {
         .trusted_issuer(ISS_B, jwks_url(&server_b))
         .build();
     let strategy: JwtStrategy<IssuedClaims> = JwtStrategy::new(config);
-    let err = strategy
+    let res = strategy
         .authenticate(&bearer_request_parts(&token, None))
         .await
-        .expect_err("an untrusted issuer must surface as an error, not as an identity");
+        .expect("authenticate must not fail on untrusted issuer");
     assert!(
-        err.to_string()
-            .contains("is not in the configured trust map"),
-        "rejection must name the untrusted issuer as the reason, got: {err}"
+        res.is_none(),
+        "an untrusted issuer must be rejected gracefully as Ok(None) to allow fallback"
     );
 }
 
@@ -637,14 +636,13 @@ async fn multi_issuer_never_falls_back_to_the_single_issuer_jwks_url() {
         Some("a-key"),
         &issued_claims(Some(ISS_UNTRUSTED), "user-1"),
     );
-    let err = strategy
+    let res = strategy
         .authenticate(&bearer_request_parts(&token, None))
         .await
-        .expect_err("an unnamed jwks_url must never verify a token from an untrusted issuer");
+        .expect("authenticate must not fail on unnamed jwks_url");
     assert!(
-        err.to_string()
-            .contains("is not in the configured trust map"),
-        "expected an untrusted-issuer rejection, got: {err}"
+        res.is_none(),
+        "an unnamed jwks_url must never verify a token from an untrusted issuer"
     );
 
     // The trust map itself still works.
@@ -826,13 +824,13 @@ async fn single_issuer_configuration_is_unchanged_by_multi_issuer_support() {
         Some("a-key"),
         &issued_claims(None, "user-1"),
     );
+    let res = strategy
+        .authenticate(&bearer_request_parts(&token, None))
+        .await
+        .expect("authenticate must not error on missing issuer");
     assert!(
-        strategy
-            .authenticate(&bearer_request_parts(&token, None))
-            .await
-            .expect("authenticate should not error")
-            .is_some(),
-        "single-issuer behaviour must be unchanged, including this pre-existing laxity"
+        res.is_none(),
+        "single-issuer mode now strictly requires the iss claim, failing as Ok(None)"
     );
 }
 


### PR DESCRIPTION
Resolves the pending decisions from #243.
- Untrusted issuers and missing issuers now map to Ok(None) so the authentication strategy chain can gracefully fall back (e.g. to API keys) under AuthPolicy::FirstSuccess.
- In single-issuer mode, the 'iss' claim is now strictly required if an issuer is configured, closing the legacy laxity.