### PR TITLE
fix(op): verify EdDSA strictly and refuse low-order enrolment keys (#256)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,7 @@ dependencies = [
  "authkestra-resource",
  "base64 0.22.1",
  "chrono",
+ "ed25519-dalek",
  "jsonwebtoken",
  "p256",
  "rand 0.9.5",

--- a/crates/authkestra-op/Cargo.toml
+++ b/crates/authkestra-op/Cargo.toml
@@ -21,6 +21,13 @@ async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4"] }
 jsonwebtoken = { version = "11", features = ["rust_crypto"] }
+# Direct, not transitive-by-accident: `crate::strict_jws` calls
+# `VerifyingKey::verify_strict` itself because `jsonwebtoken`'s EdDSA backend uses the
+# non-strict verifier (authkestra#256). This adds no new code to the dependency graph —
+# `jsonwebtoken`'s `rust_crypto` backend, already enabled above, resolves the same
+# `ed25519-dalek` 2.x, as does `authkestra-crypto-util` below. Same rationale, and same
+# wording, as `authkestra-devsig`'s equivalent dependency added by #253.
+ed25519-dalek = "2"
 tracing = "0.1.44"
 rand = { workspace = true }
 base64 = "0.22.1"

--- a/crates/authkestra-op/src/attestation.rs
+++ b/crates/authkestra-op/src/attestation.rs
@@ -282,10 +282,41 @@ pub fn parse_public_jwk(raw: &Value) -> Result<Jwk, OpError> {
     match &jwk.algorithm {
         AlgorithmParameters::EllipticCurve(_) | AlgorithmParameters::RSA(_) => Ok(jwk),
         AlgorithmParameters::OctetKeyPair(params) => {
-            if params.curve == jsonwebtoken::jwk::EllipticCurve::Ed25519 {
-                authkestra_crypto_util::parse_ed25519_verifying_key_strict(&params.x)
-                    .map_err(|e| OpError::BadJwk(e.to_string()))?;
+            // `crv` is checked first, and non-Ed25519 is a hard refusal rather
+            // than a pass-through (authkestra#256). `jsonwebtoken`'s
+            // `OctetKeyPairParameters::curve` is the *shared* `EllipticCurve`
+            // enum, so `{"kty":"OKP","crv":"P-256"}` deserialises happily into
+            // this variant — while `expected_algorithm` maps every
+            // `OctetKeyPair` to `Algorithm::EdDSA` and
+            // `DecodingKey::from_jwk` sends every `OctetKeyPair` to
+            // `from_ed_components`, both regardless of `crv`. So `x` is
+            // interpreted as Ed25519 bytes whatever `crv` claims, and a
+            // low-order check written as `if crv == Ed25519 { ... }` is
+            // simply skipped by setting `crv` to anything else. Refusing the
+            // key outright is what makes the check below unavoidable.
+            if params.curve != jsonwebtoken::jwk::EllipticCurve::Ed25519 {
+                tracing::warn!(
+                    curve = ?params.curve,
+                    "rejecting OKP jwk: Ed25519 is the only OKP curve this OP verifies, and every \
+                     OKP key is decoded as Ed25519 downstream — accepting another `crv` would let \
+                     a key skip the low-order check while still reaching the Ed25519 verifier \
+                     (authkestra#256)"
+                );
+                return Err(OpError::BadJwk(format!(
+                    "Ed25519 is the only supported OKP curve, got {:?}",
+                    params.curve
+                )));
             }
+
+            authkestra_crypto_util::parse_ed25519_verifying_key_strict(&params.x).map_err(|e| {
+                tracing::warn!(
+                    error = %e,
+                    "rejecting OKP jwk at ingest; a low-order point here would let the OP mint an \
+                     attestation for a key no private key exists for (authkestra#256)"
+                );
+                OpError::BadJwk(e.to_string())
+            })?;
+
             Ok(jwk)
         }
         AlgorithmParameters::OctetKey(_) => Err(OpError::BadJwk(
@@ -428,6 +459,26 @@ pub(crate) fn verify_challenge_signature(compact_jws: &str, jwk: &Jwk) -> Result
     }
 
     let algorithm = expected_algorithm(jwk)?;
+
+    // Strict EdDSA gate, ahead of `jsonwebtoken`'s non-strict backend
+    // (authkestra#256). A no-op for non-OKP keys. Runs before `decode` so a
+    // low-order key or a low-order `R` can never satisfy proof of possession;
+    // see `strict_jws`'s module doc for why this gates rather than replaces.
+    if let Err(rejection) = crate::strict_jws::ensure_strict_eddsa_signature(compact_jws, jwk) {
+        return Err(match rejection {
+            // A bad KEY is not a bad signature: surfacing this as
+            // `ChallengeSignatureInvalid` would hide that the key is the defect.
+            crate::strict_jws::StrictEdDsaRejection::Key(msg) => {
+                tracing::warn!(error = %msg, "enrolment challenge key refused before verification");
+                OpError::BadJwk(msg)
+            }
+            crate::strict_jws::StrictEdDsaRejection::Signature(msg) => {
+                tracing::warn!(error = %msg, "enrolment challenge signature failed strict EdDSA verification");
+                OpError::ChallengeSignatureInvalid
+            }
+        });
+    }
+
     let decoding_key = DecodingKey::from_jwk(jwk).map_err(|e| OpError::BadJwk(e.to_string()))?;
 
     let mut validation = Validation::new(algorithm);

--- a/crates/authkestra-op/src/client_assertion.rs
+++ b/crates/authkestra-op/src/client_assertion.rs
@@ -370,6 +370,36 @@ pub fn verify_client_assertion(
     })?;
 
     let jwk = select_key(jwks, header.kid.as_deref())?;
+
+    // Strict EdDSA gate, ahead of `jsonwebtoken`'s non-strict backend
+    // (authkestra#256). A no-op for non-OKP keys. Lower reachability than the
+    // enrolment path — this key was registered by an administrator rather than
+    // supplied in the request — but it is the same defect, and "registered by
+    // an administrator" is not "provably not low-order".
+    if let Err(rejection) = crate::strict_jws::ensure_strict_eddsa_signature(assertion, &jwk) {
+        return Err(match rejection {
+            // A bad KEY is not a bad assertion: a low-order registered key is an
+            // operator-facing defect in the client's JWKS, not a client that
+            // signed badly.
+            crate::strict_jws::StrictEdDsaRejection::Key(msg) => {
+                tracing::warn!(
+                    client_id = %client.client_id,
+                    error = %msg,
+                    "registered jwk refused before verification"
+                );
+                OpError::BadJwk(msg)
+            }
+            crate::strict_jws::StrictEdDsaRejection::Signature(msg) => {
+                tracing::warn!(
+                    client_id = %client.client_id,
+                    error = %msg,
+                    "client assertion failed strict EdDSA verification"
+                );
+                OpError::InvalidClientAssertion
+            }
+        });
+    }
+
     let algorithms = assertion_algorithms(&jwk)?;
     let decoding_key = DecodingKey::from_jwk(&jwk).map_err(|e| {
         tracing::warn!(client_id = %client.client_id, error = %e, "registered jwk is unusable");
@@ -513,6 +543,83 @@ pub(crate) mod tests {
             "exp": (Utc::now() + chrono::Duration::seconds(60)).timestamp(),
             "iat": Utc::now().timestamp(),
         })
+    }
+
+    // ---------------------------------------------------------------------
+    // authkestra#256, `private_key_jwt` half.
+    //
+    // Lower reachability than enrolment: there is no dynamic-registration
+    // endpoint, so a low-order key has to have been registered by an
+    // administrator. Defence in depth — but "an administrator pasted it in"
+    // is not evidence that a key is not low-order.
+    // ---------------------------------------------------------------------
+
+    /// The Ed25519 identity point: the canonical *universal* low-order vector.
+    const IDENTITY_POINT: [u8; 32] = {
+        let mut b = [0u8; 32];
+        b[0] = 1;
+        b
+    };
+
+    fn b64(bytes: &[u8]) -> String {
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+    }
+
+    fn okp_jwks(crv: &str, x: &[u8]) -> Value {
+        serde_json::json!({ "keys": [{ "kty": "OKP", "crv": crv, "x": b64(x) }] })
+    }
+
+    /// `(R = identity, S = 0)` over arbitrary claims: under non-strict
+    /// verification this verifies against the identity key for any message.
+    fn forged_eddsa_assertion(claims: &Value) -> String {
+        let header = b64(br#"{"alg":"EdDSA"}"#);
+        let payload = b64(claims.to_string().as_bytes());
+        let mut sig = [0u8; 64];
+        sig[..32].copy_from_slice(&IDENTITY_POINT);
+        format!("{header}.{payload}.{}", b64(&sig))
+    }
+
+    #[test]
+    fn rejects_a_client_assertion_under_a_low_order_ed25519_key() {
+        for crv in ["Ed25519", "P-256"] {
+            let client = test_client(Some(okp_jwks(crv, &IDENTITY_POINT)));
+            let assertion = forged_eddsa_assertion(&good_claims());
+
+            let outcome = verify_client_assertion(&assertion, &client, &audiences());
+
+            assert!(
+                outcome.is_err(),
+                "VULNERABLE: a client authenticated with a low-order Ed25519 key \
+                 (crv={crv}) that nobody holds a private key for: {outcome:?}"
+            );
+            // A bad KEY is not a bad assertion.
+            assert!(
+                matches!(outcome, Err(OpError::BadJwk(_))),
+                "expected BadJwk for crv={crv}, got {outcome:?}"
+            );
+        }
+    }
+
+    /// Positive control: a genuine registered Ed25519 client key must still
+    /// authenticate. `private_key_jwt` with EdDSA is a supported, conformant
+    /// configuration and this fix must not break it.
+    #[test]
+    fn still_accepts_an_assertion_under_a_genuine_ed25519_key() {
+        let signing = ed25519_dalek::SigningKey::from_bytes(&[13u8; 32]);
+        let client = test_client(Some(okp_jwks(
+            "Ed25519",
+            signing.verifying_key().as_bytes(),
+        )));
+
+        let header = b64(br#"{"alg":"EdDSA"}"#);
+        let payload = b64(good_claims().to_string().as_bytes());
+        let signing_input = format!("{header}.{payload}");
+        let sig = ed25519_dalek::Signer::sign(&signing, signing_input.as_bytes());
+        let assertion = format!("{signing_input}.{}", b64(&sig.to_bytes()));
+
+        let verified = verify_client_assertion(&assertion, &client, &audiences())
+            .expect("a genuine Ed25519 client assertion must still authenticate");
+        assert_eq!(verified.jti, "jti-1");
     }
 
     #[test]

--- a/crates/authkestra-op/src/client_assertion.rs
+++ b/crates/authkestra-op/src/client_assertion.rs
@@ -600,6 +600,49 @@ pub(crate) mod tests {
         }
     }
 
+    /// Directly exercises the **second** gate in `verify_client_assertion`, the
+    /// one `rejects_a_client_assertion_under_a_low_order_ed25519_key` above
+    /// cannot reach.
+    ///
+    /// Raised in review of #265, and measured: deleting the whole
+    /// `ensure_strict_eddsa_signature` block from `verify_client_assertion`
+    /// left the suite at `153 passed; 0 failed`. Every existing test routes
+    /// through `select_key` -> `parse_public_jwk`, which refuses these keys at
+    /// ingest, so the strict gate never ran and nothing pinned it.
+    ///
+    /// This is the same vacuity trap the author identified and fixed for the
+    /// enrolment test (`challenge_signature_verification_itself_refuses_low_order_keys`);
+    /// it simply was not re-applied here. Built with `serde_json::from_value`
+    /// rather than `parse_public_jwk` for exactly that reason: ingest is
+    /// bypassed on purpose so the gate under test is the one that runs.
+    #[test]
+    fn strict_gate_itself_refuses_low_order_keys_for_client_assertions() {
+        for crv in ["Ed25519", "P-256", "P-384", "P-521"] {
+            let jwk: Jwk = serde_json::from_value(
+                serde_json::json!({"kty":"OKP","crv":crv,"x": b64(&IDENTITY_POINT)}),
+            )
+            .expect("test jwk must parse");
+
+            let assertion = forged_eddsa_assertion(&good_claims());
+            let outcome = crate::strict_jws::ensure_strict_eddsa_signature(&assertion, &jwk);
+
+            assert!(
+                outcome.is_err(),
+                "VULNERABLE: the strict gate accepted the universal low-order forgery \
+                 for crv={crv}: {outcome:?}"
+            );
+            // A bad KEY, not a bad signature -- the classification convention
+            // shared with authkestra-devsig.
+            assert!(
+                matches!(
+                    outcome,
+                    Err(crate::strict_jws::StrictEdDsaRejection::Key(_))
+                ),
+                "expected a Key rejection for crv={crv}, got {outcome:?}"
+            );
+        }
+    }
+
     /// Positive control: a genuine registered Ed25519 client key must still
     /// authenticate. `private_key_jwt` with EdDSA is a supported, conformant
     /// configuration and this fix must not break it.

--- a/crates/authkestra-op/src/handlers/enrolment.rs
+++ b/crates/authkestra-op/src/handlers/enrolment.rs
@@ -397,6 +397,7 @@ mod tests {
     }
     use async_trait::async_trait;
     use authkestra_engine::store::memory::MemoryStore;
+    use jsonwebtoken::jwk::Jwk;
     use jsonwebtoken::{Algorithm, EncodingKey, Header};
     use p256::ecdsa::SigningKey;
     use p256::elliptic_curve::{JwkEcKey, PublicKey};
@@ -476,6 +477,279 @@ mod tests {
 
     fn test_tokens() -> TokenManager {
         TokenManager::new(b"super_secret_key_that_is_long_enough_for_hmac", None)
+    }
+
+    // ---------------------------------------------------------------------
+    // authkestra#256: low-order Ed25519 keys must never be enrolled.
+    // ---------------------------------------------------------------------
+
+    /// The Ed25519 identity point, encoded as a compressed Edwards point.
+    ///
+    /// This is the *universal* forgery vector, and it is deliberately not the
+    /// all-zero encoding: the all-zero encoding is an order-4 point that only
+    /// verifies for roughly one message in four, whereas the identity
+    /// verifies for every message.
+    const IDENTITY_POINT: [u8; 32] = {
+        let mut b = [0u8; 32];
+        b[0] = 1;
+        b
+    };
+
+    fn b64(bytes: &[u8]) -> String {
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+    }
+
+    /// The canned signature `(R = identity, S = 0)`.
+    ///
+    /// Under **non-strict** Ed25519 verification both sides of
+    /// `[S]B - [k]A == R` collapse to the identity for every challenge scalar
+    /// `k`, so this single 64-byte constant verifies against the identity
+    /// public key for *any* message. No private key exists for that public
+    /// key — not "is unknown", does not exist.
+    fn forged_universal_signature() -> [u8; 64] {
+        let mut sig = [0u8; 64];
+        sig[..32].copy_from_slice(&IDENTITY_POINT);
+        sig
+    }
+
+    /// A compact JWS whose signature is the canned universal forgery.
+    fn forged_challenge_jws(challenge: &str) -> String {
+        let header = b64(br#"{"alg":"EdDSA"}"#);
+        let payload = b64(serde_json::json!({ "challenge": challenge })
+            .to_string()
+            .as_bytes());
+        format!("{header}.{payload}.{}", b64(&forged_universal_signature()))
+    }
+
+    /// Runs the whole enrolment ceremony with `public_jwk` and returns
+    /// whichever step refused it — or `Ok(())` if an attestation was minted,
+    /// which for a forged key is the vulnerability.
+    async fn attempt_forged_enrolment(public_jwk: Value) -> Result<String, OpError> {
+        let challenges = MemoryStore::<EnrolmentChallenge>::new();
+        let tokens = test_tokens();
+        let config = test_config();
+
+        let start_res = handle_enrol_start(
+            EnrolStartRequest {
+                subject: "victim".to_string(),
+                principal_id: "attacker-device".to_string(),
+                principal_type: PrincipalType::Device,
+                public_jwk,
+                attributes: Value::Null,
+                second_factor: SecondFactorProof {
+                    kind: "sms_otp".to_string(),
+                    value: "123456".to_string(),
+                },
+                requested_cnf_jkt: None,
+            },
+            &AlwaysPassSecondFactor,
+            &challenges,
+            &config,
+        )
+        .await?;
+
+        let signature = forged_challenge_jws(&start_res.challenge);
+
+        let complete_res = handle_complete_challenge(
+            CompleteChallengeRequest {
+                challenge: start_res.challenge,
+                challenge_signature: signature,
+            },
+            &challenges,
+            &tokens,
+            &config,
+        )
+        .await?;
+
+        Ok(complete_res.attestation)
+    }
+
+    /// The exact vector authkestra#256 names: `crv: "Ed25519"` carrying the
+    /// identity point. Closed at ingest by #261; this pins it so the gate
+    /// cannot be removed silently.
+    #[tokio::test]
+    async fn enrolment_refuses_the_low_order_identity_point() {
+        let jwk = serde_json::json!({
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "x": b64(&IDENTITY_POINT),
+        });
+
+        match attempt_forged_enrolment(jwk).await {
+            Err(OpError::BadJwk(msg)) => assert!(
+                msg.contains("low-order"),
+                "expected the key to be refused as low-order, got: {msg}"
+            ),
+            Err(other) => panic!(
+                "expected BadJwk(low-order); got {other:?} — the key must be \
+                 refused on its own merits, not as a bad signature"
+            ),
+            Ok(attestation) => panic!(
+                "VULNERABLE: the OP minted an attestation for a low-order key \
+                 nobody holds a private key for: {attestation}"
+            ),
+        }
+    }
+
+    /// The same forgery smuggled past a `crv`-equality gate.
+    ///
+    /// `jsonwebtoken`'s `OctetKeyPairParameters::curve` is the *shared*
+    /// `EllipticCurve` enum, so `{"kty":"OKP","crv":"P-256"}` deserialises to
+    /// the `OctetKeyPair` variant carrying `P256`. `expected_algorithm` maps
+    /// **every** `OctetKeyPair` to `Algorithm::EdDSA`, and
+    /// `DecodingKey::from_jwk` sends every `OctetKeyPair` to
+    /// `from_ed_components` regardless of `crv` — so `x` is interpreted as
+    /// Ed25519 bytes either way. A low-order check written as
+    /// `if params.curve == Ed25519` therefore never runs for this key, while
+    /// the Ed25519 verifier still does.
+    #[tokio::test]
+    async fn enrolment_refuses_a_low_order_key_smuggled_past_the_crv_gate() {
+        let jwk = serde_json::json!({
+            "kty": "OKP",
+            "crv": "P-256",
+            "x": b64(&IDENTITY_POINT),
+        });
+
+        match attempt_forged_enrolment(jwk).await {
+            Err(OpError::BadJwk(_)) => {}
+            Err(other) => panic!("expected BadJwk; got {other:?}"),
+            Ok(attestation) => panic!(
+                "VULNERABLE: an OKP key with a non-Ed25519 `crv` bypassed the \
+                 low-order gate and the OP minted an attestation for it: {attestation}"
+            ),
+        }
+    }
+
+    /// The proof-of-possession check must refuse the forgery *on its own*.
+    ///
+    /// Regression guard with teeth: on `main` before this fix, the
+    /// `crv`-confusion vector below reached
+    /// [`verify_challenge_signature`] and it returned `Ok("CHAL")` — the
+    /// forged signature verified. The full ceremony was saved only
+    /// incidentally, by [`compute_cnf_jkt`] later failing with
+    /// `InvalidKeyFormat` because `jsonwebtoken` will not thumbprint an OKP
+    /// key whose `crv` is not Ed25519. That is an accident of an unrelated
+    /// downstream step, not a security control, and it would evaporate the
+    /// moment thumbprinting grew support for another OKP curve. This test
+    /// asserts the *verifier itself* refuses these keys, so the fix cannot
+    /// silently regress into depending on that accident again.
+    #[test]
+    fn challenge_signature_verification_itself_refuses_low_order_keys() {
+        for crv in ["Ed25519", "P-256", "P-384", "P-521"] {
+            // Deliberately built with `serde_json::from_value` rather than
+            // `parse_public_jwk`: routing through ingest would make this test
+            // vacuous, because ingest refuses these keys first and
+            // `verify_challenge_signature` would never run. The point here is
+            // the second gate, so the first one is bypassed on purpose.
+            let jwk: Jwk = serde_json::from_value(
+                serde_json::json!({"kty":"OKP","crv":crv,"x": b64(&IDENTITY_POINT)}),
+            )
+            .expect("test jwk must parse");
+
+            let outcome = verify_challenge_signature(&forged_challenge_jws("CHAL"), &jwk);
+
+            assert!(
+                outcome.is_err(),
+                "VULNERABLE: verify_challenge_signature accepted the universal low-order \
+                 forgery for crv={crv}: {outcome:?}"
+            );
+            // A bad KEY, not a bad signature — the classification convention
+            // this crate shares with authkestra-devsig.
+            assert!(
+                matches!(outcome, Err(OpError::BadJwk(_))),
+                "expected BadJwk for crv={crv}, got {outcome:?}"
+            );
+        }
+    }
+
+    /// Positive control for the second gate: a genuine Ed25519 signature must
+    /// survive `verify_challenge_signature` unchanged.
+    #[test]
+    fn challenge_signature_verification_still_accepts_a_genuine_ed25519_signature() {
+        let signing = ed25519_dalek::SigningKey::from_bytes(&[11u8; 32]);
+        let jwk: Jwk = serde_json::from_value(serde_json::json!({
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "x": b64(signing.verifying_key().as_bytes()),
+        }))
+        .unwrap();
+
+        let header = b64(br#"{"alg":"EdDSA"}"#);
+        let payload = b64(serde_json::json!({ "challenge": "CHAL" })
+            .to_string()
+            .as_bytes());
+        let signing_input = format!("{header}.{payload}");
+        let sig = ed25519_dalek::Signer::sign(&signing, signing_input.as_bytes());
+
+        let out =
+            verify_challenge_signature(&format!("{signing_input}.{}", b64(&sig.to_bytes())), &jwk)
+                .expect("a genuine Ed25519 challenge signature must still verify");
+        assert_eq!(out, "CHAL");
+    }
+
+    /// Positive control: a fix that rejects everything is not a fix. A genuine
+    /// Ed25519 device key must still complete the ceremony end to end.
+    #[tokio::test]
+    async fn genuine_ed25519_key_still_enrols_end_to_end() {
+        let challenges = MemoryStore::<EnrolmentChallenge>::new();
+        let tokens = test_tokens();
+        let config = test_config();
+
+        let signing = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        let public_jwk = serde_json::json!({
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "x": b64(signing.verifying_key().as_bytes()),
+        });
+
+        let start_res = handle_enrol_start(
+            EnrolStartRequest {
+                subject: "user-ed".to_string(),
+                principal_id: "device-ed".to_string(),
+                principal_type: PrincipalType::Device,
+                public_jwk: public_jwk.clone(),
+                attributes: serde_json::json!({"kyc_level": 3}),
+                second_factor: SecondFactorProof {
+                    kind: "sms_otp".to_string(),
+                    value: "123456".to_string(),
+                },
+                requested_cnf_jkt: None,
+            },
+            &AlwaysPassSecondFactor,
+            &challenges,
+            &config,
+        )
+        .await
+        .expect("a genuine Ed25519 key must be accepted at enrolment start");
+
+        let header = b64(br#"{"alg":"EdDSA"}"#);
+        let payload = b64(serde_json::json!({ "challenge": start_res.challenge })
+            .to_string()
+            .as_bytes());
+        let signing_input = format!("{header}.{payload}");
+        let sig = ed25519_dalek::Signer::sign(&signing, signing_input.as_bytes());
+        let jws = format!("{signing_input}.{}", b64(&sig.to_bytes()));
+
+        let complete_res = handle_complete_challenge(
+            CompleteChallengeRequest {
+                challenge: start_res.challenge,
+                challenge_signature: jws,
+            },
+            &challenges,
+            &tokens,
+            &config,
+        )
+        .await
+        .expect("a genuine Ed25519 signature must complete the ceremony");
+
+        let claims = tokens
+            .validate_token(&complete_res.attestation, None)
+            .unwrap();
+        assert_eq!(claims.sub, "user-ed");
+        assert_eq!(claims.extra.get("did").unwrap(), "device-ed");
+
+        let expected_jkt = compute_cnf_jkt(&parse_public_jwk(&public_jwk).unwrap()).unwrap();
+        assert_eq!(claims.extra.get("cnf").unwrap()["jkt"], expected_jkt);
     }
 
     #[tokio::test]

--- a/crates/authkestra-op/src/lib.rs
+++ b/crates/authkestra-op/src/lib.rs
@@ -44,6 +44,13 @@ pub use attestation::{
     PrincipalType, SecondFactorProof, SecondFactorVerifier,
 };
 
+/// Strict Ed25519 gating in front of `jsonwebtoken`'s non-strict EdDSA
+/// backend (authkestra#256). Deliberately `pub(crate)`: it is an internal
+/// hardening detail of `attestation` and `client_assertion`, not an API this
+/// crate wants to be held to — the day `jsonwebtoken` verifies strictly on
+/// its own, this module should be deletable without a breaking release.
+pub(crate) mod strict_jws;
+
 /// Device Authorization Grant related types.
 pub mod device;
 

--- a/crates/authkestra-op/src/strict_jws.rs
+++ b/crates/authkestra-op/src/strict_jws.rs
@@ -189,9 +189,21 @@ mod tests {
         format!("{signing_input}.{}", b64(signature))
     }
 
-    /// Pins `verify_strict` over the non-strict `Verifier::verify`, by exercising the exact input
-    /// the two verifiers disagree about. Without this, a refactor that swapped `verify_strict`
-    /// back for `Verifier::verify` could leave the suite green.
+    /// Pins that the universal low-order forgery — the one the **non-strict** verifier accepts —
+    /// is refused here.
+    ///
+    /// Note what this does *not* pin, corrected after review of #265: it does not distinguish
+    /// `verify_strict` from `Verifier::verify`. Measured — swapping the `verify_strict` call for
+    /// `Verifier::verify` leaves the whole suite green. The tell is this test's own assertion: it
+    /// expects a `Key(low-order)` rejection, which `ed25519_verifying_key`'s `is_weak()` emits
+    /// *before* the signature check runs at all.
+    ///
+    /// That gap is not worth closing with code. The only inputs the two verifiers disagree on are
+    /// a small-order `A` — already refused by `is_weak()` — and a small-order `R` under a
+    /// non-small-order `A`, which plain `verify` also rejects because `expected_R` will not match.
+    /// So `verify_strict` is genuine belt-and-braces here, and no end-to-end test can tell the two
+    /// apart. Keeping it is still correct: it is the documented-strict API, and it stops the
+    /// guarantee resting solely on `is_weak()`.
     #[test]
     fn strict_verification_rejects_the_universal_forgery_non_strict_accepts() {
         let weak = VerifyingKey::from_bytes(&IDENTITY).expect("identity is a valid Edwards point");

--- a/crates/authkestra-op/src/strict_jws.rs
+++ b/crates/authkestra-op/src/strict_jws.rs
@@ -1,0 +1,296 @@
+//! A **strict** Ed25519 gate layered in front of `jsonwebtoken`'s compact-JWS verification.
+//!
+//! ## Why this module exists ([authkestra#256](https://github.com/marcjazz/authkestra/issues/256))
+//!
+//! `jsonwebtoken` 11.0.0's `rust_crypto` backend verifies EdDSA with
+//! `ed25519_dalek::Verifier::verify` — the **non-strict** verifier. Non-strict verification never
+//! asks whether the public key, or the signature's `R`, is a low-order point, so the triple
+//! `(A = identity, R = identity, S = 0)` satisfies `[S]B - [k]A == R` for *every* message: both
+//! sides collapse to the identity whatever the challenge scalar `k` is. No private key exists for
+//! such a public key — not "is unknown", *does not exist*.
+//!
+//! In `authkestra-op` the verifying key is attacker-controlled by construction: it arrives as
+//! `EnrolStartRequest::public_jwk`, and the enrolment ceremony's entire purpose is to prove
+//! possession of the matching private key before minting an attestation bound to its thumbprint.
+//! A verifier that accepts a signature under a key nobody holds does not prove possession of
+//! anything.
+//!
+//! ## Relationship to `authkestra-devsig`
+//!
+//! This is a deliberate **port of `crates/authkestra-devsig/src/eddsa.rs`**
+//! (`verify_jws_signature` / `ed25519_verifying_key`, added by #253 for authkestra#242). Two
+//! deviations from the original, both intentional:
+//!
+//! 1. **It is a gate, not a replacement.** `devsig`'s version *is* the verifier and returns
+//!    `Ok(bool)`. Here both call sites — [`crate::attestation::verify_challenge_signature`] and
+//!    [`crate::client_assertion::verify_client_assertion`] — must also run `jsonwebtoken`'s claim
+//!    validation (`exp`, `nbf`, `aud`, the algorithm allow-list). Rather than reimplement that,
+//!    this runs *before* `jsonwebtoken::decode` and rejects what strict verification refuses.
+//!    Because strict verification rejects a strict superset of what non-strict rejects, gating
+//!    first is equivalent to making the whole path strict, with no claim logic duplicated.
+//! 2. **It dispatches on the key, not on an `Algorithm` argument.** Both call sites derive the
+//!    permitted algorithm from the key (`expected_algorithm` / `assertion_algorithms`), and every
+//!    `OctetKeyPair` is decoded as Ed25519 by `DecodingKey::from_jwk` regardless of `crv`. Keying
+//!    off "is this an OKP JWK" therefore covers exactly the set of keys that reach the EdDSA
+//!    backend. Non-OKP keys are a no-op here and stay entirely with `jsonwebtoken`.
+//!
+//! No RSA or ECDSA verification is reimplemented in this module.
+//!
+//! ## Why not fix `jsonwebtoken` instead
+//!
+//! The backend choice is upstream of authkestra and applies to every `jsonwebtoken` consumer;
+//! waiting on it would leave the exploitable path open for however long that takes. Gating only
+//! the EdDSA path here is the smallest change that closes it.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use ed25519_dalek::{Signature, VerifyingKey};
+use jsonwebtoken::jwk::{AlgorithmParameters, EllipticCurve, Jwk};
+
+/// Why a strict EdDSA check refused a compact JWS.
+///
+/// The split mirrors `authkestra-devsig`'s `VerifyFailure` so each call site can map the two
+/// cases onto the rejection code its part of the protocol names — **a bad key is not a bad
+/// signature**, and reporting a low-order key as `bad_signature` would hide the fact that the
+/// *key* is the defect.
+#[derive(Debug)]
+pub(crate) enum StrictEdDsaRejection {
+    /// The verifying key is unusable or unsafe — malformed, wrong curve, or a low-order point.
+    Key(String),
+    /// The signature is malformed, or was checked strictly and did not verify.
+    Signature(String),
+}
+
+/// Applies strict Ed25519 verification to `compact_jws` when `jwk` is an OKP key.
+///
+/// A no-op returning `Ok(())` for every other key type: those never reach `jsonwebtoken`'s EdDSA
+/// backend, so there is nothing here to add and their verification is left untouched.
+///
+/// Callers must still run `jsonwebtoken::decode` afterwards for claim validation; this only
+/// removes the signatures strict verification refuses (see the module doc for why gating rather
+/// than replacing).
+pub(crate) fn ensure_strict_eddsa_signature(
+    compact_jws: &str,
+    jwk: &Jwk,
+) -> Result<(), StrictEdDsaRejection> {
+    let params = match &jwk.algorithm {
+        AlgorithmParameters::OctetKeyPair(params) => params,
+        // Not an OKP key, so `DecodingKey::from_jwk` will not produce an Ed25519 key and the
+        // EdDSA backend is unreachable. Nothing to gate.
+        _ => return Ok(()),
+    };
+
+    if params.curve != EllipticCurve::Ed25519 {
+        return Err(StrictEdDsaRejection::Key(format!(
+            "Ed25519 is the only supported OKP curve, got {:?}",
+            params.curve
+        )));
+    }
+
+    let key = ed25519_verifying_key(&params.x)?;
+
+    // `.` splits are done here rather than reusing the caller's parse so this function is
+    // self-contained and cannot be desynchronised from how the signing input was formed.
+    let mut parts = compact_jws.rsplitn(2, '.');
+    let signature_b64 = parts
+        .next()
+        .ok_or_else(|| StrictEdDsaRejection::Signature("compact jws has no signature".into()))?;
+    let signing_input = parts.next().ok_or_else(|| {
+        StrictEdDsaRejection::Signature("compact jws is not header.payload.signature".into())
+    })?;
+
+    let signature_bytes = URL_SAFE_NO_PAD.decode(signature_b64).map_err(|e| {
+        StrictEdDsaRejection::Signature(format!("signature is not valid base64url: {e}"))
+    })?;
+    let signature = Signature::from_slice(&signature_bytes).map_err(|_| {
+        StrictEdDsaRejection::Signature(format!(
+            "an Ed25519 signature must be exactly 64 bytes, got {}",
+            signature_bytes.len()
+        ))
+    })?;
+
+    match key.verify_strict(signing_input.as_bytes(), &signature) {
+        Ok(()) => Ok(()),
+        Err(_) => {
+            // `verify_strict` folds "the equation did not hold" and "R is a low-order point" into
+            // a single opaque error. Recompute the latter so operators can tell routine signature
+            // failures from an attempted low-order forgery, which is an attack signal and not
+            // noise. `VerifyingKey::from_bytes` is reused purely as a compressed-Edwards-point
+            // decoder here — `R` has the same encoding as a public key, and `is_weak()` is the
+            // only small-order predicate `ed25519-dalek` exposes publicly.
+            let r_is_small_order = VerifyingKey::from_bytes(
+                signature_bytes[..32]
+                    .try_into()
+                    .expect("a 64-byte Ed25519 signature always yields a 32-byte R"),
+            )
+            .is_ok_and(|r| r.is_weak());
+
+            if r_is_small_order {
+                tracing::warn!(
+                    "rejecting EdDSA signature: its R component is a low-order point — strict \
+                     verification refuses these because they carry no proof of possession \
+                     (authkestra#256)"
+                );
+            } else {
+                tracing::debug!("EdDSA signature did not verify under strict verification");
+            }
+
+            Err(StrictEdDsaRejection::Signature(
+                "EdDSA signature did not verify under strict verification".into(),
+            ))
+        }
+    }
+}
+
+/// Decodes an Ed25519 verifying key from an OKP `x`, **rejecting low-order ("weak") keys**.
+///
+/// Duplicated deliberately from the equivalent step in `parse_public_jwk` rather than assumed:
+/// this module is the last gate before the non-strict backend, and it must hold on its own merits
+/// even if a future call site reaches it without having gone through `parse_public_jwk` first.
+fn ed25519_verifying_key(x_b64: &str) -> Result<VerifyingKey, StrictEdDsaRejection> {
+    authkestra_crypto_util::parse_ed25519_verifying_key_strict(x_b64).map_err(|e| {
+        if matches!(e, authkestra_crypto_util::EdDsaKeyError::LowOrderPoint) {
+            tracing::warn!(
+                "rejecting Ed25519 key: it is a low-order (weak) point, for which no private key \
+                 exists — a signature under it would prove possession of nothing, so it is \
+                 refused before verification is even attempted (authkestra#256)"
+            );
+        }
+        StrictEdDsaRejection::Key(e.to_string())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey, Verifier};
+
+    /// The Ed25519 identity point: the canonical *universal* low-order vector.
+    const IDENTITY: [u8; 32] = {
+        let mut b = [0u8; 32];
+        b[0] = 1;
+        b
+    };
+
+    fn b64(bytes: &[u8]) -> String {
+        URL_SAFE_NO_PAD.encode(bytes)
+    }
+
+    fn okp_jwk(crv: &str, x: &[u8]) -> Jwk {
+        serde_json::from_value(serde_json::json!({
+            "kty": "OKP",
+            "crv": crv,
+            "x": b64(x),
+        }))
+        .expect("test jwk must parse")
+    }
+
+    fn jws(signing_input: &str, signature: &[u8]) -> String {
+        format!("{signing_input}.{}", b64(signature))
+    }
+
+    /// Pins `verify_strict` over the non-strict `Verifier::verify`, by exercising the exact input
+    /// the two verifiers disagree about. Without this, a refactor that swapped `verify_strict`
+    /// back for `Verifier::verify` could leave the suite green.
+    #[test]
+    fn strict_verification_rejects_the_universal_forgery_non_strict_accepts() {
+        let weak = VerifyingKey::from_bytes(&IDENTITY).expect("identity is a valid Edwards point");
+        assert!(weak.is_weak(), "the identity point must be low-order");
+
+        let mut forged = [0u8; 64];
+        forged[..32].copy_from_slice(&IDENTITY);
+
+        assert!(
+            weak.verify(b"aGVhZGVy.cGF5bG9hZA", &Signature::from_bytes(&forged))
+                .is_ok(),
+            "precondition: the NON-strict verifier accepts this forgery — if this ever fails, \
+             upstream changed and this test no longer proves what it claims"
+        );
+
+        let err = ensure_strict_eddsa_signature(
+            &jws("aGVhZGVy.cGF5bG9hZA", &forged),
+            &okp_jwk("Ed25519", &IDENTITY),
+        )
+        .expect_err("the universal forgery must be refused");
+
+        // A bad KEY, not a bad signature: the key is the defect here.
+        assert!(
+            matches!(&err, StrictEdDsaRejection::Key(m) if m.contains("low-order")),
+            "expected a Key(low-order) rejection, got {err:?}"
+        );
+    }
+
+    /// The `crv`-confusion bypass: an OKP key whose `crv` is not Ed25519 still reaches the EdDSA
+    /// backend, so it must be refused here too.
+    #[test]
+    fn strict_verification_rejects_a_non_ed25519_okp_curve() {
+        let mut forged = [0u8; 64];
+        forged[..32].copy_from_slice(&IDENTITY);
+
+        let err = ensure_strict_eddsa_signature(
+            &jws("aGVhZGVy.cGF5bG9hZA", &forged),
+            &okp_jwk("P-256", &IDENTITY),
+        )
+        .expect_err("a non-Ed25519 OKP curve must be refused");
+
+        assert!(
+            matches!(&err, StrictEdDsaRejection::Key(m) if m.contains("only supported OKP curve")),
+            "expected a Key(wrong curve) rejection, got {err:?}"
+        );
+    }
+
+    /// Positive control: a gate that rejects everything is not a gate.
+    #[test]
+    fn strict_verification_accepts_a_genuine_signature() {
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let key = signing.verifying_key();
+        assert!(!key.is_weak());
+
+        let signing_input = "aGVhZGVy.cGF5bG9hZA";
+        let genuine = signing.sign(signing_input.as_bytes());
+
+        ensure_strict_eddsa_signature(
+            &jws(signing_input, &genuine.to_bytes()),
+            &okp_jwk("Ed25519", key.as_bytes()),
+        )
+        .expect("a genuine Ed25519 signature must pass the strict gate");
+    }
+
+    /// A genuine key with someone else's signature is a SIGNATURE failure, not a key failure —
+    /// the classification split this module's error type exists for.
+    #[test]
+    fn a_wrong_signature_under_a_good_key_is_classified_as_a_signature_failure() {
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let other = SigningKey::from_bytes(&[9u8; 32]);
+
+        let signing_input = "aGVhZGVy.cGF5bG9hZA";
+        let wrong = other.sign(signing_input.as_bytes());
+
+        let err = ensure_strict_eddsa_signature(
+            &jws(signing_input, &wrong.to_bytes()),
+            &okp_jwk("Ed25519", signing.verifying_key().as_bytes()),
+        )
+        .expect_err("a signature from a different key must be refused");
+
+        assert!(
+            matches!(err, StrictEdDsaRejection::Signature(_)),
+            "expected a Signature rejection, got {err:?}"
+        );
+    }
+
+    /// Non-OKP keys must pass through untouched — this module must not start refusing EC or RSA
+    /// keys it has no business inspecting.
+    #[test]
+    fn non_okp_keys_are_a_no_op() {
+        let ec: Jwk = serde_json::from_value(serde_json::json!({
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+            "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+        }))
+        .unwrap();
+
+        ensure_strict_eddsa_signature("aGVhZGVy.cGF5bG9hZA.c2ln", &ec)
+            .expect("a non-OKP key must be left entirely to jsonwebtoken");
+    }
+}


### PR DESCRIPTION
Refs #256.

## What I found, and how it differs from the issue

The issue was filed against `2731e04`. Since then #261 landed a low-order check in `parse_public_jwk`, which **does** close the literal vector in #256 (`crv: "Ed25519"` + identity point). I confirmed that before changing anything.

The defect itself was still live, via two gaps found while writing the reproduction:

**1. The `crv` gate is bypassable.** #261 wrote the check as `if params.curve == Ed25519 { ... }`. But `jsonwebtoken`'s `OctetKeyPairParameters::curve` is the *shared* `EllipticCurve` enum, so `{"kty":"OKP","crv":"P-256"}` deserialises into the `OctetKeyPair` variant and skips the gate — while `expected_algorithm` maps **every** `OctetKeyPair` to `Algorithm::EdDSA` and `DecodingKey::from_jwk` sends **every** `OctetKeyPair` to `from_ed_components`, both regardless of `crv`. So `x` is interpreted as Ed25519 bytes either way, and the key reaches the Ed25519 verifier having skipped the low-order check.

**2. The ceremony was saved by an accident, not a control.** Those keys did not actually mint an attestation on `main` — but only because `compute_cnf_jkt` fails afterwards with `InvalidKeyFormat`, since `jsonwebtoken` won't thumbprint a non-Ed25519 OKP key. That is an unrelated downstream step whose doc comment makes no security claim, and it would evaporate the moment thumbprinting grew support for another OKP curve.

Measured on `main` at `876927e`, the proof-of-possession check itself was fully bypassed:

```
PROBE[Ed25519] parse_public_jwk REJECTED: Ed25519 public key is a low-order point; ...
PROBE[P-256] parse_public_jwk ACCEPTED
PROBE[P-256]   verify_challenge_signature -> Ok("CHAL")      <-- forgery verified
PROBE[P-256]   compute_cnf_jkt -> Err(BadJwk("jwk thumbprint failed: InvalidKeyFormat"))
PROBE[P-384] parse_public_jwk ACCEPTED
PROBE[P-384]   verify_challenge_signature -> Ok("CHAL")      <-- forgery verified
PROBE[P-521] parse_public_jwk ACCEPTED
PROBE[P-521]   verify_challenge_signature -> Ok("CHAL")      <-- forgery verified
```

And with `parse_public_jwk` reverted to its pre-#261 form, the original end-to-end attack reproduces exactly as #256 describes — a real attestation, `cnf.jkt` bound to a key nobody holds:

```
VULNERABLE: the OP minted an attestation for a low-order key nobody holds a private key for:
eyJ0eXAiOiJ3ZWJhbmstYXR0ZXN0K2p3cyIsImFsZyI6IkhTMjU2In0.eyJpc3MiOm51bGwsInN1YiI6InZpY3RpbSIs...
  "cnf": { "jkt": "eV9frzBXPTP92MWWMpoFOh0WI_kJLvGlhcNs15APU_s" }
```

## Changes

1. **Ingest (`parse_public_jwk`)** — a non-Ed25519 `crv` on an OKP key is now a hard refusal instead of a pass-through, and the low-order check runs unconditionally on what remains.
2. **Strict verification** — new `pub(crate) strict_jws` module applies `VerifyingKey::verify_strict` ahead of `jsonwebtoken::decode`.
3. **`client_assertion.rs`** — same gate on `private_key_jwt`. This was in scope item 3 and turned out to be a small delta (the module already routes through `parse_public_jwk` via `select_key`), so it is done rather than deferred.

Error classification follows `authkestra-devsig`: a bad *key* is `BadJwk`, never `ChallengeSignatureInvalid`/`InvalidClientAssertion`. New rejection branches carry `tracing::warn!` per the AGENTS.md DoD.

No new handler was added, so the AGENTS.md axum/actix wiring rule does not apply here.

## Reuse vs. duplication — stated explicitly

`authkestra-devsig` is **not** a dependency of `authkestra-op`, and making it one would invert the layering (devsig is a verifier crate; the OP is the issuer). `authkestra-crypto-util` **is** already a dependency, so the key-parsing half is reused directly via `parse_ed25519_verifying_key_strict`.

The JWS-splitting and `verify_strict` half is a **deliberate port** of `authkestra-devsig/src/eddsa.rs` (#253), documented as such in `strict_jws`'s module doc, with both deviations from the original called out there:

- it *gates* rather than *replaces* `jsonwebtoken::decode`, so claim validation (`exp`/`nbf`/`aud`/alg allow-list) is not duplicated; this is sound because strict verification rejects a strict superset of what non-strict rejects;
- it dispatches on the key being OKP rather than on an `Algorithm` argument, which is exactly the set of keys that reach the EdDSA backend.

Lifting the shared logic into `authkestra-crypto-util` would mean adding `jsonwebtoken` as a dependency of that crate, which is a larger blast radius than the duplication it removes. Flagging it as a possible follow-up rather than doing it here.

## Tests

The reproduction is committed, not just run locally. Note `challenge_signature_verification_itself_refuses_low_order_keys` builds its `Jwk` via `serde_json` rather than `parse_public_jwk`: routing through ingest makes it **vacuous**, because ingest refuses first and the strict gate never executes. I caught this by disabling the gate and finding the test still passed; with the direct construction it fails correctly:

```
VULNERABLE: verify_challenge_signature accepted the universal low-order forgery for crv=Ed25519: Ok("CHAL")
```

Positive controls (a fix that rejects everything is not a fix — the trap flagged in review of #253):

- `genuine_ed25519_key_still_enrols_end_to_end` — full ceremony, real Ed25519 key, attestation minted and `cnf.jkt` verified.
- `challenge_signature_verification_still_accepts_a_genuine_ed25519_signature`
- `still_accepts_an_assertion_under_a_genuine_ed25519_key` — `private_key_jwt` with EdDSA still authenticates.
- `non_okp_keys_are_a_no_op` — EC/RSA verification left entirely untouched.

## Does this warrant `!`? — maintainer decision

I have deliberately **not** decided this. Committed without `!`; happy to amend.

- **Against `!`**: no public API or type changes (`strict_jws` is `pub(crate)`, `OpError` untouched).

> **Correction (raised in review).** The sentence previously here — *"no working configuration breaks … an OKP key with `crv` P-256/P-384/P-521 always died at `compute_cnf_jkt`"* — was **wrong**, and wrong in the direction that matters. It holds only for the *enrolment* path. `verify_client_assertion` never calls `compute_cnf_jkt`, so on `main` a **genuine, non-low-order** Ed25519 key registered under a nonconformant `crv` authenticates successfully today and is refused by this PR:
>
> ```
> main:  CA[genuine-ed25519 crv=P-256] -> Ok("jti-1")
> PR:    CA[genuine-ed25519 crv=P-256] -> Err("... Ed25519 is the only supported OKP curve, got P256")
> ```
>
> That configuration is nonconformant (RFC 8037 mandates `crv: "Ed25519"`) and refusing it is correct — but a working configuration **does** break, so the `!` decision should be made on accurate evidence.
- **For `!`**: #261 — the directly analogous fix, same defect class — shipped as `fix(crypto)!`, and release-plz drives versioning from these messages.

## Verification

All run on the CI-pinned toolchain where relevant; `cargo check --workspace --all-features` included specifically to catch cross-crate breakage that per-crate scoping hides.

| Command | Result |
| --- | --- |
| `cargo fmt --all -- --check` | clean |
| `cargo +1.98.0 clippy -p authkestra-op --all-targets --all-features -- -D warnings` | clean |
| `cargo clippy --workspace --all-features -- -D warnings` | clean |
| `cargo check --workspace --all-features` | clean |
| `cargo test -p authkestra-op --all-features` | 153 passed, 0 failed, 0 ignored |
| `cargo test --workspace --all-features` | all suites pass |

`DOCKER_HOST` was set for the container-backed store tests, so the postgres/mysql/sqlite/redis cases genuinely ran rather than silently skipping.

`Cargo.lock` gains exactly one line: `ed25519-dalek` becomes a direct dependency of `authkestra-op` for `verify_strict`, mirroring #253's rationale and wording in `authkestra-devsig`. It was already in the graph via `jsonwebtoken`'s `rust_crypto` backend and `authkestra-crypto-util`.

## Scope left undone

`crates/authkestra-resource/src/jwt.rs` is untouched, per the issue's own priority ordering and its note that resource is best done after #250/#254. **#256 should not be auto-closed by this PR** if the maintainer considers resource part of it; hence `Refs` rather than `Resolves`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Corrections and review fixes

An adversarial review found the code sound and could not construct a next bypass, but flagged that this PR **understates what it fixes** and that one of its two gates was untested.

### The client_assertion path is a complete, unmitigated bypass — not "defence in depth"

The description frames `client_assertion.rs` as lower-reachability hardening. Measured on `main`:

```
CA[low-order crv=Ed25519] -> Err("... low-order point ...")   <- #261 catches this
CA[low-order crv=P-256]   -> Ok("jti-1")                      <- full client authentication
```

`verify_client_assertion` never calls `compute_cnf_jkt`, so the accident that saves the enrolment ceremony does not exist on this path. A single low-order key in a client's registered JWKS lets anyone authenticate as that client with a 64-byte constant. This PR closes it; the framing should have said so.

### The `client_assertion` gate was entirely untested — fixed in `213e47c`

Measured: deleting the whole `ensure_strict_eddsa_signature` block from `verify_client_assertion` left the suite at **`153 passed; 0 failed`**. Every existing test routes through `select_key` → `parse_public_jwk`, which refuses these keys at ingest, so the second gate never ran.

This is the same vacuity trap already identified and fixed for the enrolment test — it just wasn't re-applied here. Added `strict_gate_itself_refuses_low_order_keys_for_client_assertions`, built with `serde_json::from_value` so ingest is bypassed on purpose. Verified load-bearing: neutering the gate now fails it, where the same mutation previously left everything green.

### A test's claim corrected — also `213e47c`

`strict_verification_rejects_the_universal_forgery_non_strict_accepts` claimed to pin `verify_strict` over `Verifier::verify`. It doesn't — swapping the call leaves the suite green, because the test asserts a `Key(low-order)` rejection that `is_weak()` emits *before* the signature check. Corrected the comment rather than the code: the only inputs the two verifiers disagree on are a small-order `A` (already caught) and a small-order `R` under a non-small-order `A` (which plain `verify` also rejects), so nothing reachable distinguishes them.

### Also fixes an unclaimed remote panic — evidence for `!`

`from_ed_components` performs no length check, so an `x` shorter than 32 bytes panics at `jsonwebtoken`'s `eddsa.rs:48` (`range end index 32 out of range for slice of length 16`). Reachable through the same `crv`-confusion door on **both** paths, including unauthenticated at the token endpoint. After this PR both refuse at ingest.

### Verification after the fixes

`fmt` clean · `clippy +1.98.0 -p authkestra-op --all-targets` clean · `cargo check --workspace --all-features` clean · **154 passed; 0 failed**.
