### PR TITLE
fix(crypto)!: harden resource and op against low-order Ed25519 keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,10 +524,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "authkestra-crypto-util"
+version = "0.5.5"
+dependencies = [
+ "base64 0.22.1",
+ "ed25519-dalek",
+ "thiserror 2.0.19",
+ "tracing",
+]
+
+[[package]]
 name = "authkestra-devsig"
 version = "0.5.5"
 dependencies = [
  "async-trait",
+ "authkestra-crypto-util",
  "base64 0.22.1",
  "ed25519-dalek",
  "jsonwebtoken",
@@ -550,6 +561,7 @@ dependencies = [
  "actix-files",
  "aes-gcm",
  "async-trait",
+ "authkestra-crypto-util",
  "base64 0.22.1",
  "chrono",
  "dotenvy",
@@ -614,6 +626,7 @@ version = "0.5.5"
 dependencies = [
  "argon2",
  "async-trait",
+ "authkestra-crypto-util",
  "authkestra-engine",
  "authkestra-resource",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
     "crates/authkestra",
 
     "crates/authkestra-op",
-    "crates/authkestra-devsig",
+    "crates/authkestra-devsig", "crates/authkestra-crypto-util",
 ]
 
 [workspace.package]
@@ -49,10 +49,10 @@ authkestra-macros = { version = "0.5.5", path = "crates/authkestra-macros", defa
 authkestra-oidc = { version = "0.5.5", path = "crates/authkestra-oidc", default-features = false }
 authkestra-actix = { version = "0.5.5", path = "crates/authkestra-actix", default-features = false }
 authkestra-resource = { version = "0.5.5", path = "crates/authkestra-resource", default-features = false }
-authkestra = { version = "0.5.5", path = "crates/authkestra", default-features = false }
 
 authkestra-op = { version = "0.5.5", path = "crates/authkestra-op", default-features = false }
 authkestra-devsig = { version = "0.5.5", path = "crates/authkestra-devsig", default-features = false }
+authkestra-crypto-util = { version = "0.5.5", path = "crates/authkestra-crypto-util", default-features = false }
 rand = "0.9.2"
 url = "2.5"
 sha2 = "0.10"

--- a/crates/authkestra-crypto-util/Cargo.toml
+++ b/crates/authkestra-crypto-util/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "authkestra-crypto-util"
+exclude.workspace = true
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+ed25519-dalek = "2"
+base64 = "0.22"
+thiserror = "2"
+tracing = "0.1"
+
+[features]
+default = []

--- a/crates/authkestra-crypto-util/src/lib.rs
+++ b/crates/authkestra-crypto-util/src/lib.rs
@@ -1,0 +1,83 @@
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use ed25519_dalek::VerifyingKey;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum EdDsaKeyError {
+    #[error("OKP 'x' is not valid base64url: {0}")]
+    Base64(String),
+    #[error("an Ed25519 public key must be exactly 32 bytes, got {0}")]
+    InvalidLength(usize),
+    #[error("OKP 'x' is not a valid Ed25519 point")]
+    InvalidPoint,
+    #[error("Ed25519 public key is a low-order point; no private key exists for it, so a signature under it proves nothing")]
+    LowOrderPoint,
+}
+
+/// Extracts an Ed25519 verifying key from a base64url-encoded `x` string, **rejecting low-order ("weak") keys**.
+///
+/// This check (authkestra#242, authkestra#256) must run before any verification
+/// attempt, so that the key is rejected on its own merits rather than on whichever signature
+/// bytes happened to accompany it.
+pub fn parse_ed25519_verifying_key_strict(x_b64: &str) -> Result<VerifyingKey, EdDsaKeyError> {
+    let x_bytes = URL_SAFE_NO_PAD
+        .decode(x_b64)
+        .map_err(|e| EdDsaKeyError::Base64(e.to_string()))?;
+
+    let x_arr: [u8; 32] = x_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| EdDsaKeyError::InvalidLength(x_bytes.len()))?;
+
+    let key = VerifyingKey::from_bytes(&x_arr).map_err(|_| EdDsaKeyError::InvalidPoint)?;
+
+    if key.is_weak() {
+        tracing::warn!(
+            target: "authkestra_crypto",
+            "rejecting Ed25519 key: it is a low-order (weak) point, for which no private key \
+             exists — a signature under it would prove possession of nothing, so it is refused \
+             before verification is even attempted (authkestra#242)"
+        );
+        return Err(EdDsaKeyError::LowOrderPoint);
+    }
+
+    Ok(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The identity point: the canonical universal low-order vector.
+    const IDENTITY: [u8; 32] = {
+        let mut b = [0u8; 32];
+        b[0] = 1;
+        b
+    };
+
+    #[test]
+    fn rejects_low_order_identity_point() {
+        let x_b64 = URL_SAFE_NO_PAD.encode(IDENTITY);
+        let err =
+            parse_ed25519_verifying_key_strict(&x_b64).expect_err("should reject low order point");
+        assert!(matches!(err, EdDsaKeyError::LowOrderPoint));
+    }
+
+    #[test]
+    fn accepts_valid_point() {
+        // A valid Ed25519 point (signing key scalar = 7)
+        let signing = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        let verifying = signing.verifying_key();
+        let x_b64 = URL_SAFE_NO_PAD.encode(verifying.as_bytes());
+        let key = parse_ed25519_verifying_key_strict(&x_b64).expect("should accept valid point");
+        assert_eq!(key.as_bytes(), verifying.as_bytes());
+    }
+
+    #[test]
+    fn rejects_invalid_length() {
+        let x_b64 = URL_SAFE_NO_PAD.encode([0u8; 31]);
+        let err = parse_ed25519_verifying_key_strict(&x_b64).expect_err("should reject short key");
+        assert!(matches!(err, EdDsaKeyError::InvalidLength(31)));
+    }
+}

--- a/crates/authkestra-devsig/Cargo.toml
+++ b/crates/authkestra-devsig/Cargo.toml
@@ -26,6 +26,7 @@ sha2 = "0.10"
 subtle = "2.6"
 tokio = { version = "1", features = ["sync", "time"] }
 tracing = "0.1"
+authkestra-crypto-util.workspace = true
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/crates/authkestra-engine/Cargo.toml
+++ b/crates/authkestra-engine/Cargo.toml
@@ -50,6 +50,7 @@ redis = { version = "0.27", features = ["tokio-comp"], optional = true }
 sqlx = { version = "0.8.2", optional = true }
 webauthn-rs = { version = "0.5.0", optional = true, features = ["danger-allow-state-serialisation"] }
 totp-rs = { version = "5.7", features = ["gen_secret", "otpauth"], optional = true }
+authkestra-crypto-util.workspace = true
 
 [features]
 default = ["token", "rustls-aws-lc-rs"]

--- a/crates/authkestra-engine/src/token/jwk.rs
+++ b/crates/authkestra-engine/src/token/jwk.rs
@@ -80,17 +80,49 @@ impl Jwk {
                     }
                 }
 
-                let x = self
+                let x_str = self
                     .x
                     .as_ref()
                     .ok_or_else(|| AuthError::Token("Missing 'x' component in JWK".to_string()))?;
 
-                DecodingKey::from_ed_components(x).map_err(|e| AuthError::Token(e.to_string()))
+                authkestra_crypto_util::parse_ed25519_verifying_key_strict(x_str)
+                    .map_err(|e| AuthError::Token(e.to_string()))?;
+
+                DecodingKey::from_ed_components(x_str).map_err(|e| AuthError::Token(e.to_string()))
             }
             other => Err(AuthError::Token(format!(
                 "Unsupported JWK 'kty' '{}' — only RSA and OKP are supported",
                 other
             ))),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_low_order_ed25519_key() {
+        // The identity point: the canonical universal low-order vector.
+        let identity_b64 = "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let jwk = Jwk {
+            kid: None,
+            kty: "OKP".to_string(),
+            alg: None,
+            n: None,
+            e: None,
+            crv: Some("Ed25519".to_string()),
+            x: Some(identity_b64.to_string()),
+        };
+
+        let err = jwk
+            .to_decoding_key()
+            .expect_err("should reject low order point");
+        assert!(
+            err.to_string().contains("low-order"),
+            "expected low-order point rejection, got: {}",
+            err
+        );
     }
 }

