### PR TITLE
fix(crypto): add missing description to authkestra-crypto-util

### DIFF
--- a/crates/authkestra-crypto-util/Cargo.toml
+++ b/crates/authkestra-crypto-util/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "authkestra-crypto-util"
+description = "Internal cryptographic utilities for the authkestra framework, specifically for strict signature and key verification"
 exclude.workspace = true
 version.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Fixes the automated release-plz failure that occurred because `authkestra-crypto-util` was missing the required `description` field in its `Cargo.toml`.