### PR TITLE
fix(op)!: enforce requested scope against the client's registration

### DIFF
--- a/crates/authkestra-op/src/client.rs
+++ b/crates/authkestra-op/src/client.rs
@@ -154,6 +154,16 @@ impl ClientRegistration {
         self.grant_types.contains(grant_type)
     }
 
+    /// Checks if the client is registered for a single scope value.
+    ///
+    /// Takes one already-split scope token, not a space-delimited string —
+    /// callers validating a whole `scope` request should split it
+    /// themselves and check each token, so they can name the specific
+    /// offending scope in their own error response (authkestra#278).
+    pub fn allows_scope(&self, scope: &str) -> bool {
+        self.scopes.iter().any(|s| s == scope)
+    }
+
     /// Verifies the provided secret against the stored argon2 hash in constant time.
     pub fn verify_secret(&self, secret: &str) -> bool {
         if let Some(hash_str) = &self.client_secret_hash {

--- a/crates/authkestra-op/src/handlers/authorize.rs
+++ b/crates/authkestra-op/src/handlers/authorize.rs
@@ -92,6 +92,23 @@ pub async fn handle_authorize(
         AuthorizeOutcome::Redirect(url.into())
     };
 
+    // 3. Validate requested scope against the client's registration
+    // (authkestra#278). `req.scope` was previously copied verbatim into the
+    // stored code — and from there into the eventual token — with no check
+    // at all, letting any registered client request (and receive) a scope
+    // it was never granted. Rejects on the first offending scope, naming it
+    // specifically, mirroring `default_handle_client_credentials`'s
+    // existing (and correct) scope check at the token endpoint.
+    for s in req.scope.split_whitespace() {
+        if !client.allows_scope(s) {
+            tracing::warn!(client_id = %req.client_id, scope = %s, "Client requested unauthorized scope");
+            return error_redirect(
+                "invalid_scope",
+                &format!("Scope {s} is not allowed for this client"),
+            );
+        }
+    }
+
     // 4. Check response_type == "code"
     if req.response_type != "code" {
         tracing::warn!(
@@ -292,7 +309,7 @@ mod tests {
                     client_secret_hash: None,
                     redirect_uris: vec!["https://app.example.com/cb".to_string()],
                     grant_types: vec![GrantType::AuthorizationCode],
-                    scopes: vec![],
+                    scopes: vec!["openid".to_string()],
                     require_pkce: false,
                     allowed_audiences: vec![],
                     token_endpoint_auth_method: None,
@@ -341,7 +358,7 @@ mod tests {
                     client_secret_hash: None,
                     redirect_uris: vec!["https://app.example.com/cb".to_string()],
                     grant_types: vec![GrantType::AuthorizationCode],
-                    scopes: vec![],
+                    scopes: vec!["openid".to_string()],
                     require_pkce: true,
                     allowed_audiences: vec![],
                     token_endpoint_auth_method: None,
@@ -388,7 +405,7 @@ mod tests {
                     client_secret_hash: None,
                     redirect_uris: vec!["https://app.example.com/cb".to_string()],
                     grant_types: vec![GrantType::AuthorizationCode],
-                    scopes: vec![],
+                    scopes: vec!["openid".to_string()],
                     require_pkce: true,
                     allowed_audiences: vec![],
                     token_endpoint_auth_method: None,
@@ -435,7 +452,7 @@ mod tests {
                     client_secret_hash: None,
                     redirect_uris: vec!["https://app.example.com/cb".to_string()],
                     grant_types: vec![GrantType::AuthorizationCode],
-                    scopes: vec![],
+                    scopes: vec!["openid".to_string(), "profile".to_string()],
                     require_pkce: true,
                     allowed_audiences: vec![],
                     token_endpoint_auth_method: None,
@@ -499,7 +516,7 @@ mod tests {
                     client_secret_hash: None,
                     redirect_uris: vec!["https://app.example.com/cb".to_string()],
                     grant_types: vec![GrantType::AuthorizationCode],
-                    scopes: vec![],
+                    scopes: vec!["openid".to_string()],
                     require_pkce: false,
                     allowed_audiences: vec![],
                     token_endpoint_auth_method: None,
@@ -574,7 +591,7 @@ mod tests {
                     client_secret_hash: None,
                     redirect_uris: vec!["https://app.example.com/cb".to_string()],
                     grant_types: vec![GrantType::AuthorizationCode],
-                    scopes: vec![],
+                    scopes: vec!["openid".to_string()],
                     require_pkce: false, // no longer changes the outcome — PKCE is always required
                     allowed_audiences: vec![],
                     token_endpoint_auth_method: None,
@@ -626,7 +643,7 @@ mod tests {
                     client_secret_hash: None,
                     redirect_uris: vec!["https://app.example.com/cb".to_string()],
                     grant_types: vec![GrantType::AuthorizationCode],
-                    scopes: vec![],
+                    scopes: vec!["openid".to_string()],
                     require_pkce: false,
                     allowed_audiences: vec![],
                     token_endpoint_auth_method: None,
@@ -668,6 +685,130 @@ mod tests {
         if let AuthorizeOutcome::Redirect(url) = outcome {
             assert!(url.contains("error=invalid_request"));
             assert!(url.contains("error_description=code_challenge+is+required"));
+        } else {
+            panic!("Expected Redirect");
+        }
+    }
+
+    /// The core regression test for authkestra#278: a client registered
+    /// with a narrow scope must not be able to request — and receive an
+    /// authorization code for — a scope it was never granted.
+    #[tokio::test]
+    async fn test_scope_not_granted_to_client_is_rejected() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<
+            crate::client::ClientRegistration,
+        >::new();
+        clients
+            .set(
+                "client-1",
+                ClientRegistration {
+                    client_id: "client-1".to_string(),
+                    client_secret_hash: None,
+                    redirect_uris: vec!["https://app.example.com/cb".to_string()],
+                    grant_types: vec![GrantType::AuthorizationCode],
+                    scopes: vec!["profile".to_string()],
+                    require_pkce: false,
+                    allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
+                },
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let codes =
+            authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new();
+        let config = test_config();
+
+        let req = AuthorizeRequest {
+            client_id: "client-1".to_string(),
+            redirect_uri: "https://app.example.com/cb".to_string(),
+            response_type: "code".to_string(),
+            scope: "admin".to_string(),
+            state: None,
+            code_challenge: Some("s256challenge".to_string()),
+            code_challenge_method: Some("S256".to_string()),
+            nonce: None,
+        };
+
+        let outcome = handle_authorize(
+            req,
+            test_identity(),
+            &config,
+            &crate::store::CompositeOpStore::new(
+                clients,
+                codes,
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(
+                ),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(),
+            ),
+        )
+        .await;
+        if let AuthorizeOutcome::Redirect(url) = outcome {
+            assert!(url.contains("error=invalid_scope"));
+            assert!(url.contains("error_description=Scope+admin+is+not+allowed"));
+        } else {
+            panic!("Expected Redirect");
+        }
+    }
+
+    /// A request mixing a granted and an ungranted scope must still be
+    /// rejected — partial credit is not an option.
+    #[tokio::test]
+    async fn test_one_ungranted_scope_among_several_is_rejected() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<
+            crate::client::ClientRegistration,
+        >::new();
+        clients
+            .set(
+                "client-1",
+                ClientRegistration {
+                    client_id: "client-1".to_string(),
+                    client_secret_hash: None,
+                    redirect_uris: vec!["https://app.example.com/cb".to_string()],
+                    grant_types: vec![GrantType::AuthorizationCode],
+                    scopes: vec!["openid".to_string(), "profile".to_string()],
+                    require_pkce: false,
+                    allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
+                },
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let codes =
+            authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new();
+        let config = test_config();
+
+        let req = AuthorizeRequest {
+            client_id: "client-1".to_string(),
+            redirect_uri: "https://app.example.com/cb".to_string(),
+            response_type: "code".to_string(),
+            scope: "openid admin".to_string(),
+            state: None,
+            code_challenge: Some("s256challenge".to_string()),
+            code_challenge_method: Some("S256".to_string()),
+            nonce: None,
+        };
+
+        let outcome = handle_authorize(
+            req,
+            test_identity(),
+            &config,
+            &crate::store::CompositeOpStore::new(
+                clients,
+                codes,
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(
+                ),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(),
+            ),
+        )
+        .await;
+        if let AuthorizeOutcome::Redirect(url) = outcome {
+            assert!(url.contains("error=invalid_scope"));
         } else {
             panic!("Expected Redirect");
         }

--- a/crates/authkestra-op/src/handlers/device_authorization.rs
+++ b/crates/authkestra-op/src/handlers/device_authorization.rs
@@ -112,6 +112,19 @@ pub async fn handle_device_authorization(
 
     let scope = req.scope.unwrap_or_default();
 
+    // Validate requested scope against the client's registration
+    // (authkestra#278) — the same gap `handle_authorize` had, found during
+    // the audit that issue asked for: this endpoint copied `req.scope`
+    // verbatim into the stored device session with no check at all.
+    for s in scope.split_whitespace() {
+        if !client.allows_scope(s) {
+            return Err(DeviceAuthorizationErrorResponse {
+                error: "invalid_scope".to_string(),
+                error_description: format!("Scope {s} is not allowed for this client"),
+            });
+        }
+    }
+
     // Generate codes
     let mut buf = [0u8; 32];
     rand::RngCore::fill_bytes(&mut rand::rng(), &mut buf);
@@ -308,5 +321,60 @@ mod tests {
 
         assert_eq!(token_res_success.token_type, "Bearer");
         assert!(token_res_success.id_token.is_some());
+    }
+
+    /// authkestra#278: the same scope-escalation gap `/authorize` had —
+    /// found during the audit that issue asked for. A client registered
+    /// for a narrow scope must not be able to request a wider one here
+    /// either.
+    #[tokio::test]
+    async fn test_scope_not_granted_to_client_is_rejected() {
+        let config = test_config();
+        let clients = authkestra_engine::store::memory::MemoryStore::<
+            crate::client::ClientRegistration,
+        >::new();
+
+        clients
+            .set(
+                "device_client",
+                ClientRegistration {
+                    client_id: "device_client".to_string(),
+                    client_secret_hash: None,
+                    redirect_uris: vec![],
+                    grant_types: vec![GrantType::DeviceCode],
+                    scopes: vec!["openid".to_string()],
+                    require_pkce: false,
+                    allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
+                },
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let req = DeviceAuthorizationRequest {
+            client_id: Some("device_client".to_string()),
+            scope: Some("admin".to_string()),
+            client_secret: None,
+            client_assertion: None,
+            client_assertion_type: None,
+        };
+
+        let err = handle_device_authorization(
+            req,
+            None,
+            &config,
+            &crate::store::CompositeOpStore::new(
+                clients,
+                authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(),
+            ),
+        )
+        .await
+        .expect_err("a scope the client isn't registered for must be refused");
+
+        assert_eq!(err.error, "invalid_scope");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #278. `handle_authorize` never validated the requested `scope` against either the client's registered `scopes` or the server's `scopes_supported` — it copied `req.scope` verbatim into the stored `AuthorizationCode`, and from there into the eventual token, with no check at all. A client registered for `scopes: ["profile"]` could request `scope=admin` and receive a code, then a token, carrying it.

Unlike #273 (PKCE), this needs **no misconfiguration** to exploit — every deployment has this gap regardless of how clients are registered.

## Audit of other grant paths (per the issue's own ask)

- `default_handle_client_credentials` and `default_handle_token_exchange` **already validate scope correctly** against `client.scopes` — confirmed by reading both, left untouched.
- `default_handle_refresh_token` never reads `req.scope` at all (no narrowing support in this implementation) — it only re-issues whatever scope was already granted, so it has no additional attack surface once the source of that scope is validated.
- `handle_device_authorization` had the **identical gap** to `/authorize` — same root cause (RFC 8628's equivalent of the same request shape), so fixed alongside it rather than filed as a separate issue.

## Changes

- `ClientRegistration::allows_scope(&self, scope: &str) -> bool` — mirrors the existing `allows_redirect_uri`/`allows_grant_type` shape.
- `handle_authorize`: a `// 3.` enforcement step, filling the exact gap the missing step numbering pointed at (steps jumped `2` → `4`). Rejects on the first ungranted scope, naming it specifically via `invalid_scope`, matching `client_credentials`'s existing error shape.
- `handle_device_authorization`: the equivalent check.

## Breaking change

Like #273, this is intentional but breaking: any client currently receiving scopes outside its registration will be rejected until its registration is corrected or the request is narrowed. Targeting `next`, not `main`, for the same release-timing reason as #273/#277.

**Design choice, explicitly**: RFC 6749 §3.3 permits an AS to *narrow* an over-broad scope request to the granted subset instead of rejecting it outright, and some providers do exactly that. This PR rejects the whole request instead — matching what `client_credentials` already does here, for consistency across grant types — which is the more disruptive option for any existing deployment currently relying on silent narrowing (there was none before this PR, but a future scope-narrowing change would be a *smaller* behavior shift than what this PR ships).

## Test plan

- [x] `cargo test -p authkestra-op --lib` — 154 passed (151 existing + 3 new).
- [x] `cargo test --workspace --all-features` — full suite green.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Fixed 7 existing `authorize.rs` tests whose fixtures registered a client with `scopes: []` while requesting `"openid"`/`"openid profile"` — updated to request scopes they're actually registered for, so each test again exercises the concern it was written for (PKCE, response_type, state encoding) rather than being blocked by the new scope check.
- [x] New regression tests:
  - `test_scope_not_granted_to_client_is_rejected` (authorize.rs) — a `scopes: ["profile"]` client requesting `scope=admin` is rejected.
  - `test_one_ungranted_scope_among_several_is_rejected` (authorize.rs) — one bad scope among several granted ones still fails the whole request.
  - `test_scope_not_granted_to_client_is_rejected` (device_authorization.rs) — the same scenario for the device flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
