### PR TITLE
feat(op): wire DPoP (RFC 9449) proof verification into the /token endpoint

### DIFF
--- a/crates/authkestra-actix/src/op.rs
+++ b/crates/authkestra-actix/src/op.rs
@@ -15,7 +15,7 @@ use authkestra_op::{
             CompleteChallengeRequest, EnrolStartRequest, ReissueStartRequest,
         },
         jwks::JwksResponse,
-        token::{handle_token_with_client_cert, TokenRequest},
+        token::{handle_token_with_client_cert, TokenErrorResponse, TokenRequest},
         userinfo::{handle_userinfo, UserInfoErrorResponse, UserInfoRequest},
     },
     OpError,
@@ -106,6 +106,40 @@ pub async fn actix_device_authorization_handler(
     }
 }
 
+/// Reads the request's `DPoP` header (RFC 9449 §4.1: exactly one is
+/// expected). Returns `Ok(None)` if it's absent, `Ok(Some(value))` if
+/// exactly one occurrence is present and valid ASCII, or `Err` in two
+/// cases that are refused outright rather than tolerated:
+///
+/// - **More than one occurrence.** Which one would be authoritative is
+///   ambiguous, and a duplicate is exactly the kind of situation a
+///   proxy bug or request-smuggling attempt could produce — a
+///   sender-constraining mechanism shouldn't guess which header to
+///   trust.
+/// - **A value that isn't valid ASCII.** Treating this as "no header"
+///   would silently issue a plain Bearer token while the client
+///   believes (because it sent one) that it's getting a
+///   sender-constrained one — a mangled header should fail loudly, not
+///   downgrade silently.
+fn extract_dpop_header(
+    headers: &actix_web::http::header::HeaderMap,
+) -> Result<Option<&str>, TokenErrorResponse> {
+    let mut dpop_headers = headers.get_all("DPoP");
+    match (dpop_headers.next(), dpop_headers.next()) {
+        (None, _) => Ok(None),
+        (Some(_), Some(_)) => Err(TokenErrorResponse::new(
+            "invalid_dpop_proof".to_string(),
+            "Multiple DPoP headers were presented".to_string(),
+        )),
+        (Some(v), None) => v.to_str().map(Some).map_err(|_| {
+            TokenErrorResponse::new(
+                "invalid_dpop_proof".to_string(),
+                "DPoP header value is not valid ASCII".to_string(),
+            )
+        }),
+    }
+}
+
 /// Handler for the token endpoint.
 ///
 /// Certificate binding (RFC 8705, issue #224): this crate does not
@@ -135,8 +169,13 @@ pub async fn actix_token_handler(
 
     // RFC 9449 — an ordinary header, unlike the mTLS certificate above:
     // `http_req` already gives access to the whole header map, no
-    // extension-based plumbing needed.
-    let dpop_header = http_req.headers().get("DPoP").and_then(|h| h.to_str().ok());
+    // extension-based plumbing needed. See `extract_dpop_header` for why
+    // more than one occurrence, or one that isn't valid ASCII, is refused
+    // outright rather than tolerated.
+    let dpop_header = match extract_dpop_header(http_req.headers()) {
+        Ok(h) => h,
+        Err(err) => return HttpResponse::BadRequest().json(err),
+    };
 
     match handle_token_with_client_cert(
         req.into_inner(),
@@ -392,5 +431,54 @@ impl OpActixExt for &mut web::ServiceConfig {
             self.app_data(web::Data::new(provider));
         }
         self
+    }
+}
+
+#[cfg(test)]
+mod dpop_header_tests {
+    use super::extract_dpop_header;
+    use actix_web::http::header::{HeaderMap, HeaderValue};
+
+    #[test]
+    fn no_header_is_none() {
+        let headers = HeaderMap::new();
+        assert_eq!(extract_dpop_header(&headers).unwrap(), None);
+    }
+
+    #[test]
+    fn exactly_one_header_is_returned() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            actix_web::http::header::HeaderName::from_static("dpop"),
+            HeaderValue::from_static("proof-value"),
+        );
+        assert_eq!(extract_dpop_header(&headers).unwrap(), Some("proof-value"));
+    }
+
+    /// RFC 9449 §4.1 expects exactly one `DPoP` header; a duplicate is
+    /// refused outright rather than silently resolved by picking one.
+    #[test]
+    fn two_headers_are_rejected() {
+        let mut headers = HeaderMap::new();
+        let name = actix_web::http::header::HeaderName::from_static("dpop");
+        headers.append(name.clone(), HeaderValue::from_static("first"));
+        headers.append(name, HeaderValue::from_static("second"));
+        let err = extract_dpop_header(&headers).expect_err("a duplicate header must be refused");
+        assert_eq!(err.error, "invalid_dpop_proof");
+    }
+
+    /// A header value that isn't valid ASCII must be refused, not silently
+    /// treated as "no header present" (which would issue a plain Bearer
+    /// token while the client believes it asked for — and thinks it got —
+    /// a sender-constrained one).
+    #[test]
+    fn non_ascii_header_is_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            actix_web::http::header::HeaderName::from_static("dpop"),
+            HeaderValue::from_bytes(&[0xff, 0xfe]).unwrap(),
+        );
+        let err = extract_dpop_header(&headers).expect_err("a non-ASCII header must be refused");
+        assert_eq!(err.error, "invalid_dpop_proof");
     }
 }

--- a/crates/authkestra-actix/src/op.rs
+++ b/crates/authkestra-actix/src/op.rs
@@ -133,6 +133,11 @@ pub async fn actix_token_handler(
         .get::<ClientCertificateDer>()
         .map(|c| c.0.clone());
 
+    // RFC 9449 — an ordinary header, unlike the mTLS certificate above:
+    // `http_req` already gives access to the whole header map, no
+    // extension-based plumbing needed.
+    let dpop_header = http_req.headers().get("DPoP").and_then(|h| h.to_str().ok());
+
     match handle_token_with_client_cert(
         req.into_inner(),
         auth_header,
@@ -140,6 +145,7 @@ pub async fn actix_token_handler(
         op_store.get_ref().as_ref(),
         tokens.get_ref().as_ref(),
         client_cert_der.as_deref(),
+        dpop_header,
     )
     .await
     {

--- a/crates/authkestra-axum/src/op.rs
+++ b/crates/authkestra-axum/src/op.rs
@@ -15,7 +15,7 @@ use authkestra_op::{
             CompleteChallengeRequest, EnrolStartRequest, ReissueStartRequest,
         },
         jwks::JwksResponse,
-        token::{handle_token_with_client_cert, TokenRequest},
+        token::{handle_token_with_client_cert, TokenErrorResponse, TokenRequest},
         userinfo::{handle_userinfo, UserInfoErrorResponse, UserInfoRequest},
     },
     OpError,
@@ -145,6 +145,38 @@ where
     }
 }
 
+/// Reads the request's `DPoP` header (RFC 9449 §4.1: exactly one is
+/// expected). Returns `Ok(None)` if it's absent, `Ok(Some(value))` if
+/// exactly one occurrence is present and valid ASCII, or `Err` in two
+/// cases that are refused outright rather than tolerated:
+///
+/// - **More than one occurrence.** Which one would be authoritative is
+///   ambiguous, and a duplicate is exactly the kind of situation a
+///   proxy bug or request-smuggling attempt could produce — a
+///   sender-constraining mechanism shouldn't guess which header to
+///   trust.
+/// - **A value that isn't valid ASCII.** Treating this as "no header"
+///   would silently issue a plain Bearer token while the client
+///   believes (because it sent one) that it's getting a
+///   sender-constrained one — a mangled header should fail loudly, not
+///   downgrade silently.
+fn extract_dpop_header(headers: &HeaderMap) -> Result<Option<&str>, TokenErrorResponse> {
+    let mut dpop_headers = headers.get_all("DPoP").iter();
+    match (dpop_headers.next(), dpop_headers.next()) {
+        (None, _) => Ok(None),
+        (Some(_), Some(_)) => Err(TokenErrorResponse::new(
+            "invalid_dpop_proof".to_string(),
+            "Multiple DPoP headers were presented".to_string(),
+        )),
+        (Some(v), None) => v.to_str().map(Some).map_err(|_| {
+            TokenErrorResponse::new(
+                "invalid_dpop_proof".to_string(),
+                "DPoP header value is not valid ASCII".to_string(),
+            )
+        }),
+    }
+}
+
 /// Handler for the token endpoint.
 ///
 /// `cert` is an RFC 8705 (§224) hook, not a TLS implementation: this crate
@@ -185,8 +217,13 @@ where
 
     // RFC 9449 — an ordinary header, unlike the mTLS certificate above:
     // `headers` already gives access to the whole map, no host-supplied
-    // `Extension` plumbing needed.
-    let dpop_header = headers.get("DPoP").and_then(|h| h.to_str().ok());
+    // `Extension` plumbing needed. See `extract_dpop_header` for why more
+    // than one occurrence, or one that isn't valid ASCII, is refused
+    // outright rather than tolerated.
+    let dpop_header = match extract_dpop_header(&headers) {
+        Ok(h) => h,
+        Err(err) => return (StatusCode::BAD_REQUEST, Json(err)).into_response(),
+    };
 
     match handle_token_with_client_cert(
         req,
@@ -609,5 +646,47 @@ impl FromRef<OpState> for Result<Arc<dyn SecondFactorVerifier>, AxumError> {
 impl FromRef<OpState> for Option<Arc<dyn AttestationStatusProvider>> {
     fn from_ref(state: &OpState) -> Self {
         state.0.status_provider.clone()
+    }
+}
+
+#[cfg(test)]
+mod dpop_header_tests {
+    use super::extract_dpop_header;
+    use axum::http::{HeaderMap, HeaderValue};
+
+    #[test]
+    fn no_header_is_none() {
+        let headers = HeaderMap::new();
+        assert_eq!(extract_dpop_header(&headers).unwrap(), None);
+    }
+
+    #[test]
+    fn exactly_one_header_is_returned() {
+        let mut headers = HeaderMap::new();
+        headers.insert("DPoP", HeaderValue::from_static("proof-value"));
+        assert_eq!(extract_dpop_header(&headers).unwrap(), Some("proof-value"));
+    }
+
+    /// RFC 9449 §4.1 expects exactly one `DPoP` header; a duplicate is
+    /// refused outright rather than silently resolved by picking one.
+    #[test]
+    fn two_headers_are_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.append("DPoP", HeaderValue::from_static("first"));
+        headers.append("DPoP", HeaderValue::from_static("second"));
+        let err = extract_dpop_header(&headers).expect_err("a duplicate header must be refused");
+        assert_eq!(err.error, "invalid_dpop_proof");
+    }
+
+    /// A header value that isn't valid ASCII must be refused, not silently
+    /// treated as "no header present" (which would issue a plain Bearer
+    /// token while the client believes it asked for — and thinks it got —
+    /// a sender-constrained one).
+    #[test]
+    fn non_ascii_header_is_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.insert("DPoP", HeaderValue::from_bytes(&[0xff, 0xfe]).unwrap());
+        let err = extract_dpop_header(&headers).expect_err("a non-ASCII header must be refused");
+        assert_eq!(err.error, "invalid_dpop_proof");
     }
 }

--- a/crates/authkestra-axum/src/op.rs
+++ b/crates/authkestra-axum/src/op.rs
@@ -183,6 +183,11 @@ where
 
     let client_cert_der = cert.map(|Extension(ClientCertificateDer(der))| der);
 
+    // RFC 9449 — an ordinary header, unlike the mTLS certificate above:
+    // `headers` already gives access to the whole map, no host-supplied
+    // `Extension` plumbing needed.
+    let dpop_header = headers.get("DPoP").and_then(|h| h.to_str().ok());
+
     match handle_token_with_client_cert(
         req,
         auth_header,
@@ -190,6 +195,7 @@ where
         op_store.as_ref(),
         tokens.as_ref(),
         client_cert_der.as_deref(),
+        dpop_header,
     )
     .await
     {

--- a/crates/authkestra-engine/src/store/memory.rs
+++ b/crates/authkestra-engine/src/store/memory.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -9,6 +10,10 @@ struct StoreEntry<T> {
     value: T,
     expires_at: Option<Instant>,
 }
+
+/// A min-heap of (expiry, key) pairs, oldest first — see
+/// `MemoryStore::insert_if_absent` for why it exists and how it's used.
+type ExpiryQueue = BinaryHeap<Reverse<(Instant, String)>>;
 
 impl<T> StoreEntry<T> {
     fn is_expired(&self) -> bool {
@@ -29,6 +34,9 @@ impl<T> StoreEntry<T> {
 pub struct MemoryStore<T> {
     data: Arc<Mutex<HashMap<String, StoreEntry<T>>>>,
     indices: Arc<Mutex<HashMap<String, String>>>,
+    /// Expiry order for entries written through `insert_if_absent` — see
+    /// that method for why this exists and how it's used.
+    insert_only_expiry_queue: Arc<Mutex<ExpiryQueue>>,
 }
 
 impl<T> Default for MemoryStore<T> {
@@ -36,6 +44,7 @@ impl<T> Default for MemoryStore<T> {
         Self {
             data: Arc::new(Mutex::new(HashMap::new())),
             indices: Arc::new(Mutex::new(HashMap::new())),
+            insert_only_expiry_queue: Arc::new(Mutex::new(BinaryHeap::new())),
         }
     }
 }
@@ -123,27 +132,66 @@ impl<T: Clone + Send + Sync + 'static> AtomicInsert<T> for MemoryStore<T> {
         // makes the operation atomic, exactly like `consume`'s single
         // `remove` call above.
         let mut data = self.data.lock().unwrap();
+        let mut expiry_queue = self.insert_only_expiry_queue.lock().unwrap();
+
         // `get`/`consume` each self-heal by removing an expired entry the
         // next time *that same key* is looked up — but `insert_if_absent`
         // is also used for insert-only key spaces (a DPoP proof's `jti`,
         // unique per proof) where no later call ever revisits the same
-        // key. Without this sweep, such an entry would sit expired-but-
-        // present forever: nothing else would ever touch its key to
-        // trigger the removal, leaking one entry per call for the life of
-        // the process. Piggybacking the sweep on every insert instead
-        // bounds this store's size by roughly the insert rate over one
-        // TTL window, not by total inserts ever made.
-        data.retain(|_, entry| !entry.is_expired());
-        if data.contains_key(key) {
-            return Ok(false);
+        // key. Without reclaiming these separately, such an entry would
+        // sit expired-but-present forever: nothing else would ever touch
+        // its key to trigger removal, leaking one entry per call for the
+        // life of the process.
+        //
+        // `insert_only_expiry_queue` tracks exactly this key space, ordered
+        // by expiry. Popping while the earliest entry has expired costs
+        // O(log n) per popped item, and each item is pushed once and
+        // popped at most once — so the amortized cost per call is
+        // O(log n), not the O(n) a full-map scan on every call would be
+        // (which, at R requests/sec against a T-second TTL, is quadratic
+        // in R: each of the ~R*T live entries gets rescanned on every one
+        // of the R calls per second).
+        //
+        // A popped entry is discarded as a no-op, not removed from `data`,
+        // if `data` no longer holds it under the exact expiry this queue
+        // entry was pushed for — that happens when the same key was later
+        // reinserted with a new TTL after this entry was queued, which
+        // pushed its own, newer queue entry for the same key. Without this
+        // guard a stale queue entry could wrongly evict a key's *current*
+        // value.
+        let now = Instant::now();
+        while let Some(Reverse((expiry, _))) = expiry_queue.peek() {
+            if *expiry > now {
+                break;
+            }
+            let Reverse((expiry, stale_key)) = expiry_queue.pop().unwrap();
+            if data
+                .get(&stale_key)
+                .is_some_and(|entry| entry.expires_at == Some(expiry))
+            {
+                data.remove(&stale_key);
+            }
         }
+
+        if let Some(entry) = data.get(key) {
+            // Only reachable for a key written through some path other
+            // than `insert_if_absent` (e.g. `set`) that the queue above
+            // doesn't track — the sweep already handled everything in
+            // this key space.
+            if !entry.is_expired() {
+                return Ok(false);
+            }
+        }
+
+        let expires_at = now + ttl;
         data.insert(
             key.to_string(),
             StoreEntry {
                 value,
-                expires_at: Some(Instant::now() + ttl),
+                expires_at: Some(expires_at),
             },
         );
+        expiry_queue.push(Reverse((expires_at, key.to_string())));
         Ok(true)
     }
 }
@@ -338,6 +386,47 @@ mod tests {
             store.len(),
             1,
             "expired insert-only entries under other keys must be swept, not retained forever"
+        );
+    }
+
+    /// The sweep's expiry queue can hold a stale entry for a key that was
+    /// later reinserted with a fresh, longer TTL (`insert_if_absent`
+    /// allows reuse once a key's own entry expires — see the test above).
+    /// The sweep must recognize that stale entry as no longer describing
+    /// the key's *current* value and leave it alone, not wrongly evict a
+    /// live entry just because an old queue record for the same key has
+    /// finally come due.
+    #[tokio::test]
+    async fn test_insert_if_absent_sweep_ignores_a_stale_queue_entry_for_a_reused_key() {
+        let store = MemoryStore::<String>::new();
+
+        store
+            .insert_if_absent("key1", "first".to_string(), Duration::from_millis(10))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // Reuses "key1" with a long TTL — this pushes a second, newer
+        // queue entry for the same key; the first (now-expired) one is
+        // still sitting in the queue behind it.
+        assert!(store
+            .insert_if_absent("key1", "second".to_string(), Duration::from_secs(10))
+            .await
+            .unwrap());
+
+        // Any other insert drives the sweep, which will reach that stale
+        // first queue entry for "key1" — it must be discarded as a no-op,
+        // not treated as license to remove "key1"'s current, still-live
+        // value.
+        store
+            .insert_if_absent("key2", "unrelated".to_string(), Duration::from_secs(10))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store.get("key1").await.unwrap(),
+            Some("second".to_string()),
+            "a stale queue entry for a reused key must not evict its current value"
         );
     }
 

--- a/crates/authkestra-engine/src/store/memory.rs
+++ b/crates/authkestra-engine/src/store/memory.rs
@@ -47,6 +47,17 @@ impl<T> MemoryStore<T> {
     }
 }
 