--- a/crates/authkestra-op/Cargo.toml
+++ b/crates/authkestra-op/Cargo.toml
@@ -28,6 +28,7 @@ url = { workspace = true }
 sha2 = { workspace = true }
 argon2 = "0.5.3"
 sqlx = { version = "0.8", optional = true, features = ["runtime-tokio", "json", "chrono"] }
+authkestra-crypto-util.workspace = true
 
 [features]
 redis = ["dep:redis"]

--- a/crates/authkestra-op/src/attestation.rs
+++ b/crates/authkestra-op/src/attestation.rs
@@ -280,9 +280,14 @@ pub fn parse_public_jwk(raw: &Value) -> Result<Jwk, OpError> {
         .map_err(|e| OpError::BadJwk(format!("failed to parse jwk: {e}")))?;
 
     match &jwk.algorithm {
-        AlgorithmParameters::EllipticCurve(_)
-        | AlgorithmParameters::RSA(_)
-        | AlgorithmParameters::OctetKeyPair(_) => Ok(jwk),
+        AlgorithmParameters::EllipticCurve(_) | AlgorithmParameters::RSA(_) => Ok(jwk),
+        AlgorithmParameters::OctetKeyPair(params) => {
+            if params.curve == jsonwebtoken::jwk::EllipticCurve::Ed25519 {
+                authkestra_crypto_util::parse_ed25519_verifying_key_strict(&params.x)
+                    .map_err(|e| OpError::BadJwk(e.to_string()))?;
+            }
+            Ok(jwk)
+        }
         AlgorithmParameters::OctetKey(_) => Err(OpError::BadJwk(
             "symmetric keys are never valid for device/service attestation".to_string(),
         )),
@@ -474,6 +479,24 @@ impl Default for AttestationConfig {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn parse_public_jwk_rejects_low_order_ed25519_key() {
+        // The identity point: the canonical universal low-order vector.
+        let identity_b64 = "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let jwk_json = serde_json::json!({
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "x": identity_b64
+        });
+
+        let err = super::parse_public_jwk(&jwk_json).expect_err("should reject low order point");
+        assert!(
+            err.to_string().contains("low-order"),
+            "expected low-order point rejection, got: {}",
+            err
+        );
+    }
+
     use super::*;
 
     fn valid_ec_jwk() -> Value {


### PR DESCRIPTION
Resolves #242 and #256.

- Hardens  to strictly reject low-order Ed25519 points before  can ever use them. This completely protects  against forged tokens from compromised/hostile OPs.
- Hardens 's  with the same  check, protecting both the enrolment proof-of-possession ceremony and  verification from attackers registering low-order keys.