### PR TITLE
fix(op)!: enforce PKCE unconditionally for the authorization code grant

### DIFF
--- a/crates/authkestra-op/src/client.rs
+++ b/crates/authkestra-op/src/client.rs
@@ -107,6 +107,12 @@ pub struct ClientRegistration {
     /// unconditionally, per OAuth 2.1 §4.1 (authkestra#273) — both
     /// `handlers::authorize` and `handlers::token` enforce it regardless of
     /// this value.
+    #[deprecated(
+        since = "0.7.0",
+        note = "PKCE is mandatory for every client on the authorization code grant, \
+                unconditionally, per OAuth 2.1 §4.1 (authkestra#273). This field is no longer \
+                read by handlers::authorize or handlers::token and has no effect."
+    )]
     pub require_pkce: bool,
     /// Downstream audiences (resources) this client is permitted to target
     /// during token exchange.
@@ -197,6 +203,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(deprecated)] // `require_pkce` (authkestra#273) — these fixtures don't exercise it
 mod tests {
 
     use super::*;

--- a/crates/authkestra-op/src/client.rs
+++ b/crates/authkestra-op/src/client.rs
@@ -102,8 +102,11 @@ pub struct ClientRegistration {
     pub grant_types: Vec<GrantType>,
     /// Scopes this client is permitted to request.
     pub scopes: Vec<String>,
-    /// Whether this client must use PKCE (mandatory for public clients,
-    /// recommended for all — see RFC-003 §7 / OAuth 2.1).
+    /// Retained for wire/storage compatibility, but no longer consulted:
+    /// PKCE is mandatory for every client on the authorization code grant,
+    /// unconditionally, per OAuth 2.1 §4.1 (authkestra#273) — both
+    /// `handlers::authorize` and `handlers::token` enforce it regardless of
+    /// this value.
     pub require_pkce: bool,
     /// Downstream audiences (resources) this client is permitted to target
     /// during token exchange.

--- a/crates/authkestra-op/src/client_assertion.rs
+++ b/crates/authkestra-op/src/client_assertion.rs
@@ -470,6 +470,7 @@ pub fn verify_client_assertion(
 }
 
 #[cfg(test)]
+#[allow(deprecated)] // `require_pkce` (authkestra#273) — these fixtures don't exercise it
 pub(crate) mod tests {
     use super::*;
     use crate::client::{GrantType, TokenEndpointAuthMethod};

--- a/crates/authkestra-op/src/handlers/authorize.rs
+++ b/crates/authkestra-op/src/handlers/authorize.rs
@@ -174,6 +174,7 @@ pub async fn handle_authorize(
 }
 
 #[cfg(test)]
+#[allow(deprecated)] // `require_pkce` (authkestra#273) — these fixtures don't exercise it
 mod tests {
     use super::*;
     use crate::client::{ClientRegistration, GrantType};

--- a/crates/authkestra-op/src/handlers/authorize.rs
+++ b/crates/authkestra-op/src/handlers/authorize.rs
@@ -117,24 +117,16 @@ pub async fn handle_authorize(
         );
     }
 
-    // 6. PKCE requirements
-    if client.require_pkce {
-        if req.code_challenge.is_none() {
-            tracing::warn!(client_id = %req.client_id, "Missing required code_challenge for PKCE");
-            return error_redirect("invalid_request", "code_challenge is required");
-        }
-        if req.code_challenge_method.as_deref() != Some("S256") {
-            tracing::warn!(client_id = %req.client_id, "Invalid code_challenge_method, S256 required");
-            return error_redirect("invalid_request", "code_challenge_method must be S256");
-        }
-    } else if req.code_challenge.is_none() && req.code_challenge_method.is_some() {
-        tracing::warn!(client_id = %req.client_id, "code_challenge_method specified without code_challenge");
-        return error_redirect(
-            "invalid_request",
-            "code_challenge is required when method is specified",
-        );
-    } else if req.code_challenge.is_some() && req.code_challenge_method.as_deref() != Some("S256") {
-        tracing::warn!(client_id = %req.client_id, "Invalid code_challenge_method provided (optional PKCE), S256 required");
+    // 6. PKCE requirements — mandatory for every client, per OAuth 2.1 §4.1
+    // (authkestra#273). `client.require_pkce` no longer gates this: OAuth 2.1
+    // does not grandfather in confidential clients or any other exemption,
+    // and per-client opt-out was the exact gap #273 closes.
+    if req.code_challenge.is_none() {
+        tracing::warn!(client_id = %req.client_id, "Missing required code_challenge for PKCE");
+        return error_redirect("invalid_request", "code_challenge is required");
+    }
+    if req.code_challenge_method.as_deref() != Some("S256") {
+        tracing::warn!(client_id = %req.client_id, "Invalid code_challenge_method, S256 required");
         return error_redirect("invalid_request", "code_challenge_method must be S256");
     }
 
@@ -524,14 +516,17 @@ mod tests {
         // State containing characters that require URL encoding
         let dangerous_state = "foo&bar=baz#123";
 
+        // PKCE is mandatory (authkestra#273) regardless of `require_pkce`,
+        // and unrelated to what this test actually covers (state encoding),
+        // but required to reach the success path at all.
         let req = AuthorizeRequest {
             client_id: "client-1".to_string(),
             redirect_uri: "https://app.example.com/cb".to_string(),
             response_type: "code".to_string(),
             scope: "openid".to_string(),
             state: Some(dangerous_state.to_string()),
-            code_challenge: None,
-            code_challenge_method: None,
+            code_challenge: Some("s256challenge".to_string()),
+            code_challenge_method: Some("S256".to_string()),
             nonce: None,
         };
 
@@ -561,6 +556,10 @@ mod tests {
         }
     }
 
+    /// PKCE is mandatory regardless of `client.require_pkce` (authkestra#273):
+    /// a client not opted into PKCE that still omits `code_challenge` (even
+    /// while sending `code_challenge_method`) is rejected exactly like one
+    /// that requires it.
     #[tokio::test]
     async fn test_pkce_method_without_challenge_redirect_error() {
         let clients = authkestra_engine::store::memory::MemoryStore::<
@@ -575,7 +574,7 @@ mod tests {
                     redirect_uris: vec!["https://app.example.com/cb".to_string()],
                     grant_types: vec![GrantType::AuthorizationCode],
                     scopes: vec![],
-                    require_pkce: false, // PKCE is optional
+                    require_pkce: false, // no longer changes the outcome — PKCE is always required
                     allowed_audiences: vec![],
                     token_endpoint_auth_method: None,
                     jwks: None,
@@ -603,11 +602,71 @@ mod tests {
         let outcome = handle_authorize(req, test_identity(), &config, &crate::store::CompositeOpStore::new(clients, codes, authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(), authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new())).await;
         if let AuthorizeOutcome::Redirect(url) = outcome {
             assert!(url.contains("error=invalid_request"));
-            assert!(
-                url.contains(
-                    "error_description=code_challenge+is+required+when+method+is+specified"
-                ) || url.contains("code_challenge%20is%20required")
-            );
+            assert!(url.contains("error_description=code_challenge+is+required"));
+        } else {
+            panic!("Expected Redirect");
+        }
+    }
+
+    /// The core regression test for authkestra#273: a client explicitly
+    /// registered with `require_pkce: false` and sending no PKCE parameters
+    /// at all must still be rejected, since OAuth 2.1 §4.1 makes PKCE
+    /// mandatory unconditionally rather than an opt-in per client.
+    #[tokio::test]
+    async fn test_pkce_is_mandatory_even_when_client_does_not_require_it() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<
+            crate::client::ClientRegistration,
+        >::new();
+        clients
+            .set(
+                "client-1",
+                ClientRegistration {
+                    client_id: "client-1".to_string(),
+                    client_secret_hash: None,
+                    redirect_uris: vec!["https://app.example.com/cb".to_string()],
+                    grant_types: vec![GrantType::AuthorizationCode],
+                    scopes: vec![],
+                    require_pkce: false,
+                    allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
+                },
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let codes =
+            authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new();
+        let config = test_config();
+
+        let req = AuthorizeRequest {
+            client_id: "client-1".to_string(),
+            redirect_uri: "https://app.example.com/cb".to_string(),
+            response_type: "code".to_string(),
+            scope: "openid".to_string(),
+            state: None,
+            code_challenge: None,
+            code_challenge_method: None,
+            nonce: None,
+        };
+
+        let outcome = handle_authorize(
+            req,
+            test_identity(),
+            &config,
+            &crate::store::CompositeOpStore::new(
+                clients,
+                codes,
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(
+                ),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(),
+            ),
+        )
+        .await;
+        if let AuthorizeOutcome::Redirect(url) = outcome {
+            assert!(url.contains("error=invalid_request"));
+            assert!(url.contains("error_description=code_challenge+is+required"));
         } else {
             panic!("Expected Redirect");
         }

--- a/crates/authkestra-op/src/handlers/device_authorization.rs
+++ b/crates/authkestra-op/src/handlers/device_authorization.rs
@@ -148,6 +148,7 @@ pub async fn handle_device_authorization(
 }
 
 #[cfg(test)]
+#[allow(deprecated)] // `require_pkce` (authkestra#273) — these fixtures don't exercise it
 mod tests {
     use super::*;
     use crate::client::{ClientRegistration, GrantType};

--- a/crates/authkestra-op/src/handlers/discovery.rs
+++ b/crates/authkestra-op/src/handlers/discovery.rs
@@ -16,6 +16,18 @@ pub struct OidcDiscovery {
     /// advertising one would point clients at an endpoint that 404s.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authorization_endpoint: Option<String>,
+    /// JSON array of PKCE code challenge methods this OP supports (RFC 8414
+    /// §2 / RFC 7636 §4.3).
+    ///
+    /// `handlers::authorize::handle_authorize` requires PKCE unconditionally
+    /// for every client (authkestra#273) — this field exists so a
+    /// spec-conformant client actually finds out, rather than discovering it
+    /// only after being rejected. Omitted entirely, for the same reason
+    /// `authorization_endpoint` is: a provider with no `authorization_code`
+    /// grant has no `/authorize` endpoint for a `code_challenge_method` to
+    /// apply to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code_challenge_methods_supported: Option<Vec<String>>,
     /// URL of the OP's OAuth 2.0 Token Endpoint.
     pub token_endpoint: String,
     /// URL of the OP's JSON Web Key Set document.
@@ -56,13 +68,17 @@ use crate::config::OpConfig;
 impl OidcDiscovery {
     /// Creates a discovery document reflecting the provided OP configuration.
     pub fn from_config(config: &OpConfig) -> Self {
+        let has_authorization_code_grant = config
+            .grant_types_supported
+            .iter()
+            .any(|grant| grant == "authorization_code");
+
         Self {
             issuer: config.issuer.clone(),
-            authorization_endpoint: config
-                .grant_types_supported
-                .iter()
-                .any(|grant| grant == "authorization_code")
+            authorization_endpoint: has_authorization_code_grant
                 .then(|| config.authorization_endpoint()),
+            code_challenge_methods_supported: has_authorization_code_grant
+                .then(|| vec!["S256".to_string()]),
             token_endpoint: config.token_endpoint(),
             jwks_uri: config.jwks_url(),
             userinfo_endpoint: Some(config.userinfo_endpoint()),
@@ -256,6 +272,42 @@ mod tests {
             Some(&serde_json::Value::String(
                 "https://auth.example.com/authorize".to_string()
             ))
+        );
+    }
+
+    /// authkestra#273: PKCE is mandatory at `/authorize` for every client —
+    /// a provider that serves the `authorization_code` grant must advertise
+    /// that, so a spec-conformant client finds out before being rejected
+    /// rather than after.
+    #[test]
+    fn code_challenge_methods_supported_advertises_s256_when_auth_code_grant_supported() {
+        let doc = OidcDiscovery::from_config(&discovery_config());
+        assert_eq!(
+            doc.code_challenge_methods_supported,
+            Some(vec!["S256".to_string()])
+        );
+    }
+
+    /// A provider with no `authorization_code` grant has no `/authorize`
+    /// endpoint for a code challenge method to apply to — must be omitted
+    /// entirely, mirroring `authorization_endpoint`'s own omission rule.
+    #[test]
+    fn code_challenge_methods_supported_omitted_when_no_auth_code_grant() {
+        let mut config = discovery_config();
+        config.grant_types_supported = vec![
+            "urn:ietf:params:oauth:grant-type:token-exchange".to_string(),
+            "refresh_token".to_string(),
+        ];
+        config.response_types_supported = vec![];
+
+        let doc = OidcDiscovery::from_config(&config);
+        assert_eq!(doc.code_challenge_methods_supported, None);
+
+        let json = serde_json::to_value(&doc).unwrap();
+        assert!(
+            json.get("code_challenge_methods_supported").is_none(),
+            "must be omitted (not null) when the provider has no authorization_code grant; got {:?}",
+            json.get("code_challenge_methods_supported")
         );
     }
 

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -1408,6 +1408,7 @@ pub async fn default_handle_token_exchange(
 }
 
 #[cfg(test)]
+#[allow(deprecated)] // `require_pkce` (authkestra#273) — these fixtures don't exercise it
 mod tests {
     use super::*;
     use crate::client::{ClientRegistration, GrantType};
@@ -2293,7 +2294,14 @@ mod tests {
             &test_tokens(),
         )
         .await;
-        assert_eq!(res.unwrap_err().error, "invalid_grant");
+        let err = res.unwrap_err();
+        assert_eq!(err.error, "invalid_grant");
+        // `invalid_grant` alone is produced by several other rejection
+        // paths in this function (expired code, wrong client, redirect_uri
+        // mismatch, ...) — pin the description too so this test actually
+        // proves the PKCE-mandatory-at-redemption guard fired, not just
+        // that *some* rejection did.
+        assert_eq!(err.error_description, "PKCE is required");
     }
 
     #[tokio::test]
@@ -4413,9 +4421,11 @@ mod tests {
 }
 
 #[cfg(test)]
+#[allow(deprecated)] // `require_pkce` (authkestra#273) — these fixtures don't exercise it
 mod device_tests;
 
 #[cfg(test)]
+#[allow(deprecated)] // `require_pkce` (authkestra#273) — these fixtures don't exercise it
 mod client_auth_tests;
 
 impl TokenResponse {

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -797,8 +797,15 @@ pub async fn default_handle_authorization_code<S: OpStore + ?Sized>(
                 error_description: "code_verifier is invalid".to_string(),
             });
         }
-    } else if client.require_pkce {
-        tracing::warn!("PKCE was required by client config but code lacks challenge");
+    } else {
+        // PKCE is mandatory for every client, per OAuth 2.1 §4.1
+        // (authkestra#273): `client.require_pkce` no longer gates this. In
+        // ordinary operation `handle_authorize` never stores a code without
+        // a challenge, so this only fires for a code that reached storage
+        // by some other path (a legacy pre-#273 code, or a downstream
+        // `OpStore::store_code` override) — reject it rather than silently
+        // skip PKCE verification for it.
+        tracing::warn!("PKCE is mandatory but the stored authorization code has no code_challenge");
         return Err(TokenErrorResponse {
             error: "invalid_grant".to_string(),
             error_description: "PKCE is required".to_string(),
@@ -1921,6 +1928,15 @@ mod tests {
             .await
             .unwrap();
 
+        // PKCE is mandatory (authkestra#273), so this fixture needs a real
+        // challenge/verifier pair — unrelated to what this test actually
+        // covers (OpStore default-dispatch behavior), but required to reach
+        // that code path at all.
+        let verifier = "test_verifier";
+        let mut hasher = sha2::Sha256::new();
+        sha2::Digest::update(&mut hasher, verifier.as_bytes());
+        let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(hasher.finalize());
+
         let codes =
             authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new();
         codes
@@ -1932,8 +1948,8 @@ mod tests {
                 scope: "openid offline_access".to_string(),
                 nonce: None,
                 expires_at: Utc::now() + Duration::minutes(5),
-                code_challenge: None,
-                code_challenge_method: None,
+                code_challenge: Some(challenge),
+                code_challenge_method: Some("S256".to_string()),
                 used: false,
             })
             .await
@@ -1943,7 +1959,10 @@ mod tests {
         // — this is the compatibility guarantee: it must behave identically
         // to before the trait method existed.
         let res = handle_token(
-            auth_code_test_req("code-default"),
+            TokenRequest {
+                code_verifier: Some(verifier.to_string()),
+                ..auth_code_test_req("code-default")
+            },
             None,
             &test_config(false),
             &crate::store::CompositeOpStore::new(
@@ -2193,6 +2212,88 @@ mod tests {
         )
         .await;
         assert_eq!(res.unwrap_err().error, "server_error");
+    }
+
+    /// authkestra#273: PKCE is mandatory at redemption too, not just at
+    /// `/authorize`. `handle_authorize` never stores a challenge-less code
+    /// any more, but a code can still reach storage without one via a
+    /// legacy pre-#273 row or a downstream `OpStore::store_code` override —
+    /// this must not be treated as "PKCE wasn't required for this client".
+    #[tokio::test]
+    async fn test_pkce_is_mandatory_at_redemption_even_for_a_challenge_less_code() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<
+            crate::client::ClientRegistration,
+        >::new();
+        clients
+            .set(
+                "client1",
+                ClientRegistration {
+                    client_id: "client1".to_string(),
+                    client_secret_hash: None,
+                    redirect_uris: vec!["https://cb".to_string()],
+                    grant_types: vec![GrantType::AuthorizationCode],
+                    scopes: vec![],
+                    require_pkce: false,
+                    allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
+                },
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+        let codes =
+            authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new();
+        codes
+            .store_code(AuthorizationCode {
+                code: "code1".to_string(),
+                client_id: "client1".to_string(),
+                redirect_uri: "https://cb".to_string(),
+                identity: test_identity(),
+                scope: "".to_string(),
+                nonce: None,
+                expires_at: Utc::now() + Duration::minutes(5),
+                code_challenge: None,
+                code_challenge_method: None,
+                used: false,
+            })
+            .await
+            .unwrap();
+
+        let req = TokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: Some("code1".to_string()),
+            redirect_uri: Some("https://cb".to_string()),
+            client_id: Some("client1".to_string()),
+            client_secret: None,
+            code_verifier: None,
+            scope: None,
+            refresh_token: None,
+            subject_token: None,
+            subject_token_type: None,
+            device_code: None,
+            actor_token: None,
+            actor_token_type: None,
+            requested_token_type: None,
+            audience: None,
+            client_assertion: None,
+            client_assertion_type: None,
+        };
+        let res = handle_token(
+            req,
+            None,
+            &test_config(false),
+            &crate::store::CompositeOpStore::new(
+                clients.clone(),
+                codes.clone(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            ),
+            ),
+            &test_tokens(),
+        )
+        .await;
+        assert_eq!(res.unwrap_err().error, "invalid_grant");
     }
 
     #[tokio::test]

--- a/crates/authkestra-op/src/sqlx_store.rs
+++ b/crates/authkestra-op/src/sqlx_store.rs
@@ -42,6 +42,7 @@ macro_rules! impl_opstore_sql {
         #[cfg(feature = $feature)]
         #[async_trait]
         impl ClientStore for SqlxOpStore<$backend> {
+            #[allow(deprecated)] // `require_pkce` (authkestra#273) — still round-tripped for wire/storage compatibility
             async fn find_client(&self, client_id: &str) -> Result<Option<ClientRegistration>, OpError> {
                 let query = format!(
                     "SELECT 

--- a/crates/authkestra-op/tests/default_handle_token_exchange_visibility_tests.rs
+++ b/crates/authkestra-op/tests/default_handle_token_exchange_visibility_tests.rs
@@ -47,6 +47,7 @@ fn test_config() -> OpConfig {
     }
 }
 
+#[allow(deprecated)] // `require_pkce` (authkestra#273) — this fixture doesn't exercise it
 fn test_client() -> ClientRegistration {
     ClientRegistration {
         client_id: "client1".to_string(),

--- a/crates/authkestra/examples/actix_op_server.rs
+++ b/crates/authkestra/examples/actix_op_server.rs
@@ -66,6 +66,7 @@ async fn main() -> std::io::Result<()> {
     let redis_client = redis::Client::open(redis_url.as_str()).expect("Failed to connect to Redis");
 
     let clients = RedisStore::with_client(redis_client.clone(), "op_clients".into());
+    #[allow(deprecated)] // require_pkce (authkestra#273) — PKCE is mandatory unconditionally now
     clients
         .set(
             "test-client",

--- a/crates/authkestra/examples/actix_op_server_custom_grant.rs
+++ b/crates/authkestra/examples/actix_op_server_custom_grant.rs
@@ -208,6 +208,7 @@ async fn main() -> std::io::Result<()> {
     ));
 
     let clients = MemoryStore::new();
+    #[allow(deprecated)] // require_pkce (authkestra#273) — PKCE is mandatory unconditionally now
     clients
         .set(
             "test-client",

--- a/crates/authkestra/examples/axum_op_server.rs
+++ b/crates/authkestra/examples/axum_op_server.rs
@@ -66,6 +66,7 @@ async fn main() {
     let redis_client = redis::Client::open(redis_url.as_str()).expect("Failed to connect to Redis");
 
     let clients = RedisStore::with_client(redis_client.clone(), "op_clients".into());
+    #[allow(deprecated)] // require_pkce (authkestra#273) — PKCE is mandatory unconditionally now
     clients
         .set(
             "test-client",

--- a/crates/authkestra/examples/axum_op_server_custom_grant.rs
+++ b/crates/authkestra/examples/axum_op_server_custom_grant.rs
@@ -210,6 +210,7 @@ async fn main() {
     ));
 
     let clients = MemoryStore::new();
+    #[allow(deprecated)] // require_pkce (authkestra#273) — PKCE is mandatory unconditionally now
     clients
         .set(
             "test-client",


### PR DESCRIPTION
## Summary

OAuth 2.1 §4.1 requires PKCE on every authorization code exchange. This codebase implements PKCE correctly, but only enforced it when a client's registration set `require_pkce: true` — which every constructor/default sets to `false`. A client not opted in could complete the entire authorization code flow with no PKCE at all.

## Changes

- **`handlers/authorize.rs`** — `handle_authorize` now always requires `code_challenge` + `code_challenge_method=S256`, regardless of `client.require_pkce`. The old three-way "PKCE optional" branch (which produced different error messages depending on partial PKCE params) collapses into the same two checks previously used only for `require_pkce: true` clients.
- **`handlers/token.rs`** — `handle_authorization_code_grant` now always rejects a stored code with no `code_challenge` at redemption too, not just when `client.require_pkce` was set. In normal operation `handle_authorize` never stores a challenge-less code after this change, but this closes the same gap for a legacy pre-existing code, or a downstream `OpStore::store_code` override that bypasses `handle_authorize` entirely.
- **`client.rs`** — `ClientRegistration::require_pkce` is retained on the struct (removing it would be an API-breaking field removal, a separate concern) but is no longer read by either handler; its doc comment now says so.

## Breaking change

Any client previously relying on `require_pkce: false` to skip PKCE will now be rejected at `/authorize` until it sends a `code_challenge`. This is intentional — it's the compliance gap the issue tracks — but it is a behavior break for existing non-PKCE deployments, hence the `!`.

## Test plan

- [x] `cargo test -p authkestra-op --lib` — 149 passed (145 existing/adjusted + 4 new/updated PKCE-focused tests)
- [x] `cargo test --workspace --all-features` — all green, including adapter (axum/actix) and doctest suites
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New regression tests:
  - `test_pkce_is_mandatory_even_when_client_does_not_require_it` (authorize.rs) — a `require_pkce: false` client sending zero PKCE params is rejected.
  - `test_pkce_is_mandatory_at_redemption_even_for_a_challenge_less_code` (token.rs) — a challenge-less stored code from a `require_pkce: false` client is rejected at `/token`, covering the code path a code that bypassed `handle_authorize` would take.
  - Existing PKCE tests (`test_state_encoding`, `test_pkce_method_without_challenge_redirect_error`, `test_authorization_code_default_behavior_is_unchanged_without_override`) updated with real PKCE fixtures where the scenario they actually cover is orthogonal to PKCE.

Fixes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)