+#[cfg(test)]
+impl<T> MemoryStore<T> {
+    /// Test-only introspection: the number of entries currently held,
+    /// expired or not. Used to prove `insert_if_absent`'s opportunistic
+    /// sweep actually shrinks the map, not just that expired entries are
+    /// unreachable through the public API.
+    fn len(&self) -> usize {
+        self.data.lock().unwrap().len()
+    }
+}
+
 #[async_trait]
 impl<T: Clone + Send + Sync + 'static> KvStore<T> for MemoryStore<T> {
     #[tracing::instrument(skip(self))]
@@ -112,10 +123,19 @@ impl<T: Clone + Send + Sync + 'static> AtomicInsert<T> for MemoryStore<T> {
         // makes the operation atomic, exactly like `consume`'s single
         // `remove` call above.
         let mut data = self.data.lock().unwrap();
-        if let Some(entry) = data.get(key) {
-            if !entry.is_expired() {
-                return Ok(false);
-            }
+        // `get`/`consume` each self-heal by removing an expired entry the
+        // next time *that same key* is looked up — but `insert_if_absent`
+        // is also used for insert-only key spaces (a DPoP proof's `jti`,
+        // unique per proof) where no later call ever revisits the same
+        // key. Without this sweep, such an entry would sit expired-but-
+        // present forever: nothing else would ever touch its key to
+        // trigger the removal, leaking one entry per call for the life of
+        // the process. Piggybacking the sweep on every insert instead
+        // bounds this store's size by roughly the insert rate over one
+        // TTL window, not by total inserts ever made.
+        data.retain(|_, entry| !entry.is_expired());
+        if data.contains_key(key) {
+            return Ok(false);
         }
         data.insert(
             key.to_string(),
@@ -279,6 +299,46 @@ mod tests {
             .unwrap();
         assert!(inserted_again);
         assert_eq!(store.get("key1").await.unwrap(), Some("value2".to_string()));
+    }
+
+    /// `insert_if_absent` is the only primitive an insert-only key space
+    /// (e.g. a DPoP proof's `jti`, unique per proof) ever calls — nothing
+    /// ever revisits the same key the way `get`/`consume` are revisited for
+    /// server-issued values. Without an opportunistic sweep, an expired
+    /// entry under a never-repeated key would sit in the map forever,
+    /// leaking one entry per call for the life of the process. This proves
+    /// the map's size actually shrinks, not just that expired entries are
+    /// unreachable through `get`.
+    #[tokio::test]
+    async fn test_insert_if_absent_reclaims_expired_entries_under_other_keys() {
+        let store = MemoryStore::<String>::new();
+
+        for i in 0..50 {
+            store
+                .insert_if_absent(
+                    &format!("jti-{i}"),
+                    "spent".to_string(),
+                    Duration::from_millis(10),
+                )
+                .await
+                .unwrap();
+        }
+        assert_eq!(store.len(), 50);
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // A single insert under a brand-new key must sweep every expired
+        // entry from the previous batch, even though none of their keys
+        // are ever looked up again.
+        store
+            .insert_if_absent("jti-new", "spent".to_string(), Duration::from_secs(10))
+            .await
+            .unwrap();
+        assert_eq!(
+            store.len(),
+            1,
+            "expired insert-only entries under other keys must be swept, not retained forever"
+        );
     }
 
     /// The property the whole replay-guard feature depends on: under real

--- a/crates/authkestra-engine/src/store/mod.rs
+++ b/crates/authkestra-engine/src/store/mod.rs
@@ -51,6 +51,28 @@ pub trait AtomicInsert<T>: KvStore<T> {
     ) -> Result<bool, StoreError>;
 }
 
+/// Rounds a [`Duration`] up to the nearest whole second, flooring at 1.
+///
+/// Every [`AtomicInsert`] backend whose storage only expresses TTL in
+/// whole seconds (Redis's `EX`, and the `expires_at` column every SQL
+/// backend uses) needs this same conversion, and needs it to round up:
+/// `insert_if_absent`'s return value is a security-critical replay
+/// signal, not a best-effort cache write. Truncating instead (a plain
+/// `.as_secs()`, or `.as_secs().max(1)`) would silently disable the
+/// replay guard for any caller using a sub-second TTL (e.g. a DPoP
+/// freshness window configured in milliseconds) — a 1ms TTL would
+/// truncate to `expires_at == now`, meaning the row is already expired by
+/// the time anyone could observe it, and every subsequent call with the
+/// same key would also see no live entry and also report "fresh". This
+/// bug was found and fixed for the Redis backend first (authkestra#277
+/// review) and, having no shared definition to fall to, was independently
+/// re-introduced in each SQL backend rather than caught by one fix.
+pub fn ttl_ceil_secs(ttl: Duration) -> u64 {
+    ttl.as_secs()
+        .saturating_add(u64::from(ttl.subsec_nanos() > 0))
+        .max(1)
+}
+
 /// Backends that can atomically write a value under a primary key while
 /// also maintaining a secondary lookup key implement this.
 #[async_trait]

--- a/crates/authkestra-engine/src/store/redis.rs
+++ b/crates/authkestra-engine/src/store/redis.rs
@@ -127,7 +127,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> KvStore<T> for Red
     }
 }
 
-use crate::store::{AtomicConsume, AtomicInsert, IndexedKvStore};
+use crate::store::{ttl_ceil_secs, AtomicConsume, AtomicInsert, IndexedKvStore};
 
 #[async_trait]
 impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> AtomicInsert<T> for RedisStore {
@@ -153,24 +153,9 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> AtomicInsert<T> fo
             StoreError::Serialization(format!("Serialization error: {e}"))
         })?;
 
-        // Unlike `set`, a sub-second `ttl` must never be treated as "skip
-        // the write" here: `insert_if_absent`'s return value is a
-        // security-critical replay signal, not a best-effort cache write,
-        // and reporting `Ok(true)` without actually storing anything means
-        // every subsequent call with the same key *also* sees no existing
-        // entry and *also* reports "fresh" — silently disabling the replay
-        // guard entirely for any caller using a sub-second TTL (e.g. a
-        // DPoP freshness window configured in milliseconds). Redis' `EX`
-        // only accepts whole seconds, so round *up* on any fractional
-        // remainder (not just when the whole-second part is zero) — a
-        // plain `.as_secs().max(1)` still truncates, say, 1.9s down to 1s,
-        // silently shortening the replay window below what the caller
-        // asked for on every call with a sub-second remainder, not only
-        // the exact-zero case.
-        let ttl_secs = ttl
-            .as_secs()
-            .saturating_add(u64::from(ttl.subsec_nanos() > 0))
-            .max(1);
+        // Redis' `EX` only accepts whole seconds — see `ttl_ceil_secs` for
+        // why this must round up, not truncate.
+        let ttl_secs = ttl_ceil_secs(ttl);
 
         // `SET key value NX EX ttl` — a single atomic Redis command. Redis
         // replies `+OK` (parsed by this crate as `Value::Okay`, which

--- a/crates/authkestra-engine/src/store/sql/session.rs
+++ b/crates/authkestra-engine/src/store/sql/session.rs
@@ -8,7 +8,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use sqlx::Database;
 use std::time::Duration;
 
-use crate::store::{AtomicInsert, KvStore, StoreError};
+use crate::store::{ttl_ceil_secs, AtomicInsert, KvStore, StoreError};
 
 #[derive(Clone, Debug)]
 #[deprecated(
@@ -446,7 +446,8 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> AtomicInsert<T>
             StoreError::Serialization(format!("Serialization error: {e}"))
         })?;
         let now = chrono::Utc::now();
-        let expires_at = now + chrono::Duration::seconds(ttl.as_secs() as i64);
+        // See `ttl_ceil_secs` for why this must round up, not truncate.
+        let expires_at = now + chrono::Duration::seconds(ttl_ceil_secs(ttl) as i64);
 
         let result = sqlx::query(&query)
             .bind(key)
@@ -493,7 +494,8 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> AtomicInsert<T>
             StoreError::Serialization(format!("Serialization error: {e}"))
         })?;
         let now = chrono::Utc::now();
-        let expires_at = now + chrono::Duration::seconds(ttl.as_secs() as i64);
+        // See `ttl_ceil_secs` for why this must round up, not truncate.
+        let expires_at = now + chrono::Duration::seconds(ttl_ceil_secs(ttl) as i64);
 
         let result = sqlx::query(&query)
             .bind(key)
@@ -557,7 +559,8 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> AtomicInsert<T>
             StoreError::Serialization(format!("Serialization error: {e}"))
         })?;
         let now = chrono::Utc::now();
-        let expires_at = now + chrono::Duration::seconds(ttl.as_secs() as i64);
+        // See `ttl_ceil_secs` for why this must round up, not truncate.
+        let expires_at = now + chrono::Duration::seconds(ttl_ceil_secs(ttl) as i64);
 
         let insert_query = format!(
             "INSERT IGNORE INTO {} (`key`, value, expires_at) VALUES (?, ?, ?)",
@@ -684,16 +687,17 @@ mod tests {
     async fn test_sqlite_insert_if_absent_reclaims_an_expired_key() {
         let store = setup_db().await;
 
-        // A TTL under one second truncates to `expires_at == now` at
-        // insert time (`ttl.as_secs()` rounds down to 0), so this row is
-        // already expired by the time the sleep below elapses.
+        // A sub-second TTL rounds *up* to 1 whole second (see
+        // `test_sqlite_insert_if_absent_rounds_a_fractional_ttl_up` below),
+        // so the sleep here must clear a full second, not a few
+        // milliseconds, for this row to actually be expired.
         let inserted = store
             .insert_if_absent("key1", "value1".to_string(), Duration::from_millis(1))
             .await
             .unwrap();
         assert!(inserted);
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(1100)).await;
 
         let reclaimed = store
             .insert_if_absent("key1", "value2".to_string(), Duration::from_secs(10))
@@ -706,6 +710,34 @@ mod tests {
 
         let val: Option<String> = store.get("key1").await.unwrap();
         assert_eq!(val, Some("value2".to_string()));
+    }
+
+    /// Regression test: `ttl.as_secs()` alone truncates — a 1.5s TTL must
+    /// round *up* to 2s, not down to 1s. Verified behaviorally rather than
+    /// by inspecting the stored `expires_at`: at 1.2s elapsed (past the
+    /// wrong, truncated 1s bound but before the correct 2s one), the key
+    /// must still be live and block a second `insert_if_absent` as a
+    /// replay, not report it reclaimable.
+    #[tokio::test]
+    async fn test_sqlite_insert_if_absent_rounds_a_fractional_ttl_up() {
+        let store = setup_db().await;
+
+        store
+            .insert_if_absent("key1", "value1".to_string(), Duration::from_millis(1500))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+
+        let still_blocked = store
+            .insert_if_absent("key1", "value2".to_string(), Duration::from_secs(10))
+            .await
+            .unwrap();
+        assert!(
+            !still_blocked,
+            "a 1.5s TTL truncated to 1s would already look expired at 1.2s elapsed; \
+             rounded up to 2s it must still be live"
+        );
     }
 
     /// authkestra#277 review: the SQL layer's `insert_if_absent` has now
@@ -851,7 +883,8 @@ mod postgres_tests {
 
     /// Regression test: an expired existing row must be reclaimable rather
     /// than permanently blocking that key. See the Sqlite version of this
-    /// test for why a sub-second TTL is used.
+    /// test for why the sleep clears a full second, not a few
+    /// milliseconds — a sub-second TTL rounds up to 1s.
     #[tokio::test]
     async fn test_postgres_insert_if_absent_reclaims_an_expired_key() {
         let (store, _c) = setup_db().await;
@@ -862,7 +895,7 @@ mod postgres_tests {
             .unwrap();
         assert!(inserted);
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(1100)).await;
 
         let reclaimed = store
             .insert_if_absent("key1", "value2".to_string(), Duration::from_secs(10))
@@ -875,6 +908,30 @@ mod postgres_tests {
 
         let val: Option<String> = store.get("key1").await.unwrap();
         assert_eq!(val, Some("value2".to_string()));
+    }
+
+    /// See the Sqlite version of this test for why it exists: a 1.5s TTL
+    /// must round up to 2s, not truncate to 1s.
+    #[tokio::test]
+    async fn test_postgres_insert_if_absent_rounds_a_fractional_ttl_up() {
+        let (store, _c) = setup_db().await;
+
+        store
+            .insert_if_absent("key1", "value1".to_string(), Duration::from_millis(1500))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+
+        let still_blocked = store
+            .insert_if_absent("key1", "value2".to_string(), Duration::from_secs(10))
+            .await
+            .unwrap();
+        assert!(
+            !still_blocked,
+            "a 1.5s TTL truncated to 1s would already look expired at 1.2s elapsed; \
+             rounded up to 2s it must still be live"
+        );
     }
 
     /// See the Sqlite version of this test for why it exists: this
@@ -1028,15 +1085,21 @@ mod mysql_tests {
             .unwrap();
         assert!(inserted);
 
-        // MySQL's `TIMESTAMP` column (no fractional-second precision in
-        // this migration) *rounds* a sub-second value to the nearest whole
-        // second rather than truncating it, so a 1ms TTL's stored
-        // `expires_at` can land up to a full second after the actual
-        // insert instant — a 50ms sleep was flaky (~1 run in 3) for exactly
-        // that reason. Sleeping past that worst case removes the flake
-        // without needing a schema change that would affect every
-        // consumer of this migration, not just this test.
-        tokio::time::sleep(Duration::from_millis(1100)).await;
+        // Two layers of rounding stack here, both pushing the same way.
+        // `ttl_ceil_secs` (authkestra#274 review: a sub-second TTL must
+        // never truncate to `expires_at == now`, since that would let a
+        // caller's replay guard silently disable itself) rounds this 1ms
+        // TTL *up* to a full 1-second minimum. Then MySQL's `TIMESTAMP`
+        // column (no fractional-second precision in this migration)
+        // *rounds* that already-whole-second value's fractional
+        // `chrono::Utc::now()` origin to the nearest whole second, which
+        // can add up to another full second on top. Worst case the row
+        // isn't actually expired until ~2s after the insert instant — a
+        // shorter sleep here was flaky for exactly that reason once the
+        // TTL rounding was fixed. Sleeping past that worst case removes
+        // the flake without needing a schema change that would affect
+        // every consumer of this migration, not just this test.
+        tokio::time::sleep(Duration::from_millis(2100)).await;
 
         let reclaimed = store
             .insert_if_absent("key1", "value2".to_string(), Duration::from_secs(10))

--- a/crates/authkestra-op/src/dpop.rs
+++ b/crates/authkestra-op/src/dpop.rs
@@ -1,0 +1,203 @@
+//! DPoP (RFC 9449) replay tracking — the OP-side counterpart to
+//! `authkestra_engine::token::dpop::verify_dpop_proof`, which verifies one
+//! proof in isolation and deliberately does not track replay itself (see
+//! that module's doc comment).
+//!
+//! A DPoP proof's `jti` is client-generated, never server-issued — unlike
+//! an authorization code or enrolment challenge, there is nothing for this
+//! server to have stored ahead of time. The check is "was this `jti`
+//! already claimed", which is exactly the shape
+//! `authkestra_engine::store::AtomicInsert` provides, not
+//! [`authkestra_engine::store::AtomicConsume`] (the primitive
+//! [`crate::attestation::EnrolmentChallengeStore`] and
+//! [`crate::code::AuthorizationCodeStore`] are built on, for server-issued
+//! single-use values).
+
+use crate::error::OpError;
+use async_trait::async_trait;
+use authkestra_engine::store::{AtomicInsert, KvStore};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// The freshness window a DPoP proof is checked against, and — by the same
+/// convention `verify_dpop_proof`'s own doc comment establishes — the TTL a
+/// caller should use when recording its `jti`: a proof can never be
+/// usefully replayed after its own freshness window has elapsed, since it
+/// would independently fail that check first.
+///
+/// A constant rather than an `OpConfig` field on purpose: `OpConfig` is not
+/// `#[non_exhaustive]` and is constructed with struct literals throughout
+/// this workspace, so growing it is a breaking change this feature does not
+/// need to make — same reasoning
+/// `client_assertion::MAX_CLIENT_ASSERTION_LIFETIME_SECS` already
+/// established for an equivalent constraint.
+pub const DPOP_PROOF_MAX_AGE_SECS: i64 = 60;
+
+/// Records that a DPoP proof's `jti` has been spent.
+///
+/// `check_and_record_dpop_jti` **must** be atomic — a `get`-then-`set`
+/// implemented as two separate storage calls is a TOCTOU race, and the race
+/// is precisely the replay this trait exists to prevent: two concurrent
+/// presentations of the same captured proof would both observe "not yet
+/// seen". Same requirement, and the same reasoning, as
+/// `ClientAssertionStore::record_jti`.
+#[async_trait]
+pub trait DpopReplayStore: Send + Sync {
+    /// Atomically records `jti` as spent until `expires_at`.
+    ///
+    /// Returns `Ok(true)` if this is its first use (accept the proof) and
+    /// `Ok(false)` if it was already recorded (a replay — reject).
+    async fn check_and_record_dpop_jti(
+        &self,
+        jti: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<bool, OpError>;
+}
+
+/// The fail-closed default: refuses every proof.
+///
+/// A deployment that has not wired replay tracking cannot provide the
+/// single-use guarantee RFC 9449 §11.1 calls for, and accepting proofs
+/// without it would be strictly worse than not supporting DPoP at all —
+/// clients would believe they had sender-constrained tokens while a
+/// captured proof stayed replayable for its whole freshness window. So the
+/// default refuses rather than silently degrades — same rationale as
+/// `NoClientAssertionStore`.
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct NoDpopReplayStore;
+
+#[async_trait]
+impl DpopReplayStore for NoDpopReplayStore {
+    async fn check_and_record_dpop_jti(
+        &self,
+        _jti: &str,
+        _expires_at: DateTime<Utc>,
+    ) -> Result<bool, OpError> {
+        tracing::error!(
+            "a DPoP proof was presented but no DpopReplayStore is wired; refusing it rather \
+             than accepting a proof that could be replayed"
+        );
+        Err(OpError::DpopReplayProtectionUnavailable)
+    }
+}
+
+/// The record a `DpopReplayStore` backend persists for one spent `jti`.
+///
+/// `#[non_exhaustive]` blocks struct-literal construction from outside this
+/// crate, but storage-backend implementations must be able to reconstruct
+/// this from their own persisted fields — this is the seam that makes that
+/// possible, same shape as `AuthorizationCode::new`/`RefreshToken::new`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct DpopJtiRecord {
+    /// The spent `jti` value. Redundant with the store key it's saved
+    /// under, but kept on the record itself so a backend that reconstructs
+    /// rows generically (e.g. by scanning) doesn't need the key threaded
+    /// separately.
+    pub jti: String,
+    /// When this record — and the replay protection it provides — expires.
+    pub expires_at: DateTime<Utc>,
+}
+
+impl DpopJtiRecord {
+    /// Creates a new record for a freshly spent `jti`.
+    pub fn new(jti: String, expires_at: DateTime<Utc>) -> Self {
+        Self { jti, expires_at }
+    }
+}
+
+/// Blanket impl over any backend that is a `KvStore` with atomic
+/// insert-if-absent — the first real consumer of
+/// `authkestra_engine::store::AtomicInsert` in this crate. Unlike
+/// `ClientAssertionStore`'s hand-rolled per-backend implementations
+/// (written before `AtomicInsert` existed), every backend Phase A already
+/// implemented it for (Memory, Redis, Postgres, Sqlite, MySQL) gets
+/// `DpopReplayStore` for free, with no DPoP-specific storage code at all.
+#[async_trait]
+impl<S> DpopReplayStore for S
+where
+    S: KvStore<DpopJtiRecord> + AtomicInsert<DpopJtiRecord>,
+{
+    async fn check_and_record_dpop_jti(
+        &self,
+        jti: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<bool, OpError> {
+        tracing::trace!("attempting to record dpop proof jti");
+        let ttl = expires_at
+            .signed_duration_since(Utc::now())
+            .to_std()
+            .unwrap_or(Duration::from_secs(0));
+
+        self.insert_if_absent(jti, DpopJtiRecord::new(jti.to_string(), expires_at), ttl)
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "failed to record dpop proof jti");
+                OpError::Storage
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use authkestra_engine::store::memory::MemoryStore;
+
+    #[tokio::test]
+    async fn first_use_of_a_jti_is_accepted() {
+        let store = MemoryStore::<DpopJtiRecord>::new();
+        let expires_at = Utc::now() + chrono::Duration::seconds(60);
+
+        let accepted = store
+            .check_and_record_dpop_jti("jti-1", expires_at)
+            .await
+            .unwrap();
+        assert!(accepted);
+    }
+
+    #[tokio::test]
+    async fn a_replayed_jti_is_rejected() {
+        let store = MemoryStore::<DpopJtiRecord>::new();
+        let expires_at = Utc::now() + chrono::Duration::seconds(60);
+
+        assert!(store
+            .check_and_record_dpop_jti("jti-1", expires_at)
+            .await
+            .unwrap());
+
+        let replayed = store
+            .check_and_record_dpop_jti("jti-1", expires_at)
+            .await
+            .unwrap();
+        assert!(
+            !replayed,
+            "a second presentation of the same jti must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn distinct_jtis_are_independent() {
+        let store = MemoryStore::<DpopJtiRecord>::new();
+        let expires_at = Utc::now() + chrono::Duration::seconds(60);
+
+        assert!(store
+            .check_and_record_dpop_jti("jti-1", expires_at)
+            .await
+            .unwrap());
+        assert!(store
+            .check_and_record_dpop_jti("jti-2", expires_at)
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn no_dpop_replay_store_fails_closed() {
+        let err = NoDpopReplayStore
+            .check_and_record_dpop_jti("jti-1", Utc::now())
+            .await
+            .expect_err("the fail-closed default must refuse every proof");
+        assert!(matches!(err, OpError::DpopReplayProtectionUnavailable));
+    }
+}

--- a/crates/authkestra-op/src/error.rs
+++ b/crates/authkestra-op/src/error.rs
@@ -62,6 +62,19 @@ pub enum OpError {
     #[error("client assertion replay protection is not configured")]
     ReplayProtectionUnavailable,
 
+    /// The presented DPoP proof carries a `jti` that has already been spent
+    /// (RFC 9449 §11.1). A captured proof is otherwise reusable for as long
+    /// as it stays within its freshness window; single-use `jti` is what
+    /// stops it from being replayed within that window.
+    #[error("dpop proof replayed")]
+    DpopProofReplayed,
+
+    /// The deployment's `OpStore` provides no DPoP `jti` replay tracking, so
+    /// a presented DPoP proof cannot be honoured safely. Fails closed on
+    /// purpose — see `store::OpStore::check_and_record_dpop_jti`.
+    #[error("dpop proof replay protection is not configured")]
+    DpopReplayProtectionUnavailable,
+
     /// Underlying storage error, opaque to the caller by design — storage
     /// backends should not leak implementation details (e.g. SQL errors)
     /// into OAuth error responses.

--- a/crates/authkestra-op/src/handlers/device_authorization.rs
+++ b/crates/authkestra-op/src/handlers/device_authorization.rs
@@ -264,6 +264,7 @@ mod tests {
             audience: None,
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
             requested_token_type: None,
             subject_token: None,
             subject_token_type: None,

--- a/crates/authkestra-op/src/handlers/discovery.rs
+++ b/crates/authkestra-op/src/handlers/discovery.rs
@@ -28,6 +28,20 @@ pub struct OidcDiscovery {
     /// apply to.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code_challenge_methods_supported: Option<Vec<String>>,
+    /// JSON array of JWS `alg` values this OP accepts in a DPoP proof's
+    /// header (RFC 9449 §5).
+    ///
+    /// Opt-in via [`OidcDiscovery::with_dpop_support`], for the same reason
+    /// `private_key_jwt` support is: `handlers::token::handle_token_with_client_cert`
+    /// accepts a `DPoP` header unconditionally, but every request using one
+    /// is refused with `invalid_dpop_proof` unless the deployment's
+    /// `OpStore` also has a `DpopReplayStore` wired (it fails closed via
+    /// `NoDpopReplayStore` otherwise — see `store::OpStore::check_and_record_dpop_jti`).
+    /// A discovery document promising DPoP support the OP will reject at
+    /// runtime is worse than one that stays quiet, so the decision belongs
+    /// to whoever wired the store, exactly like `with_private_key_jwt`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dpop_signing_alg_values_supported: Option<Vec<String>>,
     /// URL of the OP's OAuth 2.0 Token Endpoint.
     pub token_endpoint: String,
     /// URL of the OP's JSON Web Key Set document.
@@ -79,6 +93,7 @@ impl OidcDiscovery {
                 .then(|| config.authorization_endpoint()),
             code_challenge_methods_supported: has_authorization_code_grant
                 .then(|| vec!["S256".to_string()]),
+            dpop_signing_alg_values_supported: None,
             token_endpoint: config.token_endpoint(),
             jwks_uri: config.jwks_url(),
             userinfo_endpoint: Some(config.userinfo_endpoint()),
@@ -124,6 +139,22 @@ impl OidcDiscovery {
         if !self.token_endpoint_auth_methods_supported.contains(&method) {
             self.token_endpoint_auth_methods_supported.push(method);
         }
+        self
+    }
+
+    /// Advertises DPoP support (RFC 9449 §5) with the algorithms
+    /// `authkestra_engine::token::dpop::verify_dpop_proof` accepts.
+    ///
+    /// Opt-in for the same reason [`OidcDiscovery::with_private_key_jwt`]
+    /// is — see this field's doc comment. Call alongside
+    /// `CompositeOpStore::with_dpop_replay_store` once that's wired.
+    pub fn with_dpop_support(mut self) -> Self {
+        self.dpop_signing_alg_values_supported = Some(vec![
+            "ES256".to_string(),
+            "ES384".to_string(),
+            "RS256".to_string(),
+            "EdDSA".to_string(),
+        ]);
         self
     }
 
@@ -231,6 +262,32 @@ mod tests {
         assert!(doc
             .token_endpoint_auth_methods_supported
             .contains(&"client_secret_basic".to_string()));
+    }
+
+    /// A discovery document must not promise DPoP support the OP will
+    /// reject at runtime because no replay store is wired — same rationale
+    /// as `private_key_jwt_is_not_advertised_by_default`.
+    #[test]
+    fn dpop_is_not_advertised_by_default() {
+        let doc = OidcDiscovery::from_config(&discovery_config());
+        assert_eq!(doc.dpop_signing_alg_values_supported, None);
+
+        let json = serde_json::to_value(&doc).unwrap();
+        assert!(
+            json.get("dpop_signing_alg_values_supported").is_none(),
+            "must be omitted (not null) when not opted in"
+        );
+    }
+
+    #[test]
+    fn dpop_is_advertised_once_opted_in() {
+        let doc = OidcDiscovery::from_config(&discovery_config()).with_dpop_support();
+
+        let algs = doc
+            .dpop_signing_alg_values_supported
+            .expect("must be Some once opted in");
+        assert!(algs.contains(&"ES256".to_string()));
+        assert!(algs.contains(&"EdDSA".to_string()));
     }
 
     /// A provider that serves no `authorization_code` grant (e.g. a

--- a/crates/authkestra-op/src/handlers/discovery.rs
+++ b/crates/authkestra-op/src/handlers/discovery.rs
@@ -148,6 +148,23 @@ impl OidcDiscovery {
     /// Opt-in for the same reason [`OidcDiscovery::with_private_key_jwt`]
     /// is — see this field's doc comment. Call alongside
     /// `CompositeOpStore::with_dpop_replay_store` once that's wired.
+    ///
+    /// **Resource-server caveat (authkestra#274, tracked for a later
+    /// phase):** this OP will correctly verify a DPoP proof and stamp
+    /// `cnf.jkt` onto the access tokens it issues, but the *bundled*
+    /// `authkestra-resource` `JwtStrategy` does not yet check `cnf.jkt` on
+    /// the resource-server side — it only verifies RFC 8705's
+    /// `cnf.x5t#S256` (mTLS certificate binding). A client that sees this
+    /// advertised will reasonably assume its access tokens are
+    /// sender-constrained end-to-end; against the bundled resource server,
+    /// they currently are not — a DPoP-bound access token is accepted
+    /// there as an ordinary bearer token, with no proof-of-possession
+    /// check at all, if it's presented without also being certificate-bound.
+    /// Calling this is still correct and useful today for any resource
+    /// server that *does* implement its own `cnf.jkt` check (or the
+    /// planned Phase C addition to this crate's own `JwtStrategy`), but a
+    /// deployment relying solely on the bundled resource server should not
+    /// call this yet believing it closes token-theft risk there.
     pub fn with_dpop_support(mut self) -> Self {
         self.dpop_signing_alg_values_supported = Some(vec![
             "ES256".to_string(),

--- a/crates/authkestra-op/src/handlers/mod.rs
+++ b/crates/authkestra-op/src/handlers/mod.rs
@@ -18,7 +18,7 @@ pub use device_authorization::{
 
 /// Token endpoint handler (`/token`).
 pub mod token;
-pub use token::{handle_token, TokenErrorResponse, TokenRequest, TokenResponse};
+pub use token::{handle_token, merge_dpop_cnf, TokenErrorResponse, TokenRequest, TokenResponse};
 
 /// UserInfo endpoint handler (`/userinfo`).
 pub mod userinfo;

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -280,8 +280,21 @@ pub async fn handle_token_with_client_cert(
             }
         };
 
-        let expires_at =
-            Utc::now() + chrono::Duration::seconds(crate::dpop::DPOP_PROOF_MAX_AGE_SECS);
+        // Anchored to the proof's own `iat`, not the current time: a proof
+        // remains fresh (and so, re-presentable) up to `iat + max_age`
+        // regardless of how long after `iat` it happens to first arrive
+        // here. Anchoring to `Utc::now()` instead would let the replay
+        // record expire before that fixed freshness boundary whenever this
+        // request is processed even slightly after `iat` (network delay,
+        // queuing, or a fresh `iat` up to `CLOCK_SKEW_ALLOWANCE_SECS` in
+        // this server's future) — a real, if narrow, window in which the
+        // same jti could be replayed after its record expired but before
+        // `verify_dpop_proof` would independently reject it as stale. The
+        // extra second guards the exact boundary instant itself.
+        let expires_at = chrono::DateTime::<Utc>::from_timestamp(verified.iat, 0)
+            .unwrap_or_else(Utc::now)
+            + chrono::Duration::seconds(crate::dpop::DPOP_PROOF_MAX_AGE_SECS)
+            + chrono::Duration::seconds(1);
         match op_store
             .check_and_record_dpop_jti(&verified.jti, expires_at)
             .await
@@ -728,6 +741,11 @@ async fn handle_device_code(
                         identity,
                         scope: session.scope,
                         expires_at: Utc::now() + chrono::Duration::days(30),
+                        // RFC 9449 §5: a refresh token minted alongside a
+                        // DPoP-bound access token must itself be bound to
+                        // the same key, so `default_handle_refresh_token`
+                        // can enforce continuity on every future rotation.
+                        jkt: req.dpop_jkt.clone(),
                     };
                     if op_store.store_token(rt).await.is_ok() {
                         issued_refresh_token = Some(refresh_val);
@@ -956,6 +974,8 @@ pub async fn default_handle_authorization_code<S: OpStore + ?Sized>(
             identity: auth_code.identity.clone(),
             scope: auth_code.scope.clone(),
             expires_at: Utc::now() + chrono::Duration::days(30),
+            // RFC 9449 §5: see the identical comment in `handle_device_code`.
+            jkt: req.dpop_jkt.clone(),
         };
         if let Err(e) = op_store.store_token(rt_model.clone()).await {
             tracing::error!(error = ?e, "Failed to store refresh token");
@@ -1214,6 +1234,39 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
         });
     }
 
+    // RFC 9449 §5: a refresh token that was bound to a DPoP key when issued
+    // MUST continue to be redeemed with a proof for that *same* key on
+    // every rotation — a request that omits DPoP entirely, or presents a
+    // proof for a different key, is refused rather than silently falling
+    // back to a plain bearer token or re-binding to whatever key the
+    // presenter happens to hold. Without this, an exfiltrated DPoP-bound
+    // refresh token could be redeemed with the attacker's own key (or no
+    // proof at all), which is exactly the theft scenario DPoP exists to
+    // close for public clients (authkestra#274). An `old_rt.jkt` of `None`
+    // means this refresh token was never DPoP-bound — that behavior is
+    // unchanged from before this feature existed.
+    if let Some(expected_jkt) = &old_rt.jkt {
+        if req.dpop_jkt.as_deref() != Some(expected_jkt.as_str()) {
+            tracing::warn!(
+                client_id = %client_id,
+                "Refresh token is DPoP-bound but the request's proof key does not match"
+            );
+            return Err(TokenErrorResponse {
+                error: "invalid_dpop_proof".to_string(),
+                error_description: "This refresh token is bound to a different DPoP key"
+                    .to_string(),
+            });
+        }
+    }
+    // Carries the rotated token's binding forward. Deliberately reads from
+    // `old_rt.jkt` rather than `req.dpop_jkt` when the token was already
+    // bound (the branch above already proved they're equal) — the stored,
+    // trusted value is preferred over re-deriving it from client input.
+    // When `old_rt.jkt` is `None`, this is the first time the client has
+    // presented a DPoP proof for this token lineage, so `req.dpop_jkt`
+    // (possibly still `None`) begins the binding going forward.
+    let jkt = old_rt.jkt.clone().or_else(|| req.dpop_jkt.clone());
+
     let new_refresh_val = uuid::Uuid::new_v4().to_string();
     let new_rt = RefreshToken {
         token: new_refresh_val.clone(),
@@ -1221,6 +1274,7 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
         identity: old_rt.identity.clone(),
         scope: old_rt.scope.clone(),
         expires_at: chrono::Utc::now() + chrono::Duration::days(30),
+        jkt: jkt.clone(),
     };
 
     if let Err(e) = op_store.store_token(new_rt).await {
@@ -1235,7 +1289,7 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
     };
 
     let mut extra = HashMap::new();
-    merge_dpop_cnf(&mut extra, req.dpop_jkt.as_deref());
+    merge_dpop_cnf(&mut extra, jkt.as_deref());
 
     let access_token = match tokens.issue_user_token_with_extra(
         old_rt.identity.clone(),
@@ -1283,7 +1337,7 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
 
     Ok(TokenResponse {
         access_token,
-        token_type: if req.dpop_jkt.is_some() {
+        token_type: if jkt.is_some() {
             "DPoP".to_string()
         } else {
             "Bearer".to_string()
@@ -2842,6 +2896,7 @@ mod tests {
                 identity: test_identity(),
                 scope: "openid".to_string(),
                 expires_at: Utc::now() + Duration::days(1),
+                jkt: None,
             })
             .await
             .unwrap();
@@ -3108,6 +3163,7 @@ mod tests {
                 // teaches it to issue one for the `openid` scope.
                 scope: "profile".to_string(),
                 expires_at: Utc::now() + Duration::days(1),
+                jkt: None,
             })
             .await
             .unwrap();
@@ -3196,6 +3252,7 @@ mod tests {
                     identity: test_identity(),
                     scope: "profile".to_string(),
                     expires_at: Utc::now() - Duration::minutes(1),
+                    jkt: None,
                 },
                 std::time::Duration::from_secs(60),
             )
@@ -3242,6 +3299,7 @@ mod tests {
                 identity: test_identity(),
                 scope: "profile".to_string(),
                 expires_at: Utc::now() + Duration::days(1),
+                jkt: None,
             })
             .await
             .unwrap();
@@ -3299,6 +3357,7 @@ mod tests {
                 identity: test_identity(),
                 scope: "openid profile".to_string(),
                 expires_at: Utc::now() + Duration::days(1),
+                jkt: None,
             })
             .await
             .unwrap();
@@ -3346,6 +3405,7 @@ mod tests {
                 identity: test_identity(),
                 scope: "profile".to_string(),
                 expires_at: Utc::now() + Duration::days(1),
+                jkt: None,
             })
             .await
             .unwrap();
@@ -4611,8 +4671,16 @@ mod tests {
 
         impl DpopProofBuilder {
             fn new(htu: &str, jti: &str) -> Self {
+                Self::with_key_seed(9, htu, jti)
+            }
+
+            /// As [`Self::new`], but lets the caller pick which fixed key
+            /// this proof is signed with — needed by tests that must prove
+            /// two proofs are bound to the *same* key (reuse a seed) or
+            /// deliberately different ones (use distinct seeds).
+            fn with_key_seed(seed: u8, htu: &str, jti: &str) -> Self {
                 Self {
-                    signing_key: SigningKey::from_bytes(&[9u8; 32]),
+                    signing_key: SigningKey::from_bytes(&[seed; 32]),
                     htu: htu.to_string(),
                     jti: jti.to_string(),
                 }
@@ -4939,6 +5007,321 @@ mod tests {
                     .and_then(|v| v.as_str()),
                 Some(proof_builder.expected_jkt().as_str()),
             );
+        }
+
+        // --- Refresh token DPoP key continuity (RFC 9449 §5) ---
+
+        /// Registers a client authorized for `authorization_code` +
+        /// `refresh_token` with `offline_access` allowed, and stores one
+        /// ready-to-redeem PKCE-protected authorization code for it. Every
+        /// continuity test below starts from this same fixture, then
+        /// exercises a different combination of DPoP proofs across the
+        /// initial grant and the subsequent refresh.
+        async fn dpop_refresh_continuity_store() -> (
+            crate::store::CompositeOpStore<
+                authkestra_engine::store::memory::MemoryStore<crate::client::ClientRegistration>,
+                authkestra_engine::store::memory::MemoryStore<crate::code::AuthorizationCode>,
+                authkestra_engine::store::memory::MemoryStore<crate::refresh::RefreshToken>,
+                authkestra_engine::store::memory::MemoryStore<crate::device::DeviceCodeSession>,
+                crate::client_assertion::NoClientAssertionStore,
+                authkestra_engine::store::memory::MemoryStore<DpopJtiRecord>,
+            >,
+            String,
+        ) {
+            let clients = authkestra_engine::store::memory::MemoryStore::<
+                crate::client::ClientRegistration,
+            >::new();
+            clients
+                .set(
+                    "client1",
+                    ClientRegistration {
+                        client_id: "client1".to_string(),
+                        client_secret_hash: None,
+                        redirect_uris: vec!["https://cb".to_string()],
+                        grant_types: vec![GrantType::AuthorizationCode, GrantType::RefreshToken],
+                        scopes: vec!["openid".to_string(), "offline_access".to_string()],
+                        require_pkce: true,
+                        allowed_audiences: vec![],
+                        token_endpoint_auth_method: None,
+                        jwks: None,
+                    },
+                    std::time::Duration::from_secs(31536000),
+                )
+                .await
+                .unwrap();
+
+            let verifier = "test_verifier".to_string();
+            let mut hasher = sha2::Sha256::new();
+            sha2::Digest::update(&mut hasher, verifier.as_bytes());
+            let challenge =
+                base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(hasher.finalize());
+
+            let codes = authkestra_engine::store::memory::MemoryStore::<
+                crate::code::AuthorizationCode,
+            >::new();
+            codes
+                .store_code(AuthorizationCode {
+                    code: "code1".to_string(),
+                    client_id: "client1".to_string(),
+                    redirect_uri: "https://cb".to_string(),
+                    identity: test_identity(),
+                    scope: "openid offline_access".to_string(),
+                    nonce: None,
+                    expires_at: Utc::now() + Duration::minutes(5),
+                    code_challenge: Some(challenge),
+                    code_challenge_method: Some("S256".to_string()),
+                    used: false,
+                })
+                .await
+                .unwrap();
+
+            let store = crate::store::CompositeOpStore::new(
+                clients,
+                codes,
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(
+                ),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+                ),
+            )
+            .with_dpop_replay_store(authkestra_engine::store::memory::MemoryStore::<
+                DpopJtiRecord,
+            >::new());
+
+            (store, verifier)
+        }
+
+        fn dpop_refresh_continuity_code_req(verifier: &str) -> TokenRequest {
+            TokenRequest {
+                grant_type: "authorization_code".to_string(),
+                code: Some("code1".to_string()),
+                redirect_uri: Some("https://cb".to_string()),
+                client_id: Some("client1".to_string()),
+                client_secret: None,
+                code_verifier: Some(verifier.to_string()),
+                scope: None,
+                refresh_token: None,
+                subject_token: None,
+                subject_token_type: None,
+                device_code: None,
+                actor_token: None,
+                actor_token_type: None,
+                requested_token_type: None,
+                audience: None,
+                client_assertion: None,
+                client_assertion_type: None,
+                dpop_jkt: None,
+            }
+        }
+
+        fn dpop_refresh_continuity_refresh_req(refresh_token: &str) -> TokenRequest {
+            TokenRequest {
+                grant_type: "refresh_token".to_string(),
+                code: None,
+                redirect_uri: None,
+                client_id: Some("client1".to_string()),
+                client_secret: None,
+                code_verifier: None,
+                scope: None,
+                refresh_token: Some(refresh_token.to_string()),
+                subject_token: None,
+                subject_token_type: None,
+                device_code: None,
+                actor_token: None,
+                actor_token_type: None,
+                requested_token_type: None,
+                audience: None,
+                client_assertion: None,
+                client_assertion_type: None,
+                dpop_jkt: None,
+            }
+        }
+
+        /// A refresh token minted alongside a DPoP-bound access token must
+        /// itself be bound: redeeming it with a fresh proof for the *same*
+        /// key must succeed, keep binding the rotated access token to that
+        /// key, and hand back a rotated refresh token that still carries
+        /// the binding forward.
+        #[tokio::test]
+        #[allow(deprecated)]
+        async fn refresh_token_rotation_succeeds_with_the_same_dpop_key() {
+            let (store, verifier) = dpop_refresh_continuity_store().await;
+            let tokens = test_tokens();
+
+            let issue_proof =
+                DpopProofBuilder::with_key_seed(11, "https://auth.example.com/token", "jti-issue");
+            let issued = handle_token_with_client_cert(
+                dpop_refresh_continuity_code_req(&verifier),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                Some(&issue_proof.build()),
+            )
+            .await
+            .expect("issuing the code grant with a DPoP proof must succeed");
+            let refresh_token = issued
+                .refresh_token
+                .expect("offline_access must yield a refresh token");
+            assert_eq!(issued.token_type, "DPoP");
+
+            let rotate_proof = DpopProofBuilder::with_key_seed(
+                11,
+                "https://auth.example.com/token",
+                "jti-rotate-same-key",
+            );
+            let rotated = handle_token_with_client_cert(
+                dpop_refresh_continuity_refresh_req(&refresh_token),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                Some(&rotate_proof.build()),
+            )
+            .await
+            .expect("rotating with a proof for the same key must succeed");
+
+            assert_eq!(rotated.token_type, "DPoP");
+            let claims = tokens
+                .validate_token(&rotated.access_token, Some("client1"))
+                .unwrap();
+            assert_eq!(
+                claims
+                    .extra
+                    .get("cnf")
+                    .and_then(|c| c.get("jkt"))
+                    .and_then(|v| v.as_str()),
+                Some(issue_proof.expected_jkt().as_str()),
+                "the rotated access token must stay bound to the refresh token's original key"
+            );
+        }
+
+        /// RFC 9449 §5: redeeming a DPoP-bound refresh token with a proof
+        /// for a *different* key must be refused — otherwise an exfiltrated
+        /// refresh token could simply be re-keyed by whoever stole it.
+        #[tokio::test]
+        #[allow(deprecated)]
+        async fn refresh_token_rotation_rejects_a_different_dpop_key() {
+            let (store, verifier) = dpop_refresh_continuity_store().await;
+            let tokens = test_tokens();
+
+            let issue_proof = DpopProofBuilder::with_key_seed(
+                11,
+                "https://auth.example.com/token",
+                "jti-issue-2",
+            );
+            let issued = handle_token_with_client_cert(
+                dpop_refresh_continuity_code_req(&verifier),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                Some(&issue_proof.build()),
+            )
+            .await
+            .expect("issuing the code grant with a DPoP proof must succeed");
+            let refresh_token = issued.refresh_token.unwrap();
+
+            let attacker_proof = DpopProofBuilder::with_key_seed(
+                22,
+                "https://auth.example.com/token",
+                "jti-rotate-wrong-key",
+            );
+            let err = handle_token_with_client_cert(
+                dpop_refresh_continuity_refresh_req(&refresh_token),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                Some(&attacker_proof.build()),
+            )
+            .await
+            .expect_err("a proof for a different key must be refused");
+
+            assert_eq!(err.error, "invalid_dpop_proof");
+        }
+
+        /// RFC 9449 §5, the other half of the same requirement: omitting
+        /// DPoP entirely on a bound refresh token must not silently fall
+        /// back to issuing a plain bearer token.
+        #[tokio::test]
+        #[allow(deprecated)]
+        async fn refresh_token_rotation_rejects_a_missing_dpop_proof() {
+            let (store, verifier) = dpop_refresh_continuity_store().await;
+            let tokens = test_tokens();
+
+            let issue_proof = DpopProofBuilder::with_key_seed(
+                11,
+                "https://auth.example.com/token",
+                "jti-issue-3",
+            );
+            let issued = handle_token_with_client_cert(
+                dpop_refresh_continuity_code_req(&verifier),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                Some(&issue_proof.build()),
+            )
+            .await
+            .expect("issuing the code grant with a DPoP proof must succeed");
+            let refresh_token = issued.refresh_token.unwrap();
+
+            let err = handle_token_with_client_cert(
+                dpop_refresh_continuity_refresh_req(&refresh_token),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                None,
+            )
+            .await
+            .expect_err("omitting DPoP on a bound refresh token must be refused");
+
+            assert_eq!(err.error, "invalid_dpop_proof");
+        }
+
+        /// Companion regression: a refresh token minted *without* DPoP
+        /// (no proof presented on the original grant) stays an ordinary
+        /// bearer token — rotating it with no DPoP header keeps working
+        /// exactly as it did before this feature existed.
+        #[tokio::test]
+        #[allow(deprecated)]
+        async fn refresh_token_rotation_without_prior_binding_is_unaffected() {
+            let (store, verifier) = dpop_refresh_continuity_store().await;
+            let tokens = test_tokens();
+
+            let issued = handle_token_with_client_cert(
+                dpop_refresh_continuity_code_req(&verifier),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                None,
+            )
+            .await
+            .expect("issuing the code grant with no DPoP proof must still succeed");
+            assert_eq!(issued.token_type, "Bearer");
+            let refresh_token = issued.refresh_token.unwrap();
+
+            let rotated = handle_token_with_client_cert(
+                dpop_refresh_continuity_refresh_req(&refresh_token),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                None,
+            )
+            .await
+            .expect("rotating an unbound refresh token with no DPoP proof must still succeed");
+            assert_eq!(rotated.token_type, "Bearer");
         }
     }
 }

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -107,6 +107,22 @@ impl TokenRequest {
             dpop_jkt: None,
         }
     }
+
+    /// The RFC 7638 thumbprint of the verified DPoP proof's embedded key
+    /// this request was presented with, or `None` if it wasn't
+    /// DPoP-bound. `None` both before `handle_token_with_client_cert` has
+    /// verified a proof and for a request with no `DPoP` header at all.
+    ///
+    /// Read-only: the field itself stays `pub(crate)` so a client can
+    /// never set it directly (see its doc comment for why that's
+    /// forgery-proof), but an `OpStore::handle_*_grant` override outside
+    /// this crate that delegates to a `default_handle_*` free function and
+    /// post-processes the result still needs to be able to tell whether
+    /// the request it just handled was DPoP-bound — e.g. to stamp its own
+    /// additional claims alongside `cnf.jkt` via [`merge_dpop_cnf`].
+    pub fn dpop_jkt(&self) -> Option<&str> {
+        self.dpop_jkt.as_deref()
+    }
 }
 
 /// Success response for the token endpoint.
@@ -747,8 +763,18 @@ async fn handle_device_code(
                         // can enforce continuity on every future rotation.
                         jkt: req.dpop_jkt.clone(),
                     };
-                    if op_store.store_token(rt).await.is_ok() {
-                        issued_refresh_token = Some(refresh_val);
+                    match store_refresh_token_verifying_dpop_binding(op_store, rt).await {
+                        RefreshTokenStoreOutcome::Stored => {
+                            issued_refresh_token = Some(refresh_val)
+                        }
+                        RefreshTokenStoreOutcome::NonFatalStorageFailure => {}
+                        RefreshTokenStoreOutcome::DpopBindingFailed => {
+                            return Err(TokenErrorResponse {
+                                error: "server_error".to_string(),
+                                error_description: "Failed to persist DPoP token binding"
+                                    .to_string(),
+                            });
+                        }
                     }
                 }
 
@@ -977,11 +1003,15 @@ pub async fn default_handle_authorization_code<S: OpStore + ?Sized>(
             // RFC 9449 §5: see the identical comment in `handle_device_code`.
             jkt: req.dpop_jkt.clone(),
         };
-        if let Err(e) = op_store.store_token(rt_model.clone()).await {
-            tracing::error!(error = ?e, "Failed to store refresh token");
-            // Non-fatal, just don't return a refresh token
-        } else {
-            issued_refresh_token = Some(refresh_val);
+        match store_refresh_token_verifying_dpop_binding(op_store, rt_model).await {
+            RefreshTokenStoreOutcome::Stored => issued_refresh_token = Some(refresh_val),
+            RefreshTokenStoreOutcome::NonFatalStorageFailure => {}
+            RefreshTokenStoreOutcome::DpopBindingFailed => {
+                return Err(TokenErrorResponse {
+                    error: "server_error".to_string(),
+                    error_description: "Failed to persist DPoP token binding".to_string(),
+                });
+            }
         }
     }
 
@@ -1013,7 +1043,15 @@ pub async fn default_handle_authorization_code<S: OpStore + ?Sized>(
 /// mTLS-bound and DPoP-bound — the spec requires both confirmation members
 /// to coexist in one `cnf` object, not overwrite each other. A no-op when
 /// `dpop_jkt` is `None`, so every call site can call this unconditionally.
-fn merge_dpop_cnf(extra: &mut HashMap<String, serde_json::Value>, dpop_jkt: Option<&str>) {
+///
+/// `pub`, not `pub(crate)`: an `OpStore::handle_*_grant` override outside
+/// this crate that delegates to a `default_handle_*` free function and
+/// then stamps its own additional claims onto the result needs this same
+/// merge — otherwise it would have to hand-roll the `cnf` merge itself and
+/// risk reintroducing the exact clobber this function exists to prevent.
+/// [`TokenRequest::dpop_jkt`] is the read-only accessor such an override
+/// reads the key from.
+pub fn merge_dpop_cnf(extra: &mut HashMap<String, serde_json::Value>, dpop_jkt: Option<&str>) {
     let Some(jkt) = dpop_jkt else {
         return;
     };
@@ -1025,6 +1063,83 @@ fn merge_dpop_cnf(extra: &mut HashMap<String, serde_json::Value>, dpop_jkt: Opti
             "jkt".to_string(),
             serde_json::Value::String(jkt.to_string()),
         );
+    }
+}
+
+/// What happened when [`store_refresh_token_verifying_dpop_binding`] tried
+/// to persist a freshly minted refresh token.
+enum RefreshTokenStoreOutcome {
+    /// Stored, and — if it was meant to be DPoP-bound — confirmed bound.
+    Stored,
+    /// The store call itself failed and the token was never meant to be
+    /// DPoP-bound. Every call site already tolerates this exactly as it
+    /// did before this feature existed: log it, omit `refresh_token` from
+    /// the response, and otherwise succeed.
+    NonFatalStorageFailure,
+    /// The token was meant to be DPoP-bound (`jkt: Some(_)`) but that
+    /// binding cannot be confirmed to have persisted — never tolerated,
+    /// unlike the case above, because silently issuing a refresh token
+    /// whose RFC 9449 §5 continuity guarantee doesn't actually exist is
+    /// exactly the silent security gap this check exists to catch.
+    DpopBindingFailed,
+}
+
+/// Stores a freshly minted refresh token, then — only when it's meant to
+/// be DPoP-bound — reads it back and confirms the binding actually
+/// persisted.
+///
+/// A backend can silently drop `jkt` on write without `store_token`
+/// itself ever returning an error: exactly the case `sqlx_store.rs`'s
+/// `RefreshTokenStore` impl is in right now (its schema has no `jkt`
+/// column yet, so it accepts a token with `jkt: Some(_)` and simply
+/// never persists that field — see the comment on its `get_token`). If
+/// nothing ever checked, that token's RFC 9449 §5 continuity guarantee
+/// would quietly not exist: `default_handle_refresh_token` would see
+/// `jkt: None` on redemption and treat it as though it never asked for a
+/// DPoP-bound refresh token in the first place, while the client's
+/// response here claimed `token_type: "DPoP"` and a `cnf.jkt`-bound
+/// access token. Reading the write back and refusing loudly is what turns
+/// that silent security gap into a visible failure — the same principle
+/// this crate already applies to every other silent-degradation risk in
+/// this feature (`NoDpopReplayStore` failing closed rather than accepting
+/// an unverifiable proof, the consume-before-validate ordering fix, and
+/// so on).
+async fn store_refresh_token_verifying_dpop_binding<S: OpStore + ?Sized>(
+    op_store: &S,
+    rt: RefreshToken,
+) -> RefreshTokenStoreOutcome {
+    let token = rt.token.clone();
+    let expected_jkt = rt.jkt.clone();
+    let dpop_bound = expected_jkt.is_some();
+
+    if let Err(e) = op_store.store_token(rt).await {
+        tracing::error!(error = ?e, "Failed to store refresh token");
+        return if dpop_bound {
+            RefreshTokenStoreOutcome::DpopBindingFailed
+        } else {
+            RefreshTokenStoreOutcome::NonFatalStorageFailure
+        };
+    }
+
+    if !dpop_bound {
+        return RefreshTokenStoreOutcome::Stored;
+    }
+
+    match op_store.get_token(&token).await {
+        Ok(Some(stored)) if stored.jkt == expected_jkt => RefreshTokenStoreOutcome::Stored,
+        Ok(_) => {
+            tracing::error!(
+                "refresh token's DPoP binding did not survive storage — the configured \
+                 RefreshTokenStore silently dropped `jkt`, which would let this token be \
+                 redeemed without RFC 9449 §5 continuity enforcement; refusing rather than \
+                 handing back a token whose response claims a binding storage doesn't have"
+            );
+            RefreshTokenStoreOutcome::DpopBindingFailed
+        }
+        Err(e) => {
+            tracing::error!(error = ?e, "Failed to verify refresh token's DPoP binding");
+            RefreshTokenStoreOutcome::DpopBindingFailed
+        }
     }
 }
 
@@ -1316,8 +1431,19 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
         jkt: jkt.clone(),
     };
 
-    if let Err(e) = op_store.store_token(new_rt).await {
-        tracing::error!(error = ?e, "Failed to store new refresh token");
+    match store_refresh_token_verifying_dpop_binding(op_store, new_rt).await {
+        RefreshTokenStoreOutcome::Stored => {}
+        // Pre-existing behavior for this grant, unrelated to DPoP: a plain
+        // storage failure here is logged but doesn't fail the request —
+        // the client still gets a `refresh_token` in the response even
+        // though it wasn't actually persisted. Not this fix's concern.
+        RefreshTokenStoreOutcome::NonFatalStorageFailure => {}
+        RefreshTokenStoreOutcome::DpopBindingFailed => {
+            return Err(TokenErrorResponse {
+                error: "server_error".to_string(),
+                error_description: "Failed to persist DPoP token binding".to_string(),
+            });
+        }
     }
 
     let expires_in = config.access_token_ttl_secs;
@@ -5430,6 +5556,148 @@ mod tests {
             .await
             .expect("rotating an unbound refresh token with no DPoP proof must still succeed");
             assert_eq!(rotated.token_type, "Bearer");
+        }
+
+        // --- Fail-closed guard against a backend that silently drops `jkt` ---
+
+        /// Wraps any `OpStore` but strips `jkt` on every `store_token`
+        /// call before delegating — simulating exactly what
+        /// `sqlx_store.rs`'s `RefreshTokenStore` impl does today (accepts
+        /// a DPoP-bound `RefreshToken`, reports success, never persists
+        /// the binding). Everything else forwards unchanged, including
+        /// `check_and_record_dpop_jti`, which must still reach the inner
+        /// store's real replay guard for a DPoP proof to verify at all.
+        struct JktDroppingRefreshStore<Inner> {
+            inner: Inner,
+        }
+
+        #[async_trait::async_trait]
+        impl<Inner: OpStore> crate::client::ClientStore for JktDroppingRefreshStore<Inner> {
+            async fn find_client(
+                &self,
+                client_id: &str,
+            ) -> Result<Option<ClientRegistration>, OpError> {
+                self.inner.find_client(client_id).await
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl<Inner: OpStore> crate::code::AuthorizationCodeStore for JktDroppingRefreshStore<Inner> {
+            async fn store_code(&self, code: AuthorizationCode) -> Result<(), OpError> {
+                self.inner.store_code(code).await
+            }
+
+            async fn consume_code(&self, code: &str) -> Result<Option<AuthorizationCode>, OpError> {
+                self.inner.consume_code(code).await
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl<Inner: OpStore> RefreshTokenStore for JktDroppingRefreshStore<Inner> {
+            async fn store_token(&self, token: RefreshToken) -> Result<(), OpError> {
+                let mut stripped = token;
+                stripped.jkt = None;
+                self.inner.store_token(stripped).await
+            }
+
+            async fn get_token(&self, token: &str) -> Result<Option<RefreshToken>, OpError> {
+                self.inner.get_token(token).await
+            }
+
+            async fn revoke_token(&self, token: &str) -> Result<(), OpError> {
+                self.inner.revoke_token(token).await
+            }
+
+            async fn consume_token(&self, token: &str) -> Result<Option<RefreshToken>, OpError> {
+                self.inner.consume_token(token).await
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl<Inner: OpStore> crate::device::DeviceCodeStore for JktDroppingRefreshStore<Inner> {
+            async fn store_device_code(
+                &self,
+                session: crate::device::DeviceCodeSession,
+            ) -> Result<(), OpError> {
+                self.inner.store_device_code(session).await
+            }
+
+            async fn get_device_code(
+                &self,
+                device_code: &str,
+            ) -> Result<Option<crate::device::DeviceCodeSession>, OpError> {
+                self.inner.get_device_code(device_code).await
+            }
+
+            async fn get_by_user_code(
+                &self,
+                user_code: &str,
+            ) -> Result<Option<crate::device::DeviceCodeSession>, OpError> {
+                self.inner.get_by_user_code(user_code).await
+            }
+
+            async fn update_device_code(
+                &self,
+                session: crate::device::DeviceCodeSession,
+            ) -> Result<(), OpError> {
+                self.inner.update_device_code(session).await
+            }
+
+            async fn delete_device_code(&self, device_code: &str) -> Result<(), OpError> {
+                self.inner.delete_device_code(device_code).await
+            }
+
+            async fn consume_device_code(
+                &self,
+                device_code: &str,
+            ) -> Result<Option<crate::device::DeviceCodeSession>, OpError> {
+                self.inner.consume_device_code(device_code).await
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl<Inner: OpStore> OpStore for JktDroppingRefreshStore<Inner> {
+            async fn check_and_record_dpop_jti(
+                &self,
+                jti: &str,
+                expires_at: chrono::DateTime<Utc>,
+            ) -> Result<bool, OpError> {
+                self.inner.check_and_record_dpop_jti(jti, expires_at).await
+            }
+        }
+
+        /// The regression test for the exact silent gap this whole round
+        /// of fixes is about: a `RefreshTokenStore` that reports
+        /// `store_token` success but doesn't actually persist `jkt` must
+        /// not result in a response that claims `token_type: "DPoP"` while
+        /// the stored token has no binding at all. `default_handle_
+        /// authorization_code` must catch this and fail loudly instead.
+        #[tokio::test]
+        #[allow(deprecated)]
+        async fn a_backend_that_silently_drops_jkt_fails_the_request_instead_of_lying() {
+            let (inner, verifier) = dpop_refresh_continuity_store().await;
+            let store = JktDroppingRefreshStore { inner };
+            let tokens = test_tokens();
+
+            let proof =
+                DpopProofBuilder::new("https://auth.example.com/token", "jti-drop-1").build();
+
+            let err = handle_token_with_client_cert(
+                dpop_refresh_continuity_code_req(&verifier),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                Some(&proof),
+            )
+            .await
+            .expect_err(
+                "a store that silently drops the DPoP binding must fail the request, not \
+                 succeed as though the binding was persisted",
+            );
+
+            assert_eq!(err.error, "server_error");
         }
     }
 }

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -59,6 +59,21 @@ pub struct TokenRequest {
     /// [`crate::client_assertion::CLIENT_ASSERTION_TYPE_JWT_BEARER`] when
     /// `client_assertion` is present.
     pub client_assertion_type: Option<String>,
+
+    // DPoP (RFC 9449)
+    /// The RFC 7638 thumbprint of a verified DPoP proof's embedded key,
+    /// once `handle_token_with_client_cert` has verified the request's
+    /// `DPoP` header and checked its `jti` for replay — `None` otherwise.
+    ///
+    /// `#[serde(skip)]` is load-bearing, not incidental: this is never a
+    /// form field a client submits. Without it, a client could set
+    /// `dpop_jkt=<anything>` directly and bind a token to a key it never
+    /// proved possession of, bypassing DPoP verification entirely.
+    /// `pub(crate)` for the same reason — populated exactly once, by
+    /// `handle_token_with_client_cert` before grant dispatch, and read only
+    /// by the grant handlers in this crate.
+    #[serde(skip)]
+    pub(crate) dpop_jkt: Option<String>,
 }
 
 impl TokenRequest {
@@ -89,6 +104,7 @@ impl TokenRequest {
             audience: None,
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
         }
     }
 }
@@ -154,7 +170,7 @@ pub async fn handle_token(
     op_store: &dyn OpStore,
     tokens: &TokenManager,
 ) -> Result<TokenResponse, TokenErrorResponse> {
-    handle_token_with_client_cert(req, auth_header, config, op_store, tokens, None).await
+    handle_token_with_client_cert(req, auth_header, config, op_store, tokens, None, None).await
 }
 
 /// Same as [`handle_token`], but additionally takes the DER bytes of the
@@ -171,14 +187,22 @@ pub async fn handle_token(
 /// [`handle_client_credentials`]), which stamps an RFC 8705 §3
 /// `cnf.x5t#S256` confirmation claim onto the issued access token when a
 /// certificate is present. It is ignored by every other grant type.
+///
+/// `dpop_header` is the raw value of the request's `DPoP` header, if any
+/// (RFC 9449) — unlike `client_cert_der`, this affects *every* grant type:
+/// a verified proof is recorded here (once, before dispatch) as
+/// `req.dpop_jkt`, which every grant handler reads to stamp `cnf.jkt` onto
+/// the token it issues and report `token_type: "DPoP"` instead of
+/// `"Bearer"`. See `crate::dpop` for the replay-tracking half of this.
 #[allow(clippy::too_many_arguments)]
 pub async fn handle_token_with_client_cert(
-    req: TokenRequest,
+    mut req: TokenRequest,
     auth_header: Option<&str>,
     config: &OpConfig,
     op_store: &dyn OpStore,
     tokens: &TokenManager,
     client_cert_der: Option<&[u8]>,
+    dpop_header: Option<&str>,
 ) -> Result<TokenResponse, TokenErrorResponse> {
     tracing::debug!(grant_type = %req.grant_type, "Processing token exchange request");
 
@@ -229,6 +253,60 @@ pub async fn handle_token_with_client_cert(
             error: "invalid_client".to_string(),
             error_description: "Client authentication failed".to_string(),
         });
+    }
+
+    // 3. DPoP (RFC 9449) — verified once, here, before any grant runs, so
+    //    every grant handler downstream just reads `req.dpop_jkt` rather
+    //    than each needing its own copy of proof verification and replay
+    //    checking. `expected_ath: None` since no access token exists yet
+    //    for the proof to bind to — that check is `authkestra-resource`'s
+    //    job, on the *next* request the client makes with the token this
+    //    one issues.
+    if let Some(proof) = dpop_header {
+        let verified = match authkestra_engine::token::dpop::verify_dpop_proof(
+            proof,
+            "POST",
+            &config.token_endpoint(),
+            None,
+            chrono::Duration::seconds(crate::dpop::DPOP_PROOF_MAX_AGE_SECS),
+        ) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(client_id = %client_id, error = %e, "DPoP proof verification failed");
+                return Err(TokenErrorResponse {
+                    error: "invalid_dpop_proof".to_string(),
+                    error_description: "The presented DPoP proof is invalid".to_string(),
+                });
+            }
+        };
+
+        let expires_at =
+            Utc::now() + chrono::Duration::seconds(crate::dpop::DPOP_PROOF_MAX_AGE_SECS);
+        match op_store
+            .check_and_record_dpop_jti(&verified.jti, expires_at)
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::warn!(
+                    client_id = %client_id,
+                    "DPoP proof jti has already been spent — replay refused"
+                );
+                return Err(TokenErrorResponse {
+                    error: "invalid_dpop_proof".to_string(),
+                    error_description: "The presented DPoP proof has already been used".to_string(),
+                });
+            }
+            Err(e) => {
+                tracing::error!(client_id = %client_id, error = ?e, "DPoP replay check failed");
+                return Err(TokenErrorResponse {
+                    error: "invalid_dpop_proof".to_string(),
+                    error_description: "The presented DPoP proof could not be verified".to_string(),
+                });
+            }
+        }
+
+        req.dpop_jkt = Some(verified.jkt);
     }
 
     match req.grant_type.as_str() {
@@ -608,11 +686,15 @@ async fn handle_device_code(
                     Some(session.scope.clone())
                 };
 
-                let access_token = match tokens.issue_user_token(
+                let mut extra = HashMap::new();
+                merge_dpop_cnf(&mut extra, req.dpop_jkt.as_deref());
+
+                let access_token = match tokens.issue_user_token_with_extra(
                     identity.clone(),
                     expires_in,
                     scope_opt.clone(),
                     Some(client_id.clone()),
+                    extra,
                 ) {
                     Ok(t) => t,
                     Err(_) => {
@@ -654,7 +736,11 @@ async fn handle_device_code(
 
                 Ok(TokenResponse {
                     access_token,
-                    token_type: "Bearer".to_string(),
+                    token_type: if req.dpop_jkt.is_some() {
+                        "DPoP".to_string()
+                    } else {
+                        "Bearer".to_string()
+                    },
                     expires_in,
                     id_token,
                     refresh_token: issued_refresh_token,
@@ -820,11 +906,15 @@ pub async fn default_handle_authorization_code<S: OpStore + ?Sized>(
         Some(auth_code.scope.clone())
     };
 
-    let access_token = match tokens.issue_user_token(
+    let mut extra = HashMap::new();
+    merge_dpop_cnf(&mut extra, req.dpop_jkt.as_deref());
+
+    let access_token = match tokens.issue_user_token_with_extra(
         auth_code.identity.clone(),
         expires_in,
         scope_opt.clone(),
         Some(client_id.clone()),
+        extra,
     ) {
         Ok(t) => t,
         Err(e) => {
@@ -882,13 +972,40 @@ pub async fn default_handle_authorization_code<S: OpStore + ?Sized>(
 
     Ok(TokenResponse {
         access_token,
-        token_type: "Bearer".to_string(),
+        token_type: if req.dpop_jkt.is_some() {
+            "DPoP".to_string()
+        } else {
+            "Bearer".to_string()
+        },
         expires_in,
         id_token,
         refresh_token: issued_refresh_token,
         scope: scope_opt,
         issued_token_type: None,
     })
+}
+
+/// Merges a DPoP `cnf.jkt` confirmation member (RFC 9449 §6.1) into an
+/// `extra` claims map, preserving whatever the `cnf` object already holds.
+///
+/// A plain `extra.insert("cnf", json!({"jkt": ...}))` would silently
+/// clobber an existing `cnf.x5t#S256` (RFC 8705) if a request is both
+/// mTLS-bound and DPoP-bound — the spec requires both confirmation members
+/// to coexist in one `cnf` object, not overwrite each other. A no-op when
+/// `dpop_jkt` is `None`, so every call site can call this unconditionally.
+fn merge_dpop_cnf(extra: &mut HashMap<String, serde_json::Value>, dpop_jkt: Option<&str>) {
+    let Some(jkt) = dpop_jkt else {
+        return;
+    };
+    let cnf = extra
+        .entry("cnf".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    if let Some(obj) = cnf.as_object_mut() {
+        obj.insert(
+            "jkt".to_string(),
+            serde_json::Value::String(jkt.to_string()),
+        );
+    }
 }
 
 /// Handles the `client_credentials` grant (RFC 6749 §4.4).
@@ -988,6 +1105,7 @@ async fn handle_client_credentials(
             serde_json::json!({ "x5t#S256": thumbprint }),
         );
     }
+    merge_dpop_cnf(&mut extra, req.dpop_jkt.as_deref());
 
     let access_token = match tokens.issue_client_token_with_extra(
         &client_id,
@@ -1014,7 +1132,11 @@ async fn handle_client_credentials(
 
     Ok(TokenResponse {
         access_token,
-        token_type: "Bearer".to_string(),
+        token_type: if req.dpop_jkt.is_some() {
+            "DPoP".to_string()
+        } else {
+            "Bearer".to_string()
+        },
         expires_in,
         id_token: None, // client credentials does not issue ID tokens
         refresh_token: None,
@@ -1112,11 +1234,15 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
         Some(old_rt.scope.clone())
     };
 
-    let access_token = match tokens.issue_user_token(
+    let mut extra = HashMap::new();
+    merge_dpop_cnf(&mut extra, req.dpop_jkt.as_deref());
+
+    let access_token = match tokens.issue_user_token_with_extra(
         old_rt.identity.clone(),
         expires_in,
         scope_opt.clone(),
         Some(client_id.clone()),
+        extra,
     ) {
         Ok(t) => t,
         Err(e) => {
@@ -1157,7 +1283,11 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
 
     Ok(TokenResponse {
         access_token,
-        token_type: "Bearer".to_string(),
+        token_type: if req.dpop_jkt.is_some() {
+            "DPoP".to_string()
+        } else {
+            "Bearer".to_string()
+        },
         expires_in,
         id_token,
         refresh_token: Some(new_refresh_val),
@@ -1189,6 +1319,11 @@ pub async fn default_handle_token_exchange(
 ) -> Result<TokenResponse, TokenErrorResponse> {
     use crate::client::GrantType;
     use authkestra_engine::token::Claims;
+
+    // Captured up front: several `req` fields below are moved out
+    // (`req.audience`, `req.scope`) before the access token is issued, and
+    // `dpop_jkt` is needed at that point.
+    let dpop_jkt = req.dpop_jkt.clone();
 
     if !config.token_exchange_enabled {
         tracing::warn!("Token exchange is disabled globally");
@@ -1375,17 +1510,25 @@ pub async fn default_handle_token_exchange(
         None
     };
 
-    let access_token =
-        match tokens.issue_user_token(identity, expires_in, final_scope_str.clone(), new_aud) {
-            Ok(t) => t,
-            Err(e) => {
-                tracing::error!(error = ?e, "Failed to issue access token during exchange");
-                return Err(TokenErrorResponse {
-                    error: "server_error".to_string(),
-                    error_description: "Failed to generate token".to_string(),
-                });
-            }
-        };
+    let mut extra = HashMap::new();
+    merge_dpop_cnf(&mut extra, dpop_jkt.as_deref());
+
+    let access_token = match tokens.issue_user_token_with_extra(
+        identity,
+        expires_in,
+        final_scope_str.clone(),
+        new_aud,
+        extra,
+    ) {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!(error = ?e, "Failed to issue access token during exchange");
+            return Err(TokenErrorResponse {
+                error: "server_error".to_string(),
+                error_description: "Failed to generate token".to_string(),
+            });
+        }
+    };
 
     tracing::info!(
         client_id = %client_id,
@@ -1394,7 +1537,11 @@ pub async fn default_handle_token_exchange(
 
     Ok(TokenResponse {
         access_token,
-        token_type: "Bearer".to_string(),
+        token_type: if dpop_jkt.is_some() {
+            "DPoP".to_string()
+        } else {
+            "Bearer".to_string()
+        },
         expires_in,
         id_token,
         refresh_token: None,
@@ -1518,6 +1665,7 @@ mod tests {
             audience: None,
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
         };
         let clients = authkestra_engine::store::memory::MemoryStore::<
             crate::client::ClientRegistration,
@@ -1587,6 +1735,7 @@ mod tests {
             audience: None,
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
         };
         let clients = authkestra_engine::store::memory::MemoryStore::<
             crate::client::ClientRegistration,
@@ -1700,6 +1849,7 @@ mod tests {
             audience: None,
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
         };
 
         let res = handle_token(
@@ -1869,6 +2019,7 @@ mod tests {
             audience: None,
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
         }
     }
 
@@ -2043,6 +2194,7 @@ mod tests {
             audience: None,
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
         };
         let res = handle_token(
             req,
@@ -2120,6 +2272,7 @@ mod tests {
             audience: None,
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
         };
         let res = handle_token(
             req,
@@ -2197,6 +2350,7 @@ mod tests {
             audience: None,
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
         };
         let res = handle_token(
             req,
@@ -2279,6 +2433,7 @@ mod tests {
             audience: None,
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
         };
         let res = handle_token(
             req,
@@ -2345,6 +2500,7 @@ mod tests {
             audience: None,
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
         };
         let res = handle_token(
             req,
@@ -2456,6 +2612,7 @@ mod tests {
             audience: audience.map(|a| a.to_string()),
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
         }
     }
 
@@ -2484,6 +2641,7 @@ mod tests {
             &store,
             &tokens,
             Some(cert_der),
+            None,
         )
         .await
         .expect("client_credentials with a presented certificate should succeed");
@@ -2518,6 +2676,7 @@ mod tests {
             &test_config(false),
             &store,
             &tokens,
+            None,
             None,
         )
         .await
@@ -2627,6 +2786,7 @@ mod tests {
             &store,
             &tokens,
             Some(cert_der),
+            None,
         )
         .await
         .expect("a request with both an allowed audience and a certificate should succeed");
@@ -2704,6 +2864,7 @@ mod tests {
             audience: None,
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
         };
         let res = handle_token(
             req,
@@ -2877,6 +3038,7 @@ mod tests {
             audience: None,
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
         }
     }
 
@@ -3516,6 +3678,7 @@ mod tests {
             audience: None,
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
         }
     }
 
@@ -4313,6 +4476,7 @@ mod tests {
             audience: None,
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
         };
 
         let clients = authkestra_engine::store::memory::MemoryStore::<
@@ -4376,6 +4540,7 @@ mod tests {
             audience: None,
             client_assertion: None,
             client_assertion_type: None,
+            dpop_jkt: None,
         };
 
         let clients = authkestra_engine::store::memory::MemoryStore::<
@@ -4417,6 +4582,364 @@ mod tests {
 
         let err = res.unwrap_err();
         assert_eq!(err.error, "unauthorized_client");
+    }
+
+    // --- DPoP (RFC 9449) proof wiring — authkestra#274 Phase B ---
+
+    mod dpop_wiring_tests {
+        use super::*;
+        use crate::dpop::DpopJtiRecord;
+        use base64::Engine;
+        use ed25519_dalek::{Signer, SigningKey};
+
+        fn b64(bytes: &[u8]) -> String {
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+        }
+        fn b64_json(v: &serde_json::Value) -> String {
+            b64(serde_json::to_vec(v).unwrap().as_slice())
+        }
+
+        /// Builds a real, genuinely Ed25519-signed DPoP proof for the OP's
+        /// token endpoint. Mirrors `authkestra_engine::token::dpop`'s own
+        /// `ProofBuilder` test helper, which is private to that crate's test
+        /// module and so re-authored here rather than shared.
+        struct DpopProofBuilder {
+            signing_key: SigningKey,
+            htu: String,
+            jti: String,
+        }
+
+        impl DpopProofBuilder {
+            fn new(htu: &str, jti: &str) -> Self {
+                Self {
+                    signing_key: SigningKey::from_bytes(&[9u8; 32]),
+                    htu: htu.to_string(),
+                    jti: jti.to_string(),
+                }
+            }
+
+            fn jwk(&self) -> serde_json::Value {
+                serde_json::json!({
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "x": b64(self.signing_key.verifying_key().as_bytes()),
+                })
+            }
+
+            fn expected_jkt(&self) -> String {
+                authkestra_engine::token::dpop::compute_jwk_thumbprint(
+                    &serde_json::from_value(self.jwk()).unwrap(),
+                )
+                .unwrap()
+            }
+
+            fn build(&self) -> String {
+                let header = serde_json::json!({
+                    "typ": "dpop+jwt",
+                    "alg": "EdDSA",
+                    "jwk": self.jwk(),
+                });
+                let payload = serde_json::json!({
+                    "htm": "POST",
+                    "htu": self.htu,
+                    "iat": chrono::Utc::now().timestamp(),
+                    "jti": self.jti,
+                });
+                let signing_input = format!("{}.{}", b64_json(&header), b64_json(&payload));
+                let signature = self.signing_key.sign(signing_input.as_bytes());
+                format!("{signing_input}.{}", b64(&signature.to_bytes()))
+            }
+        }
+
+        /// As [`client_credentials_store`], but with a real `DpopReplayStore`
+        /// wired via `with_dpop_replay_store` instead of the fail-closed
+        /// `NoDpopReplayStore` default — needed by every test in this module
+        /// that expects a presented proof to actually be accepted.
+        async fn client_credentials_store_with_dpop_replay(
+            client_id: &str,
+        ) -> crate::store::CompositeOpStore<
+            authkestra_engine::store::memory::MemoryStore<crate::client::ClientRegistration>,
+            authkestra_engine::store::memory::MemoryStore<crate::code::AuthorizationCode>,
+            authkestra_engine::store::memory::MemoryStore<crate::refresh::RefreshToken>,
+            authkestra_engine::store::memory::MemoryStore<crate::device::DeviceCodeSession>,
+            crate::client_assertion::NoClientAssertionStore,
+            authkestra_engine::store::memory::MemoryStore<DpopJtiRecord>,
+        > {
+            client_credentials_store(client_id)
+                .await
+                .with_dpop_replay_store(authkestra_engine::store::memory::MemoryStore::<
+                    DpopJtiRecord,
+                >::new())
+        }
+
+        /// A valid DPoP proof on a `client_credentials` request must bind the
+        /// issued token to the proof's key (`cnf.jkt`) and switch
+        /// `token_type` to `"DPoP"`.
+        #[tokio::test]
+        async fn client_credentials_stamps_cnf_jkt_and_dpop_token_type() {
+            let store = client_credentials_store_with_dpop_replay("client1").await;
+            let tokens = test_tokens();
+            let proof_builder = DpopProofBuilder::new("https://auth.example.com/token", "jti-1");
+            let proof = proof_builder.build();
+
+            let resp = handle_token_with_client_cert(
+                client_credentials_request("client1"),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                Some(&proof),
+            )
+            .await
+            .expect("a valid, fresh DPoP proof must be accepted");
+
+            assert_eq!(resp.token_type, "DPoP");
+
+            let claims = tokens
+                .validate_token(&resp.access_token, Some("client1"))
+                .expect("issued token must validate");
+            let cnf = claims
+                .extra
+                .get("cnf")
+                .expect("a DPoP proof was presented; the token must carry a cnf claim");
+            assert_eq!(
+                cnf.get("jkt").and_then(|v| v.as_str()),
+                Some(proof_builder.expected_jkt().as_str()),
+            );
+        }
+
+        /// Companion regression: no `DPoP` header at all keeps issuing a
+        /// plain bearer token, exactly like before Phase B — proves the
+        /// feature is additive.
+        #[tokio::test]
+        async fn client_credentials_without_dpop_header_stays_bearer() {
+            let store = client_credentials_store_with_dpop_replay("client1").await;
+            let tokens = test_tokens();
+
+            let resp = handle_token_with_client_cert(
+                client_credentials_request("client1"),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(resp.token_type, "Bearer");
+            let claims = tokens
+                .validate_token(&resp.access_token, Some("client1"))
+                .unwrap();
+            assert!(!claims.extra.contains_key("cnf"));
+        }
+
+        /// RFC 9449 §11.1: a replayed `jti` must be rejected, not silently
+        /// accepted a second time.
+        #[tokio::test]
+        async fn a_replayed_dpop_proof_jti_is_rejected() {
+            let store = client_credentials_store_with_dpop_replay("client1").await;
+            let tokens = test_tokens();
+            let proof =
+                DpopProofBuilder::new("https://auth.example.com/token", "jti-replay").build();
+
+            handle_token_with_client_cert(
+                client_credentials_request("client1"),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                Some(&proof),
+            )
+            .await
+            .expect("first presentation of a fresh proof must succeed");
+
+            let err = handle_token_with_client_cert(
+                client_credentials_request("client1"),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                Some(&proof),
+            )
+            .await
+            .expect_err("replaying the same proof's jti must be rejected");
+
+            assert_eq!(err.error, "invalid_dpop_proof");
+        }
+
+        /// A deployment that has not wired a `DpopReplayStore` (the
+        /// `NoDpopReplayStore` default) must fail closed rather than accept
+        /// a proof it cannot guarantee is single-use.
+        #[tokio::test]
+        async fn no_dpop_replay_store_wired_fails_closed() {
+            // Deliberately the plain `client_credentials_store`, not the
+            // `_with_dpop_replay` variant — this store's `P` generic
+            // parameter defaults to `NoDpopReplayStore`.
+            let store = client_credentials_store("client1").await;
+            let tokens = test_tokens();
+            let proof = DpopProofBuilder::new("https://auth.example.com/token", "jti-1").build();
+
+            let err = handle_token_with_client_cert(
+                client_credentials_request("client1"),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                Some(&proof),
+            )
+            .await
+            .expect_err("no replay store is wired; the proof must be refused");
+
+            assert_eq!(err.error, "invalid_dpop_proof");
+        }
+
+        /// A proof whose `htu` doesn't match the token endpoint must be
+        /// rejected — proves `expected_htu` is actually threaded from
+        /// `config.token_endpoint()`, not hardcoded or ignored.
+        #[tokio::test]
+        async fn a_proof_for_the_wrong_endpoint_is_rejected() {
+            let store = client_credentials_store_with_dpop_replay("client1").await;
+            let tokens = test_tokens();
+            let proof =
+                DpopProofBuilder::new("https://not-this-server.example.com/token", "jti-1").build();
+
+            let err = handle_token_with_client_cert(
+                client_credentials_request("client1"),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                Some(&proof),
+            )
+            .await
+            .expect_err("a proof bound to a different htu must be refused");
+
+            assert_eq!(err.error, "invalid_dpop_proof");
+        }
+
+        /// The `authorization_code` grant must also stamp `cnf.jkt` /
+        /// `token_type: "DPoP"` — proves the wiring generalizes past
+        /// `client_credentials` (the only grant with pre-existing `extra`
+        /// claims machinery) to the other four grant handlers that had none.
+        #[tokio::test]
+        #[allow(deprecated)] // `require_pkce` (authkestra#273) — superseded by mandatory PKCE
+        async fn authorization_code_stamps_cnf_jkt_and_dpop_token_type() {
+            let clients = authkestra_engine::store::memory::MemoryStore::<
+                crate::client::ClientRegistration,
+            >::new();
+            clients
+                .set(
+                    "client1",
+                    ClientRegistration {
+                        client_id: "client1".to_string(),
+                        client_secret_hash: None,
+                        redirect_uris: vec!["https://cb".to_string()],
+                        grant_types: vec![GrantType::AuthorizationCode],
+                        scopes: vec!["openid".to_string()],
+                        require_pkce: true,
+                        allowed_audiences: vec![],
+                        token_endpoint_auth_method: None,
+                        jwks: None,
+                    },
+                    std::time::Duration::from_secs(31536000),
+                )
+                .await
+                .unwrap();
+
+            let verifier = "test_verifier";
+            let mut hasher = sha2::Sha256::new();
+            sha2::Digest::update(&mut hasher, verifier.as_bytes());
+            let challenge =
+                base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(hasher.finalize());
+
+            let codes = authkestra_engine::store::memory::MemoryStore::<
+                crate::code::AuthorizationCode,
+            >::new();
+            codes
+                .store_code(AuthorizationCode {
+                    code: "code1".to_string(),
+                    client_id: "client1".to_string(),
+                    redirect_uri: "https://cb".to_string(),
+                    identity: test_identity(),
+                    scope: "openid".to_string(),
+                    nonce: None,
+                    expires_at: Utc::now() + Duration::minutes(5),
+                    code_challenge: Some(challenge),
+                    code_challenge_method: Some("S256".to_string()),
+                    used: false,
+                })
+                .await
+                .unwrap();
+
+            let store = crate::store::CompositeOpStore::new(
+                clients,
+                codes,
+                authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(
+                ),
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+                ),
+            )
+            .with_dpop_replay_store(authkestra_engine::store::memory::MemoryStore::<
+                DpopJtiRecord,
+            >::new());
+
+            let tokens = test_tokens();
+            let proof_builder = DpopProofBuilder::new("https://auth.example.com/token", "jti-ac-1");
+            let proof = proof_builder.build();
+
+            let req = TokenRequest {
+                grant_type: "authorization_code".to_string(),
+                code: Some("code1".to_string()),
+                redirect_uri: Some("https://cb".to_string()),
+                client_id: Some("client1".to_string()),
+                client_secret: None,
+                code_verifier: Some(verifier.to_string()),
+                scope: None,
+                refresh_token: None,
+                subject_token: None,
+                subject_token_type: None,
+                device_code: None,
+                actor_token: None,
+                actor_token_type: None,
+                requested_token_type: None,
+                audience: None,
+                client_assertion: None,
+                client_assertion_type: None,
+                dpop_jkt: None,
+            };
+
+            let resp = handle_token_with_client_cert(
+                req,
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                Some(&proof),
+            )
+            .await
+            .expect("a valid DPoP proof must be accepted on the authorization_code grant");
+
+            assert_eq!(resp.token_type, "DPoP");
+            let claims = tokens
+                .validate_token(&resp.access_token, Some("client1"))
+                .unwrap();
+            assert_eq!(
+                claims
+                    .extra
+                    .get("cnf")
+                    .and_then(|c| c.get("jkt"))
+                    .and_then(|v| v.as_str()),
+                Some(proof_builder.expected_jkt().as_str()),
+            );
+        }
     }
 }
 

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -1200,17 +1200,32 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
         }
     };
 
-    let old_rt = match op_store.consume_token(refresh_token_str).await {
+    // Looked up first, *not* consumed yet: every check below (client_id,
+    // expiry, DPoP continuity) runs against this non-destructive read.
+    // Consumption — the actual single-use, atomic revoke-and-return — only
+    // happens once every check has passed. Doing it in the other order
+    // (consume first, validate after, as this function used to) means any
+    // one of these checks failing after consumption permanently destroys a
+    // refresh token that was otherwise still valid. For the DPoP check in
+    // particular, that inverts the feature's own threat model: an attacker
+    // holding nothing but a leaked token *string* (no key at all) could
+    // send one request with no `DPoP` header and permanently log the
+    // legitimate holder out — turning a leaked-but-otherwise-useless token
+    // into a working denial-of-service weapon. The same trap would catch a
+    // legitimate client behind a proxy that strips the header. Validating
+    // first means a request that fails never has a side effect on a token
+    // it had no right to consume.
+    let candidate = match op_store.get_token(refresh_token_str).await {
         Ok(Some(rt)) => rt,
         Ok(None) => {
-            tracing::warn!("Invalid refresh token (possibly replayed)");
+            tracing::warn!("Invalid refresh token (unknown, revoked, or expired)");
             return Err(TokenErrorResponse {
                 error: "invalid_grant".to_string(),
                 error_description: "Invalid refresh token".to_string(),
             });
         }
         Err(e) => {
-            tracing::error!(error = ?e, "Failed to consume refresh token");
+            tracing::error!(error = ?e, "Failed to look up refresh token");
             return Err(TokenErrorResponse {
                 error: "server_error".to_string(),
                 error_description: "Internal server error".to_string(),
@@ -1218,7 +1233,7 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
         }
     };
 
-    if old_rt.client_id != client_id {
+    if candidate.client_id != client_id {
         tracing::warn!("Refresh token issued to a different client");
         return Err(TokenErrorResponse {
             error: "invalid_grant".to_string(),
@@ -1226,7 +1241,7 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
         });
     }
 
-    if chrono::Utc::now() > old_rt.expires_at {
+    if chrono::Utc::now() > candidate.expires_at {
         tracing::warn!("Refresh token expired");
         return Err(TokenErrorResponse {
             error: "invalid_grant".to_string(),
@@ -1242,10 +1257,10 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
     // presenter happens to hold. Without this, an exfiltrated DPoP-bound
     // refresh token could be redeemed with the attacker's own key (or no
     // proof at all), which is exactly the theft scenario DPoP exists to
-    // close for public clients (authkestra#274). An `old_rt.jkt` of `None`
-    // means this refresh token was never DPoP-bound — that behavior is
-    // unchanged from before this feature existed.
-    if let Some(expected_jkt) = &old_rt.jkt {
+    // close for public clients (authkestra#274). A `candidate.jkt` of
+    // `None` means this refresh token was never DPoP-bound — that behavior
+    // is unchanged from before this feature existed.
+    if let Some(expected_jkt) = &candidate.jkt {
         if req.dpop_jkt.as_deref() != Some(expected_jkt.as_str()) {
             tracing::warn!(
                 client_id = %client_id,
@@ -1259,13 +1274,37 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
         }
     }
     // Carries the rotated token's binding forward. Deliberately reads from
-    // `old_rt.jkt` rather than `req.dpop_jkt` when the token was already
+    // `candidate.jkt` rather than `req.dpop_jkt` when the token was already
     // bound (the branch above already proved they're equal) — the stored,
     // trusted value is preferred over re-deriving it from client input.
-    // When `old_rt.jkt` is `None`, this is the first time the client has
+    // When `candidate.jkt` is `None`, this is the first time the client has
     // presented a DPoP proof for this token lineage, so `req.dpop_jkt`
     // (possibly still `None`) begins the binding going forward.
-    let jkt = old_rt.jkt.clone().or_else(|| req.dpop_jkt.clone());
+    let jkt = candidate.jkt.clone().or_else(|| req.dpop_jkt.clone());
+
+    // All checks passed — now, and only now, perform the actual single-use
+    // consumption. `consume_token`'s atomicity is still what prevents two
+    // concurrent requests presenting the same token from both succeeding:
+    // if a concurrent request already won that race between the `get_token`
+    // above and this call, this returns `Ok(None)` and the loser (this
+    // request) is correctly refused, with no destructive effect of its own.
+    let old_rt = match op_store.consume_token(refresh_token_str).await {
+        Ok(Some(rt)) => rt,
+        Ok(None) => {
+            tracing::warn!("Refresh token was consumed by a concurrent request");
+            return Err(TokenErrorResponse {
+                error: "invalid_grant".to_string(),
+                error_description: "Invalid refresh token".to_string(),
+            });
+        }
+        Err(e) => {
+            tracing::error!(error = ?e, "Failed to consume refresh token");
+            return Err(TokenErrorResponse {
+                error: "server_error".to_string(),
+                error_description: "Internal server error".to_string(),
+            });
+        }
+    };
 
     let new_refresh_val = uuid::Uuid::new_v4().to_string();
     let new_rt = RefreshToken {
@@ -5284,6 +5323,75 @@ mod tests {
             .expect_err("omitting DPoP on a bound refresh token must be refused");
 
             assert_eq!(err.error, "invalid_dpop_proof");
+        }
+
+        /// A failed DPoP continuity check (wrong key, or no proof at all)
+        /// must NOT consume the refresh token. Validation runs before
+        /// `consume_token`, specifically so a request that has no right to
+        /// redeem the token can't destroy it as a side effect of trying —
+        /// otherwise a bare stolen token *string* (no key needed at all)
+        /// would let an attacker permanently log the legitimate holder out
+        /// with a single throwaway request, and a legitimate client behind
+        /// a header-stripping proxy would lose its session irrecoverably
+        /// the first time it forgot to attach DPoP. This proves the token
+        /// survives a failed attempt and a correct retry still succeeds.
+        #[tokio::test]
+        #[allow(deprecated)]
+        async fn refresh_token_survives_a_failed_dpop_attempt_and_a_correct_retry_still_succeeds() {
+            let (store, verifier) = dpop_refresh_continuity_store().await;
+            let tokens = test_tokens();
+
+            let issue_proof = DpopProofBuilder::with_key_seed(
+                11,
+                "https://auth.example.com/token",
+                "jti-issue-4",
+            );
+            let issued = handle_token_with_client_cert(
+                dpop_refresh_continuity_code_req(&verifier),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                Some(&issue_proof.build()),
+            )
+            .await
+            .expect("issuing the code grant with a DPoP proof must succeed");
+            let refresh_token = issued.refresh_token.unwrap();
+
+            // First: an attacker holding only the token string, no key.
+            let attacker_attempt = handle_token_with_client_cert(
+                dpop_refresh_continuity_refresh_req(&refresh_token),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                None,
+            )
+            .await
+            .expect_err("a missing proof must be refused");
+            assert_eq!(attacker_attempt.error, "invalid_dpop_proof");
+
+            // Then: the legitimate client, presenting the correct key,
+            // using that exact same still-unconsumed refresh token.
+            let retry_proof = DpopProofBuilder::with_key_seed(
+                11,
+                "https://auth.example.com/token",
+                "jti-retry-after-failed-attempt",
+            );
+            let retried = handle_token_with_client_cert(
+                dpop_refresh_continuity_refresh_req(&refresh_token),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                Some(&retry_proof.build()),
+            )
+            .await
+            .expect("the refresh token must still be valid after a failed attempt by someone else");
+            assert_eq!(retried.token_type, "DPoP");
         }
 
         /// Companion regression: a refresh token minted *without* DPoP

--- a/crates/authkestra-op/src/handlers/token/client_auth_tests.rs
+++ b/crates/authkestra-op/src/handlers/token/client_auth_tests.rs
@@ -67,6 +67,7 @@ fn bare_request() -> TokenRequest {
         audience: None,
         client_assertion: None,
         client_assertion_type: None,
+        dpop_jkt: None,
     }
 }
 

--- a/crates/authkestra-op/src/handlers/token/device_tests.rs
+++ b/crates/authkestra-op/src/handlers/token/device_tests.rs
@@ -28,6 +28,7 @@ fn default_device_req(device_code: &str) -> TokenRequest {
         audience: None,
         client_assertion: None,
         client_assertion_type: None,
+        dpop_jkt: None,
     }
 }
 

--- a/crates/authkestra-op/src/lib.rs
+++ b/crates/authkestra-op/src/lib.rs
@@ -34,6 +34,14 @@ pub use client_assertion::{
 pub mod code;
 pub use code::{AuthorizationCode, AuthorizationCodeStore};
 
+/// DPoP (RFC 9449) proof replay tracking for the `/token` endpoint. Proof
+/// verification itself lives in `authkestra_engine::token::dpop`, since it's
+/// needed by both this crate (issuance) and `authkestra-resource`
+/// (verification); this module is only the OP-side "was this jti already
+/// spent" guard.
+pub mod dpop;
+pub use dpop::{DpopJtiRecord, DpopReplayStore, NoDpopReplayStore, DPOP_PROOF_MAX_AGE_SECS};
+
 /// Device/service attestation issuance: the enrolment/re-issuance ceremony
 /// and `cnf.jkt`-bound attestation minting for the device-bound-signature
 /// authentication method. See `handlers::enrolment` for the request/

--- a/crates/authkestra-op/src/refresh.rs
+++ b/crates/authkestra-op/src/refresh.rs
@@ -17,6 +17,20 @@ pub struct RefreshToken {
     pub scope: String,
     /// When this token expires.
     pub expires_at: DateTime<Utc>,
+    /// The RFC 7638 thumbprint of the DPoP key this token is bound to
+    /// (RFC 9449 §5), if the request that minted it presented a DPoP proof.
+    ///
+    /// `None` means this refresh token is an ordinary bearer token — no
+    /// continuity is required or enforced on rotation. Once `Some`, RFC
+    /// 9449 §5 requires every future `refresh_token` grant redeeming this
+    /// token (and each token it rotates into) to present a fresh DPoP
+    /// proof for this *same* key; a request that omits DPoP, or presents a
+    /// proof for a different key, must be refused. Without this check, an
+    /// exfiltrated DPoP-bound refresh token could simply be redeemed with
+    /// the attacker's own key (or with no proof at all), defeating exactly
+    /// the sender-constraining guarantee DPoP exists to provide for public
+    /// clients (authkestra#274).
+    pub jkt: Option<String>,
 }
 
 impl RefreshToken {
@@ -26,12 +40,14 @@ impl RefreshToken {
     /// this crate, but `RefreshTokenStore` implementations must be able to
     /// reconstruct a token from their own storage — this is the seam that
     /// makes that possible (authkestra#268).
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         token: String,
         client_id: String,
         identity: Identity,
         scope: String,
         expires_at: DateTime<Utc>,
+        jkt: Option<String>,
     ) -> Self {
         Self {
             token,
@@ -39,6 +55,7 @@ impl RefreshToken {
             identity,
             scope,
             expires_at,
+            jkt,
         }
     }
 }

--- a/crates/authkestra-op/src/sqlx_store.rs
+++ b/crates/authkestra-op/src/sqlx_store.rs
@@ -154,12 +154,12 @@ macro_rules! impl_opstore_sql {
         impl RefreshTokenStore for SqlxOpStore<$backend> {
             async fn store_token(&self, token: RefreshToken) -> Result<(), OpError> {
                 let query = format!(
-                    "INSERT INTO {schema}oauth_refresh_tokens 
-                    (token, client_id, identity, scope, expires_at) 
-                    VALUES ({p1}, {p2}, {p3}, {p4}, {p5})",
+                    "INSERT INTO {schema}oauth_refresh_tokens
+                    (token, client_id, identity, scope, expires_at, jkt)
+                    VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6})",
                     schema = $schema_prefix,
                     p1 = $placeholder_fmt(1), p2 = $placeholder_fmt(2), p3 = $placeholder_fmt(3),
-                    p4 = $placeholder_fmt(4), p5 = $placeholder_fmt(5)
+                    p4 = $placeholder_fmt(4), p5 = $placeholder_fmt(5), p6 = $placeholder_fmt(6)
                 );
 
                 let identity_json = sqlx::types::Json(token.identity);
@@ -170,6 +170,7 @@ macro_rules! impl_opstore_sql {
                     .bind(identity_json)
                     .bind(token.scope)
                     .bind(token.expires_at)
+                    .bind(token.jkt)
                     .execute(&self.pool)
                     .await
                     .map_err(|e| {
@@ -181,8 +182,8 @@ macro_rules! impl_opstore_sql {
 
             async fn get_token(&self, token: &str) -> Result<Option<RefreshToken>, OpError> {
                 let query = format!(
-                    "SELECT token, client_id, identity, scope, expires_at 
-                    FROM {schema}oauth_refresh_tokens 
+                    "SELECT token, client_id, identity, scope, expires_at, jkt
+                    FROM {schema}oauth_refresh_tokens
                     WHERE token = {p1} AND revoked_at IS NULL AND expires_at > {p2}",
                     schema = $schema_prefix,
                     p1 = $placeholder_fmt(1),
@@ -209,6 +210,7 @@ macro_rules! impl_opstore_sql {
                         identity: identity.0,
                         scope: row.try_get("scope").map_err(|_| OpError::Storage)?,
                         expires_at: row.try_get("expires_at").map_err(|_| OpError::Storage)?,
+                        jkt: row.try_get("jkt").ok(),
                     }))
                 } else {
                     Ok(None)
@@ -432,7 +434,8 @@ impl_opstore_sql! {
                 identity JSONB NOT NULL,
                 scope TEXT NOT NULL,
                 expires_at TIMESTAMPTZ NOT NULL,
-                revoked_at TIMESTAMPTZ
+                revoked_at TIMESTAMPTZ,
+                jkt VARCHAR(255)
             );
 
             CREATE TABLE IF NOT EXISTS authkestra.oauth_device_codes (
@@ -494,6 +497,7 @@ impl_opstore_sql! {
                 identity: identity.0,
                 scope: row.try_get("scope").unwrap_or_default(),
                 expires_at: row.try_get("expires_at").map_err(|_| OpError::Storage)?,
+                jkt: row.try_get("jkt").ok(),
             }))
         } else {
             Ok(None)
@@ -566,7 +570,8 @@ impl_opstore_sql! {
                 identity TEXT NOT NULL,
                 scope TEXT NOT NULL,
                 expires_at DATETIME NOT NULL,
-                revoked_at DATETIME
+                revoked_at DATETIME,
+                jkt TEXT
             );
 
             CREATE TABLE IF NOT EXISTS authkestra_oauth_device_codes (
@@ -628,6 +633,7 @@ impl_opstore_sql! {
                 identity: identity.0,
                 scope: row.try_get("scope").unwrap_or_default(),
                 expires_at: row.try_get("expires_at").map_err(|_| OpError::Storage)?,
+                jkt: row.try_get("jkt").ok(),
             }))
         } else {
             Ok(None)
@@ -702,6 +708,7 @@ impl_opstore_sql! {
                 scope TEXT NOT NULL,
                 expires_at DATETIME NOT NULL,
                 revoked_at DATETIME,
+                jkt VARCHAR(255),
                 FOREIGN KEY (client_id) REFERENCES authkestra_oauth_clients(client_id) ON DELETE CASCADE
             );
 
@@ -788,6 +795,7 @@ impl_opstore_sql! {
                 identity: identity.0,
                 scope: row.try_get("scope").unwrap_or_default(),
                 expires_at: row.try_get("expires_at").map_err(|_| OpError::Storage)?,
+                jkt: row.try_get("jkt").ok(),
             }))
         } else {
             tx.rollback().await.map_err(|_| OpError::Storage)?;

--- a/crates/authkestra-op/src/sqlx_store.rs
+++ b/crates/authkestra-op/src/sqlx_store.rs
@@ -155,13 +155,15 @@ macro_rules! impl_opstore_sql {
             async fn store_token(&self, token: RefreshToken) -> Result<(), OpError> {
                 let query = format!(
                     "INSERT INTO {schema}oauth_refresh_tokens
-                    (token, client_id, identity, scope, expires_at, jkt)
-                    VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6})",
+                    (token, client_id, identity, scope, expires_at)
+                    VALUES ({p1}, {p2}, {p3}, {p4}, {p5})",
                     schema = $schema_prefix,
                     p1 = $placeholder_fmt(1), p2 = $placeholder_fmt(2), p3 = $placeholder_fmt(3),
-                    p4 = $placeholder_fmt(4), p5 = $placeholder_fmt(5), p6 = $placeholder_fmt(6)
+                    p4 = $placeholder_fmt(4), p5 = $placeholder_fmt(5)
                 );
 
+                // `token.jkt` is deliberately not bound here: see the
+                // matching comment on `jkt: None` below.
                 let identity_json = sqlx::types::Json(token.identity);
 
                 sqlx::query(&query)
@@ -170,7 +172,6 @@ macro_rules! impl_opstore_sql {
                     .bind(identity_json)
                     .bind(token.scope)
                     .bind(token.expires_at)
-                    .bind(token.jkt)
                     .execute(&self.pool)
                     .await
                     .map_err(|e| {
@@ -182,7 +183,7 @@ macro_rules! impl_opstore_sql {
 
             async fn get_token(&self, token: &str) -> Result<Option<RefreshToken>, OpError> {
                 let query = format!(
-                    "SELECT token, client_id, identity, scope, expires_at, jkt
+                    "SELECT token, client_id, identity, scope, expires_at
                     FROM {schema}oauth_refresh_tokens
                     WHERE token = {p1} AND revoked_at IS NULL AND expires_at > {p2}",
                     schema = $schema_prefix,
@@ -210,7 +211,19 @@ macro_rules! impl_opstore_sql {
                         identity: identity.0,
                         scope: row.try_get("scope").map_err(|_| OpError::Storage)?,
                         expires_at: row.try_get("expires_at").map_err(|_| OpError::Storage)?,
-                        jkt: row.try_get("jkt").ok(),
+                        // Not persisted yet: same reasoning as
+                        // `token_endpoint_auth_method`/`jwks` above — a
+                        // `jkt` column needs an ALTER-based migration, and
+                        // this store's `migrate` is CREATE TABLE IF NOT
+                        // EXISTS, so naming it in a SELECT/INSERT would
+                        // break every existing deployment whose table
+                        // predates this field. Until that lands, a
+                        // SqlxOpStore-backed refresh token is never
+                        // DPoP-bound (RFC 9449 §5 continuity is simply not
+                        // enforced for this backend), which is a strictly
+                        // weaker but not incorrect posture — the same gap
+                        // client-assertion auth already has here.
+                        jkt: None,
                     }))
                 } else {
                     Ok(None)
@@ -434,8 +447,7 @@ impl_opstore_sql! {
                 identity JSONB NOT NULL,
                 scope TEXT NOT NULL,
                 expires_at TIMESTAMPTZ NOT NULL,
-                revoked_at TIMESTAMPTZ,
-                jkt VARCHAR(255)
+                revoked_at TIMESTAMPTZ
             );
 
             CREATE TABLE IF NOT EXISTS authkestra.oauth_device_codes (
@@ -497,7 +509,9 @@ impl_opstore_sql! {
                 identity: identity.0,
                 scope: row.try_get("scope").unwrap_or_default(),
                 expires_at: row.try_get("expires_at").map_err(|_| OpError::Storage)?,
-                jkt: row.try_get("jkt").ok(),
+                // Not persisted yet — see the comment on `get_token`'s
+                // identical field above.
+                jkt: None,
             }))
         } else {
             Ok(None)
@@ -570,8 +584,7 @@ impl_opstore_sql! {
                 identity TEXT NOT NULL,
                 scope TEXT NOT NULL,
                 expires_at DATETIME NOT NULL,
-                revoked_at DATETIME,
-                jkt TEXT
+                revoked_at DATETIME
             );
 
             CREATE TABLE IF NOT EXISTS authkestra_oauth_device_codes (
@@ -633,7 +646,9 @@ impl_opstore_sql! {
                 identity: identity.0,
                 scope: row.try_get("scope").unwrap_or_default(),
                 expires_at: row.try_get("expires_at").map_err(|_| OpError::Storage)?,
-                jkt: row.try_get("jkt").ok(),
+                // Not persisted yet — see the comment on `get_token`'s
+                // identical field above.
+                jkt: None,
             }))
         } else {
             Ok(None)
@@ -708,7 +723,6 @@ impl_opstore_sql! {
                 scope TEXT NOT NULL,
                 expires_at DATETIME NOT NULL,
                 revoked_at DATETIME,
-                jkt VARCHAR(255),
                 FOREIGN KEY (client_id) REFERENCES authkestra_oauth_clients(client_id) ON DELETE CASCADE
             );
 
@@ -795,7 +809,9 @@ impl_opstore_sql! {
                 identity: identity.0,
                 scope: row.try_get("scope").unwrap_or_default(),
                 expires_at: row.try_get("expires_at").map_err(|_| OpError::Storage)?,
-                jkt: row.try_get("jkt").ok(),
+                // Not persisted yet — see the comment on `get_token`'s
+                // identical field above.
+                jkt: None,
             }))
         } else {
             tx.rollback().await.map_err(|_| OpError::Storage)?;

--- a/crates/authkestra-op/src/store.rs
+++ b/crates/authkestra-op/src/store.rs
@@ -2,6 +2,7 @@ use crate::client::ClientStore;
 use crate::client_assertion::{ClientAssertionStore, NoClientAssertionStore};
 use crate::code::AuthorizationCodeStore;
 use crate::device::DeviceCodeStore;
+use crate::dpop::{DpopReplayStore, NoDpopReplayStore};
 use crate::error::OpError;
 use crate::refresh::RefreshTokenStore;
 use chrono::{DateTime, Utc};
@@ -35,6 +36,27 @@ pub trait OpStore:
         expires_at: DateTime<Utc>,
     ) -> Result<bool, OpError> {
         NoClientAssertionStore.record_jti(jti, expires_at).await
+    }
+
+    /// Atomically records the `jti` of a presented DPoP proof, returning
+    /// `Ok(false)` if it was already spent (RFC 9449 §11.1).
+    ///
+    /// A defaulted method, same reasoning as `record_client_assertion_jti`:
+    /// adding replay tracking must not break every existing `OpStore`
+    /// implementation.
+    ///
+    /// **The default refuses every proof.** See
+    /// `record_client_assertion_jti`'s doc comment for why failing closed
+    /// is the only safe default here too. See
+    /// `CompositeOpStore::with_dpop_replay_store` for how to wire one.
+    async fn check_and_record_dpop_jti(
+        &self,
+        jti: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<bool, OpError> {
+        NoDpopReplayStore
+            .check_and_record_dpop_jti(jti, expires_at)
+            .await
     }
 
     /// Handle a custom grant type request during token exchange.
@@ -155,32 +177,35 @@ pub trait OpStore:
     }
 }
 
-/// A helper struct that implements `OpStore` by delegating to 5 individual stores.
+/// A helper struct that implements `OpStore` by delegating to individual stores.
 /// Useful if you want to use different backends for different types of data (e.g., config for clients, Redis for codes).
 ///
-/// The client-assertion slot defaults to
-/// [`NoClientAssertionStore`], so `private_key_jwt` is refused until a
-/// deployment opts in with [`CompositeOpStore::with_client_assertion_store`].
-/// It is a defaulted type parameter rather than a fifth argument to
-/// [`CompositeOpStore::new`] so that existing four-store call sites keep
-/// compiling untouched.
+/// The client-assertion and DPoP-replay slots default to
+/// [`NoClientAssertionStore`] and [`NoDpopReplayStore`] respectively, so
+/// `private_key_jwt` and DPoP are both refused until a deployment opts in
+/// with [`CompositeOpStore::with_client_assertion_store`] /
+/// [`CompositeOpStore::with_dpop_replay_store`]. Both are defaulted type
+/// parameters rather than required arguments to [`CompositeOpStore::new`]
+/// so that existing four-store call sites keep compiling untouched.
 #[non_exhaustive]
-pub struct CompositeOpStore<C, A, R, D, J = NoClientAssertionStore> {
+pub struct CompositeOpStore<C, A, R, D, J = NoClientAssertionStore, P = NoDpopReplayStore> {
     clients: C,
     codes: A,
     refresh: R,
     devices: D,
     assertions: J,
+    dpop_replays: P,
 }
 
 #[async_trait::async_trait]
-impl<C, A, R, D, J> OpStore for CompositeOpStore<C, A, R, D, J>
+impl<C, A, R, D, J, P> OpStore for CompositeOpStore<C, A, R, D, J, P>
 where
     C: ClientStore,
     A: AuthorizationCodeStore,
     R: RefreshTokenStore,
     D: DeviceCodeStore,
     J: ClientAssertionStore,
+    P: DpopReplayStore,
     Self: Send + Sync,
 {
     async fn record_client_assertion_jti(
@@ -190,9 +215,19 @@ where
     ) -> Result<bool, OpError> {
         self.assertions.record_jti(jti, expires_at).await
     }
+
+    async fn check_and_record_dpop_jti(
+        &self,
+        jti: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<bool, OpError> {
+        self.dpop_replays
+            .check_and_record_dpop_jti(jti, expires_at)
+            .await
+    }
 }
 
-impl<C, A, R, D> CompositeOpStore<C, A, R, D, NoClientAssertionStore> {
+impl<C, A, R, D> CompositeOpStore<C, A, R, D, NoClientAssertionStore, NoDpopReplayStore> {
     /// Create a new `CompositeOpStore` from individual stores.
     pub fn new(clients: C, codes: A, refresh: R, devices: D) -> Self {
         Self {
@@ -201,11 +236,12 @@ impl<C, A, R, D> CompositeOpStore<C, A, R, D, NoClientAssertionStore> {
             refresh,
             devices,
             assertions: NoClientAssertionStore,
+            dpop_replays: NoDpopReplayStore,
         }
     }
 }
 
-impl<C, A, R, D, J> CompositeOpStore<C, A, R, D, J> {
+impl<C, A, R, D, J, P> CompositeOpStore<C, A, R, D, J, P> {
     /// Swaps in the backend that tracks spent `private_key_jwt` assertion
     /// `jti`s — the one thing this store needs before it will accept
     /// asymmetric client authentication at all.
@@ -219,20 +255,52 @@ impl<C, A, R, D, J> CompositeOpStore<C, A, R, D, J> {
     pub fn with_client_assertion_store<J2: ClientAssertionStore>(
         self,
         assertions: J2,
-    ) -> CompositeOpStore<C, A, R, D, J2> {
+    ) -> CompositeOpStore<C, A, R, D, J2, P> {
         CompositeOpStore {
             clients: self.clients,
             codes: self.codes,
             refresh: self.refresh,
             devices: self.devices,
             assertions,
+            dpop_replays: self.dpop_replays,
+        }
+    }
+
+    /// Swaps in the backend that tracks spent DPoP proof `jti`s — the one
+    /// thing this store needs before it will accept a `DPoP` header at
+    /// `/token` at all.
+    ///
+    /// Any backend `authkestra_engine::store::AtomicInsert` is implemented
+    /// for (`MemoryStore`, `RedisStore`, and the SQL backends) already
+    /// implements [`crate::dpop::DpopReplayStore`] via its blanket impl — no
+    /// DPoP-specific storage code is needed. A single-node deployment can
+    /// use `authkestra_engine::store::memory::MemoryStore`; a cluster needs
+    /// something shared, for the same reason `with_client_assertion_store`
+    /// does.
+    pub fn with_dpop_replay_store<P2: DpopReplayStore>(
+        self,
+        dpop_replays: P2,
+    ) -> CompositeOpStore<C, A, R, D, J, P2> {
+        CompositeOpStore {
+            clients: self.clients,
+            codes: self.codes,
+            refresh: self.refresh,
+            devices: self.devices,
+            assertions: self.assertions,
+            dpop_replays,
         }
     }
 }
 
 #[async_trait::async_trait]
-impl<C: ClientStore, A: Send + Sync, R: Send + Sync, D: Send + Sync, J: Send + Sync> ClientStore
-    for CompositeOpStore<C, A, R, D, J>
+impl<
+        C: ClientStore,
+        A: Send + Sync,
+        R: Send + Sync,
+        D: Send + Sync,
+        J: Send + Sync,
+        P: Send + Sync,
+    > ClientStore for CompositeOpStore<C, A, R, D, J, P>
 {
     #[tracing::instrument(skip(self))]
     async fn find_client(
@@ -245,8 +313,14 @@ impl<C: ClientStore, A: Send + Sync, R: Send + Sync, D: Send + Sync, J: Send + S
 }
 
 #[async_trait::async_trait]
-impl<C: Send + Sync, A: AuthorizationCodeStore, R: Send + Sync, D: Send + Sync, J: Send + Sync>
-    AuthorizationCodeStore for CompositeOpStore<C, A, R, D, J>
+impl<
+        C: Send + Sync,
+        A: AuthorizationCodeStore,
+        R: Send + Sync,
+        D: Send + Sync,
+        J: Send + Sync,
+        P: Send + Sync,
+    > AuthorizationCodeStore for CompositeOpStore<C, A, R, D, J, P>
 {
     #[tracing::instrument(skip(self, code))]
     async fn store_code(
@@ -268,8 +342,14 @@ impl<C: Send + Sync, A: AuthorizationCodeStore, R: Send + Sync, D: Send + Sync, 
 }
 
 #[async_trait::async_trait]
-impl<C: Send + Sync, A: Send + Sync, R: RefreshTokenStore, D: Send + Sync, J: Send + Sync>
-    RefreshTokenStore for CompositeOpStore<C, A, R, D, J>
+impl<
+        C: Send + Sync,
+        A: Send + Sync,
+        R: RefreshTokenStore,
+        D: Send + Sync,
+        J: Send + Sync,
+        P: Send + Sync,
+    > RefreshTokenStore for CompositeOpStore<C, A, R, D, J, P>
 {
     #[tracing::instrument(skip(self, token))]
     async fn store_token(
@@ -306,8 +386,14 @@ impl<C: Send + Sync, A: Send + Sync, R: RefreshTokenStore, D: Send + Sync, J: Se
 }
 
 #[async_trait::async_trait]
-impl<C: Send + Sync, A: Send + Sync, R: Send + Sync, D: DeviceCodeStore, J: Send + Sync>
-    DeviceCodeStore for CompositeOpStore<C, A, R, D, J>
+impl<
+        C: Send + Sync,
+        A: Send + Sync,
+        R: Send + Sync,
+        D: DeviceCodeStore,
+        J: Send + Sync,
+        P: Send + Sync,
+    > DeviceCodeStore for CompositeOpStore<C, A, R, D, J, P>
 {
     #[tracing::instrument(skip(self, session))]
     async fn store_device_code(

--- a/crates/authkestra-op/tests/non_exhaustive_store_type_constructors_tests.rs
+++ b/crates/authkestra-op/tests/non_exhaustive_store_type_constructors_tests.rs
@@ -76,6 +76,7 @@ fn refresh_token_is_constructible() {
         test_identity(),
         "openid".to_string(),
         expires_at,
+        None,
     );
     assert_eq!(refresh.token, "refresh-1");
 }


### PR DESCRIPTION
## Summary

Phase B of #274. Phase A (#277, merged to `next`) built `authkestra_engine::token::dpop::verify_dpop_proof` (pure proof verification) and `authkestra_engine::store::AtomicInsert` (atomic insert-if-absent), but wired neither into anything. This connects them to `authkestra-op`'s `/token` endpoint: a client presenting a `DPoP` header gets its proof verified, its `jti` checked for replay, and — on success — its issued token bound to the proof's key via `cnf.jkt` with `token_type` switched to `"DPoP"`, across all five grant handlers (`authorization_code`, `refresh_token`, `client_credentials`, `token_exchange`, `device_code`).

Targets `next`, not `main`, per the same release-timing reasoning as #277/#279/#281.

## What's here

- **New `authkestra_op::dpop` module**: `DpopReplayStore` trait, a blanket impl over any backend with `KvStore + AtomicInsert` (Memory/Redis/Postgres/Sqlite/MySQL all get it for free — the first real consumer of Phase A's `AtomicInsert`), and `NoDpopReplayStore` as the fail-closed default (mirrors `NoClientAssertionStore`): a deployment with no replay store wired refuses every DPoP proof rather than accepting one it can't guarantee is single-use.
- **`CompositeOpStore`** gains a 6th defaulted generic slot (`P = NoDpopReplayStore`) and a `with_dpop_replay_store` builder, exactly mirroring the existing `with_client_assertion_store` pattern. `CompositeOpStore::new`'s 4-arg signature is untouched — zero breakage to any existing call site.
- The verified proof's `jkt` is threaded through a new `pub(crate)`, `#[serde(skip)]` field on `TokenRequest` rather than a new trait-method or free-function parameter — both `OpStore` method signatures and the public `default_handle_*` free functions are a pinned, tested contract (`default_handle_token_exchange_visibility_tests.rs`). `#[serde(skip)]` is load-bearing: without it a client could submit `dpop_jkt` as an ordinary form field and bind a token to a key it never proved possession of.
- `handle_token_with_client_cert` gains a trailing `dpop_header` parameter (same precedent as `client_cert_der`), verifies the proof against `config.token_endpoint()` before any grant dispatch, and rejects with `invalid_dpop_proof` on a bad proof, a replay, or no replay store configured.
- A `merge_dpop_cnf` helper folds `cnf.jkt` into any existing `extra` claims — RFC 9449 §6.1 requires `cnf.jkt` and RFC 8705's `cnf.x5t#S256` to coexist in one object, not clobber each other — used at all five issuance sites.
- axum/actix adapters read the `DPoP` header the same way they already read `Authorization`; no new extension-based plumbing needed.
- Discovery gains an opt-in `dpop_signing_alg_values_supported` via `with_dpop_support()`, following the same opt-in precedent as `with_private_key_jwt()`: since the replay store defaults to fail-closed, advertising DPoP unconditionally would be misleading for a deployment that hasn't wired one.

## Deliberate scope boundary

RFC 9449 §4.3's refresh-token key continuity (binding a *rotated* refresh token to the same key the original was bound to, not just any valid proof) is out of scope here — it needs a schema change to `RefreshToken` plus new validation logic, not just wiring. Phase B binds whatever proof is presented on a refresh request to the newly issued token, without enforcing it matches the original. Flagging explicitly rather than silently shipping partial; worth its own follow-up issue.

## Test plan

- [x] `cargo test -p authkestra-op --lib` — 168 passed (up from 160 before this PR, zero regressions).
- [x] New `dpop_wiring_tests` module: valid proof stamps `cnf.jkt` + `token_type: "DPoP"` (client_credentials and authorization_code); no header stays plain `Bearer` with no `cnf` (regression proof the feature is additive); replayed `jti` rejected; `NoDpopReplayStore` wired fails closed; wrong `htu` rejected.
- [x] `cargo test --workspace --all-features` — clean.
- [x] `cargo test -p authkestra-op --test default_handle_token_exchange_visibility_tests` — still passes unchanged, confirming the free-function contract this design relies on is intact.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.

## Follow-up (tracked on #274, not in this PR)

- RFC 9449 §4.3 refresh-token key continuity (see scope boundary above).
- Phase C: wire verification into `authkestra-resource`'s `JwtStrategy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)