### PR TITLE
feat(resource): DPoP (RFC 9449) key-binding verification in JwtStrategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,8 @@ dependencies = [
  "async-trait",
  "authkestra-engine",
  "base64 0.22.1",
+ "chrono",
+ "ed25519-dalek",
  "http 1.5.0",
  "jsonwebtoken",
  "rand 0.8.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tracing",
+ "url",
  "wiremock",
 ]
 

--- a/crates/authkestra-engine/src/token/dpop.rs
+++ b/crates/authkestra-engine/src/token/dpop.rs
@@ -129,10 +129,23 @@ struct DpopClaims {
 /// Verifies a DPoP proof JWT (RFC 9449 §4.3).
 ///
 /// `expected_htm` is compared case-insensitively (§4.2: "the value of the
-/// HTTP method"). `expected_htu` and the proof's own `htu` are both
-/// stripped of query and fragment before comparison, per §4.3 step 6, using
-/// `url::Url` for canonicalization — pass in the request's URI as received,
-/// not pre-stripped.
+/// HTTP method") and always checked — a caller always knows the current
+/// request's method unambiguously, so there's no case where skipping it
+/// would be appropriate.
+///
+/// `expected_htu`, when `Some`, is compared against the proof's own `htu`
+/// with both sides stripped of query and fragment first, per §4.3 step 6,
+/// using `url::Url` for canonicalization — pass in the request's URI as
+/// received, not pre-stripped. `None` skips the `htu` check entirely: a
+/// resource server protecting many routes behind a reverse proxy or load
+/// balancer often cannot reliably reconstruct the exact absolute URL the
+/// client used (scheme and authority depend on the TLS-termination point,
+/// which isn't always visible to application code), unlike an
+/// authorization server's `/token` endpoint, which has exactly one, known,
+/// statically configured absolute URL. Skipping `htu` still leaves `jti`
+/// replay tracking and (when the caller supplies it) `ath` binding to
+/// prevent a captured proof from being reused — see the caller's own
+/// threat-model notes for what's traded away by not also checking `htu`.
 ///
 /// `expected_ath` should be `Some(base64url(SHA256(access_token)))` when
 /// verifying a proof presented alongside an access token (the resource
@@ -149,7 +162,7 @@ struct DpopClaims {
 pub fn verify_dpop_proof(
     compact_jws: &str,
     expected_htm: &str,
-    expected_htu: &str,
+    expected_htu: Option<&str>,
     expected_ath: Option<&str>,
     max_age: chrono::Duration,
 ) -> Result<VerifiedDpopProof, DpopError> {
@@ -258,8 +271,10 @@ pub fn verify_dpop_proof(
     if !claims.htm.eq_ignore_ascii_case(expected_htm) {
         return Err(DpopError::WrongHtm);
     }
-    if canonicalize_htu(&claims.htu) != canonicalize_htu(expected_htu) {
-        return Err(DpopError::WrongHtu);
+    if let Some(expected_htu) = expected_htu {
+        if canonicalize_htu(&claims.htu) != canonicalize_htu(expected_htu) {
+            return Err(DpopError::WrongHtu);
+        }
     }
 
     let now = chrono::Utc::now().timestamp();
@@ -431,7 +446,7 @@ mod tests {
         let verified = verify_dpop_proof(
             &proof,
             "POST",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             None,
             chrono::Duration::seconds(60),
         )
@@ -447,7 +462,7 @@ mod tests {
         verify_dpop_proof(
             &proof,
             "post",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             None,
             chrono::Duration::seconds(60),
         )
@@ -460,7 +475,7 @@ mod tests {
         let err = verify_dpop_proof(
             &proof,
             "GET",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             None,
             chrono::Duration::seconds(60),
         )
@@ -474,7 +489,7 @@ mod tests {
         verify_dpop_proof(
             &proof,
             "POST",
-            "https://as.example.com/token?foo=bar#frag",
+            Some("https://as.example.com/token?foo=bar#frag"),
             None,
             chrono::Duration::seconds(60),
         )
@@ -487,12 +502,24 @@ mod tests {
         let err = verify_dpop_proof(
             &proof,
             "POST",
-            "https://as.example.com/other-path",
+            Some("https://as.example.com/other-path"),
             None,
             chrono::Duration::seconds(60),
         )
         .expect_err("a mismatched htu must be refused");
         assert!(matches!(err, DpopError::WrongHtu));
+    }
+
+    /// A resource server protecting many routes behind a proxy or load
+    /// balancer often can't reliably reconstruct the exact absolute URL a
+    /// client used — `expected_htu: None` lets such a caller skip this one
+    /// check while still getting every other one (`htm`, freshness, and
+    /// whatever `ath`/replay checks it layers on top itself).
+    #[test]
+    fn expected_htu_none_skips_the_check_entirely() {
+        let proof = ProofBuilder::new().build();
+        verify_dpop_proof(&proof, "POST", None, None, chrono::Duration::seconds(60))
+            .expect("None must skip the htu check regardless of the proof's own htu");
     }
 
     #[test]
@@ -504,7 +531,7 @@ mod tests {
         let err = verify_dpop_proof(
             &proof,
             "POST",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             None,
             chrono::Duration::seconds(60),
         )
@@ -521,7 +548,7 @@ mod tests {
         let err = verify_dpop_proof(
             &proof,
             "POST",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             None,
             chrono::Duration::seconds(60),
         )
@@ -548,7 +575,7 @@ mod tests {
             let err = verify_dpop_proof(
                 proof,
                 "POST",
-                "https://as.example.com/token",
+                Some("https://as.example.com/token"),
                 None,
                 chrono::Duration::seconds(60),
             )
@@ -569,7 +596,7 @@ mod tests {
         let err = verify_dpop_proof(
             proof,
             "POST",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             None,
             chrono::Duration::seconds(60),
         )
@@ -584,7 +611,7 @@ mod tests {
         let err = verify_dpop_proof(
             &proof,
             "POST",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             None,
             chrono::Duration::seconds(60),
         )
@@ -601,7 +628,7 @@ mod tests {
         let err = verify_dpop_proof(
             &proof,
             "POST",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             None,
             chrono::Duration::seconds(60),
         )
@@ -624,7 +651,7 @@ mod tests {
             let err = verify_dpop_proof(
                 &proof,
                 "POST",
-                "https://as.example.com/token",
+                Some("https://as.example.com/token"),
                 None,
                 chrono::Duration::seconds(60),
             )
@@ -645,7 +672,7 @@ mod tests {
         verify_dpop_proof(
             &proof,
             "POST",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             Some("correct-ath"),
             chrono::Duration::seconds(60),
         )
@@ -654,7 +681,7 @@ mod tests {
         let err = verify_dpop_proof(
             &proof,
             "POST",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             Some("wrong-ath"),
             chrono::Duration::seconds(60),
         )
@@ -668,7 +695,7 @@ mod tests {
         let err = verify_dpop_proof(
             &proof,
             "POST",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             Some("expected-ath"),
             chrono::Duration::seconds(60),
         )
@@ -709,7 +736,7 @@ mod tests {
         let err = verify_dpop_proof(
             &proof,
             "POST",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             None,
             chrono::Duration::seconds(60),
         )
@@ -743,7 +770,7 @@ mod tests {
         let err = verify_dpop_proof(
             &proof,
             "POST",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             None,
             chrono::Duration::seconds(60),
         )
@@ -771,7 +798,7 @@ mod tests {
         let err = verify_dpop_proof(
             &proof,
             "POST",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             None,
             chrono::Duration::seconds(60),
         )
@@ -817,7 +844,7 @@ mod tests {
         let verified = verify_dpop_proof(
             &proof,
             "POST",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             None,
             chrono::Duration::seconds(60),
         )
@@ -838,7 +865,7 @@ mod tests {
         let err = verify_dpop_proof(
             &proof,
             "POST",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             None,
             chrono::Duration::seconds(60),
         )
@@ -855,7 +882,7 @@ mod tests {
         verify_dpop_proof(
             &proof,
             "POST",
-            "https://as.example.com/token",
+            Some("https://as.example.com/token"),
             None,
             chrono::Duration::seconds(60),
         )

--- a/crates/authkestra-oidc/src/error.rs
+++ b/crates/authkestra-oidc/src/error.rs
@@ -89,6 +89,11 @@ impl From<authkestra_resource::jwt::ValidationError> for OidcError {
             authkestra_resource::jwt::ValidationError::DpopReplayUnavailable(e) => {
                 OidcError::Internal(e)
             }
+            // `ValidationError` is `#[non_exhaustive]`: a variant added
+            // there after this match was written lands here instead of
+            // failing to compile — its `Display` text is preserved, just
+            // without a specific `OidcError` mapping of its own yet.
+            other => OidcError::ValidationError(other.to_string()),
         }
     }
 }

--- a/crates/authkestra-oidc/src/error.rs
+++ b/crates/authkestra-oidc/src/error.rs
@@ -82,6 +82,13 @@ impl From<authkestra_resource::jwt::ValidationError> for OidcError {
             authkestra_resource::jwt::ValidationError::Validation(e) => {
                 OidcError::ValidationError(e)
             }
+            // Not "the token is invalid" — "we could not determine whether
+            // it is" (no DpopReplayStore configured, or it errored). See
+            // that variant's doc comment for why `authkestra-resource`
+            // itself treats this as distinct from `InvalidToken`.
+            authkestra_resource::jwt::ValidationError::DpopReplayUnavailable(e) => {
+                OidcError::Internal(e)
+            }
         }
     }
 }

--- a/crates/authkestra-op/src/handlers/discovery.rs
+++ b/crates/authkestra-op/src/handlers/discovery.rs
@@ -149,22 +149,19 @@ impl OidcDiscovery {
     /// is — see this field's doc comment. Call alongside
     /// `CompositeOpStore::with_dpop_replay_store` once that's wired.
     ///
-    /// **Resource-server caveat (authkestra#274, tracked for a later
-    /// phase):** this OP will correctly verify a DPoP proof and stamp
-    /// `cnf.jkt` onto the access tokens it issues, but the *bundled*
-    /// `authkestra-resource` `JwtStrategy` does not yet check `cnf.jkt` on
-    /// the resource-server side — it only verifies RFC 8705's
-    /// `cnf.x5t#S256` (mTLS certificate binding). A client that sees this
-    /// advertised will reasonably assume its access tokens are
-    /// sender-constrained end-to-end; against the bundled resource server,
-    /// they currently are not — a DPoP-bound access token is accepted
-    /// there as an ordinary bearer token, with no proof-of-possession
-    /// check at all, if it's presented without also being certificate-bound.
-    /// Calling this is still correct and useful today for any resource
-    /// server that *does* implement its own `cnf.jkt` check (or the
-    /// planned Phase C addition to this crate's own `JwtStrategy`), but a
-    /// deployment relying solely on the bundled resource server should not
-    /// call this yet believing it closes token-theft risk there.
+    /// **Resource-server note (authkestra#274 Phase C):** the bundled
+    /// `authkestra-resource` `JwtStrategy` can check `cnf.jkt` too, but it
+    /// is its own opt-in —
+    /// `ValidationConfig::require_dpop`/`ValidationConfigBuilder::require_dpop`
+    /// on that crate's side, off by default for the same backward-
+    /// compatibility reason this method is. Calling `with_dpop_support`
+    /// here only affects what this OP *advertises*; a deployment must
+    /// separately enable `require_dpop` (and wire a
+    /// `JwtStrategy::with_dpop_replay_store`) on the resource-server side
+    /// for a DPoP-bound access token to actually be rejected there when
+    /// presented without a matching proof. A client that sees DPoP
+    /// advertised should not assume every resource server behind it has
+    /// necessarily turned that check on.
     pub fn with_dpop_support(mut self) -> Self {
         self.dpop_signing_alg_values_supported = Some(vec![
             "ES256".to_string(),

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -282,7 +282,7 @@ pub async fn handle_token_with_client_cert(
         let verified = match authkestra_engine::token::dpop::verify_dpop_proof(
             proof,
             "POST",
-            &config.token_endpoint(),
+            Some(&config.token_endpoint()),
             None,
             chrono::Duration::seconds(crate::dpop::DPOP_PROOF_MAX_AGE_SECS),
         ) {

--- a/crates/authkestra-resource/Cargo.toml
+++ b/crates/authkestra-resource/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 readme = "README.md"
 
 [dependencies]
-authkestra-engine = { workspace = true, default-features = false, features = ["token", "memory"] }
+authkestra-engine = { workspace = true, default-features = false, features = ["token"] }
 async-trait = "0.1"
 jsonwebtoken = { version = "11", features = ["rust_crypto"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -45,3 +45,9 @@ rand = "0.8"
 # Test-only: signing genuine DPoP proofs for JwtStrategy's DPoP-binding
 # tests, mirroring authkestra-engine's own token::dpop test suite.
 ed25519-dalek = "2"
+# `MemoryStore`, used only by this crate's own `#[cfg(test)]` DPoP replay
+# tests — not by any production code path here, so this feature belongs on
+# the dev-dependency, not the main one. A downstream deployment that wants
+# `MemoryStore` as a real `DpopReplayStore` still gets it by depending on
+# `authkestra-engine` directly with this feature enabled.
+authkestra-engine = { workspace = true, default-features = false, features = ["token", "memory"] }

--- a/crates/authkestra-resource/Cargo.toml
+++ b/crates/authkestra-resource/Cargo.toml
@@ -29,6 +29,11 @@ http = "1"
 base64 = "0.22.1"
 tracing = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
+# Validating `ValidationConfig::dpop_resource_origin`'s shape properly
+# (scheme present, no query/fragment) instead of by hand-rolled string
+# checks — the same crate `authkestra_engine::token::dpop` already uses for
+# `htu` canonicalization, so parsing here agrees with parsing there.
+url = { workspace = true }
 
 [features]
 default = ["rustls-aws-lc-rs"]

--- a/crates/authkestra-resource/Cargo.toml
+++ b/crates/authkestra-resource/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 readme = "README.md"
 
 [dependencies]
-authkestra-engine = { workspace = true, default-features = false, features = ["token"] }
+authkestra-engine = { workspace = true, default-features = false, features = ["token", "memory"] }
 async-trait = "0.1"
 jsonwebtoken = { version = "11", features = ["rust_crypto"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -28,6 +28,7 @@ thiserror = "2.0.18"
 http = "1"
 base64 = "0.22.1"
 tracing = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
 
 [features]
 default = ["rustls-aws-lc-rs"]
@@ -41,3 +42,6 @@ rustls-no-provider = ["authkestra-engine/rustls-no-provider"]
 wiremock = "0.6"
 rsa = "0.9.6"
 rand = "0.8"
+# Test-only: signing genuine DPoP proofs for JwtStrategy's DPoP-binding
+# tests, mirroring authkestra-engine's own token::dpop test suite.
+ed25519-dalek = "2"

--- a/crates/authkestra-resource/src/dpop.rs
+++ b/crates/authkestra-resource/src/dpop.rs
@@ -72,8 +72,8 @@ impl DpopReplayStore for NoDpopReplayStore {
              DpopReplayStore is wired into this JwtStrategy; refusing it rather than accepting \
              a proof that could be replayed"
         );
-        Err(ValidationError::InvalidToken(
-            "DPoP replay protection is not configured".to_string(),
+        Err(ValidationError::DpopReplayUnavailable(
+            "no DpopReplayStore is configured".to_string(),
         ))
     }
 }
@@ -127,7 +127,9 @@ where
             .await
             .map_err(|e| {
                 tracing::error!(error = %e, "failed to record dpop proof jti");
-                ValidationError::InvalidToken(format!("failed to record dpop proof jti: {e}"))
+                ValidationError::DpopReplayUnavailable(format!(
+                    "failed to record dpop proof jti: {e}"
+                ))
             })
     }
 }
@@ -190,6 +192,6 @@ mod tests {
             .check_and_record_dpop_jti("jti-1", Utc::now())
             .await
             .expect_err("the fail-closed default must refuse every proof");
-        assert!(matches!(err, ValidationError::InvalidToken(_)));
+        assert!(matches!(err, ValidationError::DpopReplayUnavailable(_)));
     }
 }

--- a/crates/authkestra-resource/src/dpop.rs
+++ b/crates/authkestra-resource/src/dpop.rs
@@ -1,0 +1,195 @@
+//! DPoP (RFC 9449) replay tracking for the resource server.
+//!
+//! This is the [`JwtStrategy`](crate::jwt::JwtStrategy)-side counterpart to
+//! `authkestra_engine::token::dpop::verify_dpop_proof`, which verifies one
+//! proof in isolation and deliberately does not track replay itself (see
+//! that module's doc comment).
+//!
+//! Deliberately independent from `authkestra-op`'s own DPoP replay guard:
+//! an authorization server and a resource server are commonly separate
+//! deployments — even separate processes on separate hosts — each needing
+//! its own record of which `jti`s it has already seen for proofs presented
+//! *to it*. The OP's `/token`-endpoint replay guard has no visibility into,
+//! and no bearing on, a fresh proof a client mints when calling a protected
+//! resource; that is a second value from the client's key, with its own
+//! `jti`, that this crate must independently track.
+
+use crate::jwt::ValidationError;
+use authkestra_engine::store::{AtomicInsert, KvStore};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// The freshness window a DPoP proof presented to a protected resource is
+/// checked against, and, by the same convention
+/// `authkestra_engine::token::dpop::verify_dpop_proof`'s own doc comment
+/// establishes, the TTL a caller should use when recording its `jti`.
+pub const DPOP_PROOF_MAX_AGE_SECS: i64 = 60;
+
+/// Records that a DPoP proof's `jti` has been spent, for proofs presented
+/// to this resource server.
+///
+/// `check_and_record_dpop_jti` **must** be atomic — a `get`-then-`set`
+/// implemented as two separate storage calls is a TOCTOU race, and the race
+/// is precisely the replay this trait exists to prevent: two concurrent
+/// presentations of the same captured proof would both observe "not yet
+/// seen".
+#[async_trait::async_trait]
+pub trait DpopReplayStore: Send + Sync {
+    /// Atomically records `jti` as spent until `expires_at`.
+    ///
+    /// Returns `Ok(true)` if this is its first use (accept the proof) and
+    /// `Ok(false)` if it was already recorded (a replay — reject).
+    async fn check_and_record_dpop_jti(
+        &self,
+        jti: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<bool, ValidationError>;
+}
+
+/// The fail-closed default: refuses every proof.
+///
+/// A deployment that has not wired replay tracking cannot provide the
+/// single-use guarantee RFC 9449 §11.1 calls for, and accepting proofs
+/// without it would be strictly worse than not checking DPoP at the
+/// resource server at all — clients would believe they had sender-
+/// constrained tokens while a captured proof stayed replayable for its
+/// whole freshness window. So the default refuses rather than silently
+/// degrades — same rationale as `authkestra_op::dpop::NoDpopReplayStore`.
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct NoDpopReplayStore;
+
+#[async_trait::async_trait]
+impl DpopReplayStore for NoDpopReplayStore {
+    async fn check_and_record_dpop_jti(
+        &self,
+        _jti: &str,
+        _expires_at: DateTime<Utc>,
+    ) -> Result<bool, ValidationError> {
+        tracing::error!(
+            "a DPoP-bound access token was presented along with a DPoP proof, but no \
+             DpopReplayStore is wired into this JwtStrategy; refusing it rather than accepting \
+             a proof that could be replayed"
+        );
+        Err(ValidationError::InvalidToken(
+            "DPoP replay protection is not configured".to_string(),
+        ))
+    }
+}
+
+/// The record a `DpopReplayStore` backend persists for one spent `jti`.
+///
+/// `#[non_exhaustive]` blocks struct-literal construction from outside this
+/// crate, but storage-backend implementations must be able to reconstruct
+/// this from their own persisted fields — this is the seam that makes that
+/// possible.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct DpopJtiRecord {
+    /// The spent `jti` value. Redundant with the store key it's saved
+    /// under, but kept on the record itself so a backend that reconstructs
+    /// rows generically (e.g. by scanning) doesn't need the key threaded
+    /// separately.
+    pub jti: String,
+    /// When this record — and the replay protection it provides — expires.
+    pub expires_at: DateTime<Utc>,
+}
+
+impl DpopJtiRecord {
+    /// Creates a new record for a freshly spent `jti`.
+    pub fn new(jti: String, expires_at: DateTime<Utc>) -> Self {
+        Self { jti, expires_at }
+    }
+}
+
+/// Blanket impl over any backend that is a `KvStore` with atomic
+/// insert-if-absent — every backend `authkestra_engine::store::AtomicInsert`
+/// is implemented for (Memory, Redis, Postgres, Sqlite, MySQL) gets
+/// `DpopReplayStore` for free, with no DPoP-specific storage code at all.
+#[async_trait::async_trait]
+impl<S> DpopReplayStore for S
+where
+    S: KvStore<DpopJtiRecord> + AtomicInsert<DpopJtiRecord>,
+{
+    async fn check_and_record_dpop_jti(
+        &self,
+        jti: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<bool, ValidationError> {
+        tracing::trace!("attempting to record dpop proof jti");
+        let ttl = expires_at
+            .signed_duration_since(Utc::now())
+            .to_std()
+            .unwrap_or(Duration::from_secs(0));
+
+        self.insert_if_absent(jti, DpopJtiRecord::new(jti.to_string(), expires_at), ttl)
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "failed to record dpop proof jti");
+                ValidationError::InvalidToken(format!("failed to record dpop proof jti: {e}"))
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use authkestra_engine::store::memory::MemoryStore;
+
+    #[tokio::test]
+    async fn first_use_of_a_jti_is_accepted() {
+        let store = MemoryStore::<DpopJtiRecord>::new();
+        let expires_at = Utc::now() + chrono::Duration::seconds(60);
+
+        let accepted = store
+            .check_and_record_dpop_jti("jti-1", expires_at)
+            .await
+            .unwrap();
+        assert!(accepted);
+    }
+
+    #[tokio::test]
+    async fn a_replayed_jti_is_rejected() {
+        let store = MemoryStore::<DpopJtiRecord>::new();
+        let expires_at = Utc::now() + chrono::Duration::seconds(60);
+
+        assert!(store
+            .check_and_record_dpop_jti("jti-1", expires_at)
+            .await
+            .unwrap());
+
+        let replayed = store
+            .check_and_record_dpop_jti("jti-1", expires_at)
+            .await
+            .unwrap();
+        assert!(
+            !replayed,
+            "a second presentation of the same jti must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn distinct_jtis_are_independent() {
+        let store = MemoryStore::<DpopJtiRecord>::new();
+        let expires_at = Utc::now() + chrono::Duration::seconds(60);
+
+        assert!(store
+            .check_and_record_dpop_jti("jti-1", expires_at)
+            .await
+            .unwrap());
+        assert!(store
+            .check_and_record_dpop_jti("jti-2", expires_at)
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn no_dpop_replay_store_fails_closed() {
+        let err = NoDpopReplayStore
+            .check_and_record_dpop_jti("jti-1", Utc::now())
+            .await
+            .expect_err("the fail-closed default must refuse every proof");
+        assert!(matches!(err, ValidationError::InvalidToken(_)));
+    }
+}

--- a/crates/authkestra-resource/src/jwt.rs
+++ b/crates/authkestra-resource/src/jwt.rs
@@ -18,7 +18,16 @@ use thiserror::Error;
 use tokio::sync::RwLock;
 
 /// Errors that can occur during offline validation.
+///
+/// `#[non_exhaustive]` for the same reason [`ValidationConfig`] is (see its
+/// doc comment): a new error condition — like [`ValidationError::
+/// DpopReplayUnavailable`], added after this enum first shipped without
+/// this attribute — must be addable without forcing every downstream
+/// exhaustive `match` to break. That break was demonstrated in-tree:
+/// adding that variant needed a new arm in `authkestra-oidc`'s own match
+/// over this enum, in the same crate this ships from.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ValidationError {
     #[error("HTTP error: {0}")]
     Http(#[from] reqwest::Error),
@@ -308,16 +317,36 @@ pub struct ValidationConfig {
     /// DPoP-bound and this check is a no-op for it, regardless of this
     /// setting. See [`JwtStrategy`] and issue #274.
     ///
-    /// Deliberately does **not** check `htm`/`htu`: unlike an authorization
-    /// server's single, statically-known `/token` endpoint, a resource
-    /// server protects many routes and commonly sits behind a reverse
-    /// proxy or load balancer, where the exact absolute URL a client used
-    /// isn't always reliably reconstructible from the request alone. Key
-    /// binding, `ath`, and `jti` replay tracking together still mean a
-    /// captured proof cannot be reused for a different token, or reused at
-    /// all — see `authkestra_engine::token::dpop::verify_dpop_proof`'s doc
-    /// comment on its `expected_htu: None` case for the full reasoning.
+    /// `htm` (the request's HTTP method) is always checked. `htu` — the
+    /// absolute URL the proof was minted for — is checked only when
+    /// [`dpop_resource_origin`](Self::dpop_resource_origin) is configured;
+    /// see that field for why it's opt-in rather than always-on. Without
+    /// it, key binding, `ath`, and `jti` replay tracking together still
+    /// mean a captured proof cannot be reused for a different token, or
+    /// reused at all — but a legitimate holder of a still-fresh proof
+    /// (a downstream service the request was forwarded to, say) could
+    /// present the same token+proof pair to a *different* resource server
+    /// within the proof's freshness window; `htu` is what closes that gap.
     pub require_dpop: bool,
+    /// This resource server's own origin (scheme + host, e.g.
+    /// `"https://api.example.com"` — no path, no trailing slash), used to
+    /// reconstruct the current request's absolute URL and check it against
+    /// a DPoP proof's `htu` claim (RFC 9449 §4.3 step 6).
+    ///
+    /// `None` (the default) skips the `htu` check entirely: unlike an
+    /// authorization server's single, statically-known `/token` endpoint,
+    /// a resource server protects many routes and commonly sits behind a
+    /// reverse proxy or load balancer, where the exact absolute URL a
+    /// client used isn't always reliably reconstructible from the request
+    /// alone (the scheme in particular depends on where TLS terminates,
+    /// which application code can't always see) — see
+    /// `authkestra_engine::token::dpop::verify_dpop_proof`'s doc comment on
+    /// its `expected_htu: None` case. A deployment that *can* state its own
+    /// origin reliably (no proxy, or one that's configured to preserve or
+    /// forward it accurately) should set this to close the cross-service
+    /// forwarding gap [`require_dpop`](Self::require_dpop) documents.
+    /// Only consulted when `require_dpop` is also `true`.
+    pub dpop_resource_origin: Option<String>,
     /// Trust map of `iss` -> JWKS endpoint, for a resource server that accepts
     /// tokens from several issuers. Empty by default, which keeps the
     /// single-issuer `jwks_url` path unchanged. When non-empty, an `iss` absent
@@ -345,6 +374,7 @@ pub struct ValidationConfigBuilder {
     require_kid: bool,
     require_cert_binding: bool,
     require_dpop: bool,
+    dpop_resource_origin: Option<String>,
     trusted_issuers: BTreeMap<String, String>,
 }
 
@@ -456,6 +486,15 @@ impl ValidationConfigBuilder {
         self
     }
 
+    /// Set [`ValidationConfig::dpop_resource_origin`], enabling the `htu`
+    /// half of the RFC 9449 DPoP check. `origin` is scheme + host only
+    /// (e.g. `"https://api.example.com"`) — no path, no trailing slash;
+    /// the request's own path is appended at check time.
+    pub fn dpop_resource_origin(mut self, origin: impl Into<String>) -> Self {
+        self.dpop_resource_origin = Some(origin.into());
+        self
+    }
+
     /// Build a `ValidationConfig`.
     ///
     /// # Panics
@@ -492,6 +531,7 @@ impl ValidationConfigBuilder {
             require_kid: self.require_kid,
             require_cert_binding: self.require_cert_binding,
             require_dpop: self.require_dpop,
+            dpop_resource_origin: self.dpop_resource_origin,
             trusted_issuers: self.trusted_issuers,
         }
     }
@@ -504,6 +544,7 @@ pub struct JwtStrategy<I> {
     validation: Validation,
     require_cert_binding: bool,
     require_dpop: bool,
+    dpop_resource_origin: Option<String>,
     dpop_replay_store: Arc<dyn crate::dpop::DpopReplayStore>,
     _marker: std::marker::PhantomData<I>,
 }
@@ -524,6 +565,7 @@ impl<I> JwtStrategy<I> {
             validation: build_validation(&config, !config.trusted_issuers.is_empty()),
             require_cert_binding: config.require_cert_binding,
             require_dpop: config.require_dpop,
+            dpop_resource_origin: config.dpop_resource_origin,
             dpop_replay_store: Arc::new(crate::dpop::NoDpopReplayStore),
             _marker: std::marker::PhantomData,
         }
@@ -547,6 +589,7 @@ impl<I> JwtStrategy<I> {
             validation: build_validation(&config, true),
             require_cert_binding: config.require_cert_binding,
             require_dpop: config.require_dpop,
+            dpop_resource_origin: config.dpop_resource_origin,
             dpop_replay_store: Arc::new(crate::dpop::NoDpopReplayStore),
             _marker: std::marker::PhantomData,
         }
@@ -726,27 +769,40 @@ where
                         }
 
                         if self.require_dpop {
-                            let is_dpop_bound = cnf_claim
-                                .cnf
-                                .as_ref()
-                                .and_then(|v| v.get("jkt"))
-                                .and_then(|v| v.as_str())
-                                .is_some();
+                            let is_dpop_bound = dpop_bound_jkt(cnf_claim.cnf.as_ref()).is_some();
 
-                            // RFC 9449 §7.1: a DPoP-bound token MUST be
+                            // RFC 9449 §7.1, both directions of the same
+                            // requirement: a DPoP-bound token MUST be
                             // presented via the `DPoP` auth-scheme, never
-                            // `Bearer` — checked independently of whether a
-                            // `DPoP` proof header also happens to be
-                            // present, since accepting either scheme for a
-                            // bound token would let a client (or attacker
-                            // holding a stolen token) simply choose the
-                            // scheme requiring no proof at all.
-                            if is_dpop_bound && !matches!(presented, PresentedToken::DPoP(_)) {
-                                tracing::warn!(
-                                    "token is DPoP-bound (cnf.jkt) but was presented via the \
-                                     Bearer scheme, not DPoP; rejecting"
-                                );
-                                return Ok(None);
+                            // `Bearer`, and a request presented via `DPoP`
+                            // MUST carry a token that actually has a
+                            // confirmation claim to check. The first is
+                            // checked independently of whether a `DPoP`
+                            // proof header also happens to be present,
+                            // since accepting either scheme for a bound
+                            // token would let a client (or attacker holding
+                            // a stolen token) simply choose the scheme
+                            // requiring no proof at all. Neither case falls
+                            // out of `verify_dpop_binding` on its own: an
+                            // absent `cnf.jkt` makes it a no-op by design
+                            // (mirroring `verify_cert_binding`), which is
+                            // correct for `Bearer` but not for `DPoP`.
+                            match (presented, is_dpop_bound) {
+                                (PresentedToken::Bearer(_), true) => {
+                                    tracing::warn!(
+                                        "token is DPoP-bound (cnf.jkt) but was presented via \
+                                         the Bearer scheme, not DPoP; rejecting"
+                                    );
+                                    return Ok(None);
+                                }
+                                (PresentedToken::DPoP(_), false) => {
+                                    tracing::warn!(
+                                        "request used the DPoP auth-scheme but the token \
+                                         carries no cnf.jkt confirmation claim; rejecting"
+                                    );
+                                    return Ok(None);
+                                }
+                                _ => {}
                             }
 
                             let dpop_header = match extract_dpop_header(&parts.headers) {
@@ -757,9 +813,15 @@ where
                                 }
                             };
 
+                            let htu = self
+                                .dpop_resource_origin
+                                .as_deref()
+                                .map(|origin| format!("{origin}{}", parts.uri.path()));
+
                             match verify_dpop_binding(
                                 dpop_header,
                                 parts.method.as_str(),
+                                htu.as_deref(),
                                 token,
                                 cnf_claim.cnf.as_ref(),
                                 self.dpop_replay_store.as_ref(),
@@ -863,6 +925,7 @@ pub fn verify_cert_binding(
 /// among a token's own claims says which scheme it *arrived* under, only
 /// [`JwtStrategy::authenticate`] observing the header directly can, and
 /// only if this type keeps the two apart.
+#[derive(Clone, Copy)]
 enum PresentedToken<'a> {
     Bearer(&'a str),
     DPoP(&'a str),
@@ -882,13 +945,28 @@ impl<'a> PresentedToken<'a> {
 /// in this workspace and has no reason to know about DPoP.
 fn extract_presented_token(headers: &http::HeaderMap) -> Option<PresentedToken<'_>> {
     let value = headers.get(http::header::AUTHORIZATION)?.to_str().ok()?;
-    if let Some(token) = value.strip_prefix("DPoP ") {
-        return Some(PresentedToken::DPoP(token.trim()));
+    if let Some(token) = strip_scheme_ci(value, "DPoP") {
+        return Some(PresentedToken::DPoP(token));
     }
-    if let Some(token) = value.strip_prefix("Bearer ") {
-        return Some(PresentedToken::Bearer(token.trim()));
+    if let Some(token) = strip_scheme_ci(value, "Bearer") {
+        return Some(PresentedToken::Bearer(token));
     }
     None
+}
+
+/// Strips an `Authorization` header's auth-scheme token and the single
+/// space after it, comparing the scheme case-insensitively per RFC 9110
+/// §11.1 ("the auth-scheme value is case-insensitive"). A plain
+/// `strip_prefix("DPoP ")` would silently reject `dpop <token>` — a
+/// case a real client sending a lowercase scheme would hit with no
+/// diagnostic at all, since a parse miss here just falls through to
+/// `Ok(None)` ("no credential presented").
+fn strip_scheme_ci<'a>(value: &'a str, scheme: &str) -> Option<&'a str> {
+    let (candidate, rest) = value.split_at_checked(scheme.len())?;
+    if !candidate.eq_ignore_ascii_case(scheme) {
+        return None;
+    }
+    rest.strip_prefix(' ').map(str::trim)
 }
 
 /// Reads the request's `DPoP` header (RFC 9449 §4.1: exactly one is
@@ -922,15 +1000,31 @@ fn compute_ath(access_token: &str) -> String {
     x5t_s256_thumbprint(access_token.as_bytes())
 }
 
+/// Reads `cnf.jkt` out of a decoded token's `cnf` claim, if present — the
+/// single "is this token DPoP-bound" predicate, shared by
+/// [`JwtStrategy::authenticate`] (which needs it to decide whether the
+/// `DPoP` auth-scheme is required) and [`verify_dpop_binding`] (which needs
+/// it to know what key a presented proof must match). Kept as one function
+/// so the two call sites can't drift apart on what "bound" means.
+fn dpop_bound_jkt(cnf: Option<&serde_json::Value>) -> Option<&str> {
+    cnf.and_then(|v| v.get("jkt")).and_then(|v| v.as_str())
+}
+
 /// Verifies RFC 9449 DPoP key binding for a decoded token's `cnf` claim.
 ///
 /// - If the token carries no `cnf.jkt` claim at all, it is not DPoP-bound;
 ///   this always succeeds (nothing to check) — mirrors
 ///   [`verify_cert_binding`]'s identical "absent means not bound" shape.
-/// - If it does, `dpop_header` must be present, and the proof it contains
-///   must: verify (signature, `typ`, freshness), bind to `access_token` via
-///   `ath`, and carry the same key as `cnf.jkt`. `htu` is deliberately not
-///   checked — see [`ValidationConfig::require_dpop`]'s doc comment.
+///   `JwtStrategy::authenticate` is responsible for rejecting the *other*
+///   mismatch this function can't see on its own — a request presented via
+///   the `DPoP` auth-scheme for a token that isn't actually bound.
+/// - If it is bound, `dpop_header` must be present, and the proof it
+///   contains must: verify (signature, `typ`, freshness), bind to
+///   `access_token` via `ath`, carry the same key as `cnf.jkt`, and — when
+///   `htu` is `Some` — have been minted for this exact URL. `htu` is
+///   `None` unless the caller configured
+///   [`ValidationConfig::dpop_resource_origin`]; see that field's doc
+///   comment for why it's opt-in.
 /// - Finally, the proof's `jti` is checked and recorded via
 ///   `replay_store`: a DPoP-bound token is **never** accepted with a reused
 ///   proof, and a proof that can't be recorded at all (e.g. no replay store
@@ -938,11 +1032,12 @@ fn compute_ath(access_token: &str) -> String {
 pub async fn verify_dpop_binding(
     dpop_header: Option<&str>,
     htm: &str,
+    htu: Option<&str>,
     access_token: &str,
     cnf: Option<&serde_json::Value>,
     replay_store: &dyn crate::dpop::DpopReplayStore,
 ) -> Result<(), ValidationError> {
-    let Some(expected_jkt) = cnf.and_then(|v| v.get("jkt")).and_then(|v| v.as_str()) else {
+    let Some(expected_jkt) = dpop_bound_jkt(cnf) else {
         return Ok(());
     };
 
@@ -956,7 +1051,7 @@ pub async fn verify_dpop_binding(
     let verified = authkestra_engine::token::dpop::verify_dpop_proof(
         proof,
         htm,
-        None,
+        htu,
         Some(&ath),
         chrono::Duration::seconds(crate::dpop::DPOP_PROOF_MAX_AGE_SECS),
     )
@@ -1327,13 +1422,14 @@ mod tests {
             // wired — it must never be consulted for a token that isn't
             // DPoP-bound in the first place.
             assert!(
-                verify_dpop_binding(None, "GET", "token", None, &NoDpopReplayStore)
+                verify_dpop_binding(None, "GET", None, "token", None, &NoDpopReplayStore)
                     .await
                     .is_ok()
             );
             assert!(verify_dpop_binding(
                 Some("some-proof"),
                 "GET",
+                None,
                 "token",
                 Some(&serde_json::json!({ "x5t#S256": "unrelated" })),
                 &NoDpopReplayStore,
@@ -1353,6 +1449,7 @@ mod tests {
             verify_dpop_binding(
                 Some(&builder.build()),
                 "GET",
+                None,
                 access_token,
                 Some(&cnf),
                 &store,
@@ -1366,9 +1463,10 @@ mod tests {
             let builder = DpopProofBuilder::with_key_seed(11, "jti-2");
             let cnf = cnf_with_jkt(&builder.expected_jkt());
 
-            let err = verify_dpop_binding(None, "GET", "token", Some(&cnf), &NoDpopReplayStore)
-                .await
-                .expect_err("a DPoP-bound token presented with no proof must be refused");
+            let err =
+                verify_dpop_binding(None, "GET", None, "token", Some(&cnf), &NoDpopReplayStore)
+                    .await
+                    .expect_err("a DPoP-bound token presented with no proof must be refused");
             assert!(matches!(err, ValidationError::InvalidToken(_)));
         }
 
@@ -1387,6 +1485,7 @@ mod tests {
             let err = verify_dpop_binding(
                 Some(&presented.build()),
                 "GET",
+                None,
                 access_token,
                 Some(&cnf),
                 &store,
@@ -1406,6 +1505,7 @@ mod tests {
             let err = verify_dpop_binding(
                 Some(&builder.build()),
                 "GET",
+                None,
                 "the-actual-access-token",
                 Some(&cnf),
                 &store,
@@ -1424,13 +1524,14 @@ mod tests {
             let cnf = cnf_with_jkt(&builder.expected_jkt());
             let proof = builder.build();
 
-            verify_dpop_binding(Some(&proof), "GET", access_token, Some(&cnf), &store)
+            verify_dpop_binding(Some(&proof), "GET", None, access_token, Some(&cnf), &store)
                 .await
                 .expect("first presentation of a fresh proof must succeed");
 
-            let err = verify_dpop_binding(Some(&proof), "GET", access_token, Some(&cnf), &store)
-                .await
-                .expect_err("replaying the same proof must be refused");
+            let err =
+                verify_dpop_binding(Some(&proof), "GET", None, access_token, Some(&cnf), &store)
+                    .await
+                    .expect_err("replaying the same proof must be refused");
             assert!(matches!(err, ValidationError::InvalidToken(_)));
         }
 
@@ -1444,6 +1545,7 @@ mod tests {
             let err = verify_dpop_binding(
                 Some(&builder.build()),
                 "GET",
+                None,
                 access_token,
                 Some(&cnf),
                 &NoDpopReplayStore,
@@ -1465,6 +1567,7 @@ mod tests {
             let err = verify_dpop_binding(
                 Some(&builder.build()),
                 "POST",
+                None,
                 access_token,
                 Some(&cnf),
                 &store,
@@ -1515,6 +1618,75 @@ mod tests {
             let err =
                 extract_dpop_header(&headers).expect_err("a non-ASCII header must be refused");
             assert!(matches!(err, ValidationError::InvalidToken(_)));
+        }
+    }
+
+    mod presented_token_tests {
+        use super::{extract_presented_token, PresentedToken};
+
+        fn authorization_headers(value: &str) -> http::HeaderMap {
+            let mut headers = http::HeaderMap::new();
+            headers.insert(
+                http::header::AUTHORIZATION,
+                http::HeaderValue::from_str(value).unwrap(),
+            );
+            headers
+        }
+
+        #[test]
+        fn recognizes_bearer() {
+            let headers = authorization_headers("Bearer abc123");
+            assert!(matches!(
+                extract_presented_token(&headers),
+                Some(PresentedToken::Bearer("abc123"))
+            ));
+        }
+
+        #[test]
+        fn recognizes_dpop() {
+            let headers = authorization_headers("DPoP abc123");
+            assert!(matches!(
+                extract_presented_token(&headers),
+                Some(PresentedToken::DPoP("abc123"))
+            ));
+        }
+
+        /// RFC 9110 §11.1: the auth-scheme token is case-insensitive. A
+        /// client that lowercases (or otherwise re-cases) the scheme name
+        /// must still be recognized, not silently treated as "no
+        /// credential presented" — the DPoP scheme is new surface with no
+        /// prior real-world clients to have already shaken this out.
+        #[test]
+        fn scheme_matching_is_case_insensitive() {
+            for value in ["dpop abc123", "DPOP abc123", "DpoP abc123"] {
+                assert!(
+                    matches!(
+                        extract_presented_token(&authorization_headers(value)),
+                        Some(PresentedToken::DPoP("abc123"))
+                    ),
+                    "{value:?} must be recognized as the DPoP scheme"
+                );
+            }
+            for value in ["bearer abc123", "BEARER abc123"] {
+                assert!(
+                    matches!(
+                        extract_presented_token(&authorization_headers(value)),
+                        Some(PresentedToken::Bearer("abc123"))
+                    ),
+                    "{value:?} must be recognized as the Bearer scheme"
+                );
+            }
+        }
+
+        #[test]
+        fn unrecognized_scheme_is_none() {
+            let headers = authorization_headers("Basic dXNlcjpwYXNz");
+            assert!(extract_presented_token(&headers).is_none());
+        }
+
+        #[test]
+        fn no_authorization_header_is_none() {
+            assert!(extract_presented_token(&http::HeaderMap::new()).is_none());
         }
     }
 }

--- a/crates/authkestra-resource/src/jwt.rs
+++ b/crates/authkestra-resource/src/jwt.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use authkestra_engine::{
     error::AuthError,
-    strategy::{utils, AuthenticationStrategy},
+    strategy::AuthenticationStrategy,
     token::{
         cert_binding::{constant_time_eq, x5t_s256_thumbprint, ClientCertificateDer},
         Claims,
@@ -46,6 +46,16 @@ pub enum ValidationError {
     Discovery(#[from] AuthError),
     #[error("Validation error: {0}")]
     Validation(String),
+    /// A DPoP proof's `jti` could not be checked for replay — the
+    /// configured `DpopReplayStore` errored, or none is configured at all
+    /// (the fail-closed `NoDpopReplayStore` default). Deliberately a
+    /// distinct variant from `InvalidToken`: this is never "the credential
+    /// is bad", it's "we could not determine whether it is", which
+    /// `JwtStrategy::authenticate` must propagate as a hard `AuthError`
+    /// rather than `Ok(None)` — see that method for why the distinction
+    /// matters under `AuthPolicy::FirstSuccess`.
+    #[error("DPoP replay protection could not be checked: {0}")]
+    DpopReplayUnavailable(String),
 }
 
 pub use authkestra_engine::token::jwk::Jwk;
@@ -652,7 +662,8 @@ where
     I: for<'de> Deserialize<'de> + Send + Sync + 'static,
 {
     async fn authenticate(&self, parts: &Parts) -> Result<Option<I>, AuthError> {
-        if let Some(token) = utils::extract_bearer_token(&parts.headers) {
+        if let Some(presented) = extract_presented_token(&parts.headers) {
+            let token = presented.token();
             // Resolve once and reuse the same cache below: which JWKS applies is
             // a property of the token, so re-resolving for the `cnf` re-decode
             // could only introduce a discrepancy.
@@ -715,6 +726,29 @@ where
                         }
 
                         if self.require_dpop {
+                            let is_dpop_bound = cnf_claim
+                                .cnf
+                                .as_ref()
+                                .and_then(|v| v.get("jkt"))
+                                .and_then(|v| v.as_str())
+                                .is_some();
+
+                            // RFC 9449 §7.1: a DPoP-bound token MUST be
+                            // presented via the `DPoP` auth-scheme, never
+                            // `Bearer` — checked independently of whether a
+                            // `DPoP` proof header also happens to be
+                            // present, since accepting either scheme for a
+                            // bound token would let a client (or attacker
+                            // holding a stolen token) simply choose the
+                            // scheme requiring no proof at all.
+                            if is_dpop_bound && !matches!(presented, PresentedToken::DPoP(_)) {
+                                tracing::warn!(
+                                    "token is DPoP-bound (cnf.jkt) but was presented via the \
+                                     Bearer scheme, not DPoP; rejecting"
+                                );
+                                return Ok(None);
+                            }
+
                             let dpop_header = match extract_dpop_header(&parts.headers) {
                                 Ok(h) => h,
                                 Err(e) => {
@@ -723,7 +757,7 @@ where
                                 }
                             };
 
-                            if let Err(e) = verify_dpop_binding(
+                            match verify_dpop_binding(
                                 dpop_header,
                                 parts.method.as_str(),
                                 token,
@@ -732,8 +766,31 @@ where
                             )
                             .await
                             {
-                                tracing::warn!(error = %e, "RFC 9449 DPoP binding check failed; rejecting token");
-                                return Ok(None);
+                                Ok(()) => {}
+                                // The credential itself is bad (missing/malformed
+                                // proof, wrong key, wrong ath, already-used jti,
+                                // wrong method) — decline this strategy, same as
+                                // every other "invalid token" outcome above.
+                                Err(e @ ValidationError::InvalidToken(_)) => {
+                                    tracing::warn!(error = %e, "RFC 9449 DPoP binding check failed; rejecting token");
+                                    return Ok(None);
+                                }
+                                // Replay protection could not be *checked* at
+                                // all (store errored, or none is configured) —
+                                // this is not "the token is invalid", it's "we
+                                // don't know", and must not be reported as
+                                // `Ok(None)`: under `AuthPolicy::FirstSuccess` a
+                                // `Guard` chain would treat that as "this
+                                // strategy declined, try the next one", letting
+                                // a replay-store outage silently authenticate
+                                // the request with the DPoP check skipped
+                                // entirely. Propagating `Err` here matches how
+                                // the JWKS-resolution failure above is already
+                                // handled, for the identical reason.
+                                Err(e) => {
+                                    tracing::warn!(error = %e, "could not verify DPoP replay protection; rejecting request");
+                                    return Err(AuthError::Token(e.to_string()));
+                                }
                             }
                         }
                     }
@@ -792,6 +849,46 @@ pub fn verify_cert_binding(
         )),
         (_, None) => Ok(()),
     }
+}
+
+/// The credential carried by a request's `Authorization` header, tagged by
+/// which auth-scheme carried it.
+///
+/// RFC 9449 §7.1 requires a DPoP-bound access token be presented as
+/// `Authorization: DPoP <token>`, never `Bearer <token>` — the two schemes
+/// are not interchangeable spellings of "here is a token". A resource
+/// server that pulled the token out without recording which scheme it
+/// arrived under (as `authkestra_engine::strategy::utils::extract_bearer_token` alone does — it only
+/// recognizes `Bearer`) could never enforce that distinction: nothing
+/// among a token's own claims says which scheme it *arrived* under, only
+/// [`JwtStrategy::authenticate`] observing the header directly can, and
+/// only if this type keeps the two apart.
+enum PresentedToken<'a> {
+    Bearer(&'a str),
+    DPoP(&'a str),
+}
+
+impl<'a> PresentedToken<'a> {
+    fn token(&self) -> &'a str {
+        match self {
+            PresentedToken::Bearer(t) | PresentedToken::DPoP(t) => t,
+        }
+    }
+}
+
+/// Reads the request's `Authorization` header, recognizing both the
+/// `Bearer` and `DPoP` schemes (RFC 9449 §7.1) — unlike
+/// `authkestra_engine::strategy::utils::extract_bearer_token`, which exists for every other strategy
+/// in this workspace and has no reason to know about DPoP.
+fn extract_presented_token(headers: &http::HeaderMap) -> Option<PresentedToken<'_>> {
+    let value = headers.get(http::header::AUTHORIZATION)?.to_str().ok()?;
+    if let Some(token) = value.strip_prefix("DPoP ") {
+        return Some(PresentedToken::DPoP(token.trim()));
+    }
+    if let Some(token) = value.strip_prefix("Bearer ") {
+        return Some(PresentedToken::Bearer(token.trim()));
+    }
+    None
 }
 
 /// Reads the request's `DPoP` header (RFC 9449 §4.1: exactly one is
@@ -871,8 +968,18 @@ pub async fn verify_dpop_binding(
         ));
     }
 
-    let expires_at =
-        chrono::Utc::now() + chrono::Duration::seconds(crate::dpop::DPOP_PROOF_MAX_AGE_SECS);
+    // Anchored to the proof's own `iat`, not the current time — see the
+    // identical comment on the OP-side `/token` DPoP check
+    // (`authkestra_op::handlers::token::handle_token_with_client_cert`)
+    // for the full reasoning: anchoring to `Utc::now()` instead would let
+    // the replay record expire before the proof's own freshness boundary
+    // (`iat + max_age`) whenever this request is processed even slightly
+    // after `iat`, opening a real, if narrow, replay window. The extra
+    // second guards the exact boundary instant itself.
+    let expires_at = chrono::DateTime::<chrono::Utc>::from_timestamp(verified.iat, 0)
+        .unwrap_or_else(chrono::Utc::now)
+        + chrono::Duration::seconds(crate::dpop::DPOP_PROOF_MAX_AGE_SECS)
+        + chrono::Duration::seconds(1);
     match replay_store
         .check_and_record_dpop_jti(&verified.jti, expires_at)
         .await
@@ -1343,7 +1450,7 @@ mod tests {
             )
             .await
             .expect_err("no replay store is wired; an otherwise-valid proof must be refused");
-            assert!(matches!(err, ValidationError::InvalidToken(_)));
+            assert!(matches!(err, ValidationError::DpopReplayUnavailable(_)));
         }
 
         #[tokio::test]

--- a/crates/authkestra-resource/src/jwt.rs
+++ b/crates/authkestra-resource/src/jwt.rs
@@ -489,7 +489,8 @@ impl ValidationConfigBuilder {
     /// Set [`ValidationConfig::dpop_resource_origin`], enabling the `htu`
     /// half of the RFC 9449 DPoP check. `origin` is scheme + host only
     /// (e.g. `"https://api.example.com"`) — no path, no trailing slash;
-    /// the request's own path is appended at check time.
+    /// the request's own path is appended at check time. [`Self::build`]
+    /// panics if `origin` is missing a scheme or ends with `/`.
     pub fn dpop_resource_origin(mut self, origin: impl Into<String>) -> Self {
         self.dpop_resource_origin = Some(origin.into());
         self
@@ -504,6 +505,21 @@ impl ValidationConfigBuilder {
     /// be no key material at all. A trust-map-only config leaves `jwks_url`
     /// empty; an empty `jwks_url` is never fetched from, it just means "no
     /// single-issuer endpoint".
+    ///
+    /// Also panics if [`dpop_resource_origin`](Self::dpop_resource_origin)
+    /// was set to a value with no scheme, or with a trailing slash. Both
+    /// shapes are easy typos (`"api.example.com"` instead of
+    /// `"https://api.example.com"`; `"https://api.example.com/"` instead of
+    /// without the trailing `/`) that would otherwise silently break every
+    /// DPoP request once `require_dpop` is on: the request's own path
+    /// (which always starts with `/`) is joined directly onto this value at
+    /// check time, so a trailing slash produces a doubled `//` that will
+    /// never match any proof's genuine `htu`, and a missing scheme produces
+    /// a string `url::Url` can't parse as absolute, falling back to an
+    /// exact-string comparison that also never matches. Either mistake
+    /// fails every single request with only a `tracing::warn!`,
+    /// indistinguishable from an actual attack — checking the shape here,
+    /// once, at startup, is cheaper than debugging that in production.
     pub fn build(self) -> ValidationConfig {
         let jwks_url = match self.jwks_url {
             Some(jwks_url) => jwks_url,
@@ -515,6 +531,20 @@ impl ValidationConfigBuilder {
                 String::new()
             }
         };
+
+        if let Some(origin) = &self.dpop_resource_origin {
+            assert!(
+                origin.starts_with("http://") || origin.starts_with("https://"),
+                "ValidationConfigBuilder::dpop_resource_origin must include a scheme \
+                 (e.g. \"https://api.example.com\"), got {origin:?}"
+            );
+            assert!(
+                !origin.ends_with('/'),
+                "ValidationConfigBuilder::dpop_resource_origin must not end with a trailing \
+                 slash — it's joined directly with the request's own path, which always \
+                 starts with one — got {origin:?}"
+            );
+        }
 
         ValidationConfig {
             jwks_url,
@@ -1687,6 +1717,47 @@ mod tests {
         #[test]
         fn no_authorization_header_is_none() {
             assert!(extract_presented_token(&http::HeaderMap::new()).is_none());
+        }
+    }
+
+    mod dpop_resource_origin_validation_tests {
+        use super::ValidationConfig;
+
+        #[test]
+        fn a_well_formed_origin_is_accepted() {
+            let config = ValidationConfig::builder()
+                .jwks_url("https://issuer.example.com/.well-known/jwks.json")
+                .dpop_resource_origin("https://api.example.com")
+                .build();
+            assert_eq!(
+                config.dpop_resource_origin.as_deref(),
+                Some("https://api.example.com")
+            );
+        }
+
+        /// A missing scheme would make every DPoP request fail: the
+        /// reconstructed `htu` couldn't be parsed as an absolute URL,
+        /// falling back to an exact-string comparison against the proof's
+        /// genuine (scheme-carrying) `htu`, which can never match.
+        #[test]
+        #[should_panic(expected = "must include a scheme")]
+        fn a_scheme_less_origin_panics() {
+            ValidationConfig::builder()
+                .jwks_url("https://issuer.example.com/.well-known/jwks.json")
+                .dpop_resource_origin("api.example.com")
+                .build();
+        }
+
+        /// A trailing slash would double up with the request's own
+        /// leading `/`, producing a `//` the genuine proof's `htu` never
+        /// has — also failing every request.
+        #[test]
+        #[should_panic(expected = "trailing slash")]
+        fn a_trailing_slash_origin_panics() {
+            ValidationConfig::builder()
+                .jwks_url("https://issuer.example.com/.well-known/jwks.json")
+                .dpop_resource_origin("https://api.example.com/")
+                .build();
         }
     }
 }

--- a/crates/authkestra-resource/src/jwt.rs
+++ b/crates/authkestra-resource/src/jwt.rs
@@ -286,6 +286,28 @@ pub struct ValidationConfig {
     /// bearer token, same as before this option existed. See
     /// [`JwtStrategy`] and issue #224.
     pub require_cert_binding: bool,
+    /// When `true`, enforce RFC 9449 DPoP key binding: a token carrying a
+    /// `cnf.jkt` claim is only accepted if the request presents a `DPoP`
+    /// header whose proof verifies for the same key, binds (`ath`) to
+    /// *this* access token, and hasn't been seen before (tracked via
+    /// [`JwtStrategy::with_dpop_replay_store`]). Off by default for
+    /// backward compatibility — with this `false`, a DPoP-bound token is
+    /// still accepted as a plain bearer token, same as before this option
+    /// existed. Mirrors [`ValidationConfig::require_cert_binding`]'s
+    /// design exactly: a token that carries *no* `cnf.jkt` at all is not
+    /// DPoP-bound and this check is a no-op for it, regardless of this
+    /// setting. See [`JwtStrategy`] and issue #274.
+    ///
+    /// Deliberately does **not** check `htm`/`htu`: unlike an authorization
+    /// server's single, statically-known `/token` endpoint, a resource
+    /// server protects many routes and commonly sits behind a reverse
+    /// proxy or load balancer, where the exact absolute URL a client used
+    /// isn't always reliably reconstructible from the request alone. Key
+    /// binding, `ath`, and `jti` replay tracking together still mean a
+    /// captured proof cannot be reused for a different token, or reused at
+    /// all — see `authkestra_engine::token::dpop::verify_dpop_proof`'s doc
+    /// comment on its `expected_htu: None` case for the full reasoning.
+    pub require_dpop: bool,
     /// Trust map of `iss` -> JWKS endpoint, for a resource server that accepts
     /// tokens from several issuers. Empty by default, which keeps the
     /// single-issuer `jwks_url` path unchanged. When non-empty, an `iss` absent
@@ -312,6 +334,7 @@ pub struct ValidationConfigBuilder {
     algorithms: Vec<Algorithm>,
     require_kid: bool,
     require_cert_binding: bool,
+    require_dpop: bool,
     trusted_issuers: BTreeMap<String, String>,
 }
 
@@ -412,6 +435,17 @@ impl ValidationConfigBuilder {
         self
     }
 
+    /// When `true`, enforce RFC 9449 DPoP key binding. See
+    /// [`ValidationConfig::require_dpop`]. Off by default. A deployment
+    /// enabling this should also call
+    /// [`JwtStrategy::with_dpop_replay_store`] — without one, the
+    /// fail-closed [`crate::dpop::NoDpopReplayStore`] default refuses every
+    /// DPoP-bound token outright.
+    pub fn require_dpop(mut self, value: bool) -> Self {
+        self.require_dpop = value;
+        self
+    }
+
     /// Build a `ValidationConfig`.
     ///
     /// # Panics
@@ -447,6 +481,7 @@ impl ValidationConfigBuilder {
             },
             require_kid: self.require_kid,
             require_cert_binding: self.require_cert_binding,
+            require_dpop: self.require_dpop,
             trusted_issuers: self.trusted_issuers,
         }
     }
@@ -458,6 +493,8 @@ pub struct JwtStrategy<I> {
     resolver: Box<dyn JwksResolver>,
     validation: Validation,
     require_cert_binding: bool,
+    require_dpop: bool,
+    dpop_replay_store: Arc<dyn crate::dpop::DpopReplayStore>,
     _marker: std::marker::PhantomData<I>,
 }
 
@@ -476,6 +513,8 @@ impl<I> JwtStrategy<I> {
             resolver,
             validation: build_validation(&config, !config.trusted_issuers.is_empty()),
             require_cert_binding: config.require_cert_binding,
+            require_dpop: config.require_dpop,
+            dpop_replay_store: Arc::new(crate::dpop::NoDpopReplayStore),
             _marker: std::marker::PhantomData,
         }
     }
@@ -497,8 +536,22 @@ impl<I> JwtStrategy<I> {
             // multi-issuer case, whether or not a static trust map accompanies it.
             validation: build_validation(&config, true),
             require_cert_binding: config.require_cert_binding,
+            require_dpop: config.require_dpop,
+            dpop_replay_store: Arc::new(crate::dpop::NoDpopReplayStore),
             _marker: std::marker::PhantomData,
         }
+    }
+
+    /// Supplies the [`crate::dpop::DpopReplayStore`] this strategy checks
+    /// DPoP proof `jti`s against, replacing the fail-closed
+    /// [`crate::dpop::NoDpopReplayStore`] default.
+    ///
+    /// Only meaningful alongside [`ValidationConfig::require_dpop`] — without
+    /// it, no token ever reaches the DPoP check this store backs, so a
+    /// deployment that calls this but not `require_dpop` sees no effect.
+    pub fn with_dpop_replay_store(mut self, store: Arc<dyn crate::dpop::DpopReplayStore>) -> Self {
+        self.dpop_replay_store = store;
+        self
     }
 }
 
@@ -622,17 +675,19 @@ where
 
             match validate_jwt_generic::<I>(token, &cache, &self.validation).await {
                 Ok(claims) => {
-                    if self.require_cert_binding {
-                        // Re-decode as `CnfClaim` to read `cnf.x5t#S256`
-                        // regardless of what identity type `I` the caller
-                        // asked for — `I` is not required to expose `cnf`
-                        // itself, so this can't be read off of `claims`
-                        // above. The token was already fully verified by the
-                        // decode above; this second decode reuses the same
-                        // cache/validation and cannot itself fail
-                        // differently, short of key rotation racing between
-                        // the two calls, which is treated the same as any
-                        // other verification failure: reject.
+                    if self.require_cert_binding || self.require_dpop {
+                        // Re-decode as `CnfClaim` to read `cnf` regardless of
+                        // what identity type `I` the caller asked for — `I`
+                        // is not required to expose `cnf` itself, so this
+                        // can't be read off of `claims` above. The token was
+                        // already fully verified by the decode above; this
+                        // second decode reuses the same cache/validation and
+                        // cannot itself fail differently, short of key
+                        // rotation racing between the two calls, which is
+                        // treated the same as any other verification
+                        // failure: reject. Shared between both checks below
+                        // since a token can carry both `cnf.x5t#S256` and
+                        // `cnf.jkt` at once (RFC 9449 §6.1).
                         let cnf_claim = match validate_jwt_generic::<CnfClaim>(
                             token,
                             &cache,
@@ -642,19 +697,44 @@ where
                         {
                             Ok(c) => c,
                             Err(e) => {
-                                tracing::warn!(error = %e, "failed to re-decode token while checking RFC 8705 certificate binding");
+                                tracing::warn!(error = %e, "failed to re-decode token while checking cnf-based binding");
                                 return Ok(None);
                             }
                         };
 
-                        let cert_der = parts
-                            .extensions
-                            .get::<ClientCertificateDer>()
-                            .map(|c| c.0.as_slice());
+                        if self.require_cert_binding {
+                            let cert_der = parts
+                                .extensions
+                                .get::<ClientCertificateDer>()
+                                .map(|c| c.0.as_slice());
 
-                        if let Err(e) = verify_cert_binding(cert_der, cnf_claim.cnf.as_ref()) {
-                            tracing::warn!(error = %e, "RFC 8705 certificate-binding check failed; rejecting token");
-                            return Ok(None);
+                            if let Err(e) = verify_cert_binding(cert_der, cnf_claim.cnf.as_ref()) {
+                                tracing::warn!(error = %e, "RFC 8705 certificate-binding check failed; rejecting token");
+                                return Ok(None);
+                            }
+                        }
+
+                        if self.require_dpop {
+                            let dpop_header = match extract_dpop_header(&parts.headers) {
+                                Ok(h) => h,
+                                Err(e) => {
+                                    tracing::warn!(error = %e, "malformed DPoP header; rejecting token");
+                                    return Ok(None);
+                                }
+                            };
+
+                            if let Err(e) = verify_dpop_binding(
+                                dpop_header,
+                                parts.method.as_str(),
+                                token,
+                                cnf_claim.cnf.as_ref(),
+                                self.dpop_replay_store.as_ref(),
+                            )
+                            .await
+                            {
+                                tracing::warn!(error = %e, "RFC 9449 DPoP binding check failed; rejecting token");
+                                return Ok(None);
+                            }
                         }
                     }
                     Ok(Some(claims))
@@ -711,6 +791,97 @@ pub fn verify_cert_binding(
                 .to_string(),
         )),
         (_, None) => Ok(()),
+    }
+}
+
+/// Reads the request's `DPoP` header (RFC 9449 §4.1: exactly one is
+/// expected). Returns `Ok(None)` if it's absent, `Ok(Some(value))` if
+/// exactly one occurrence is present and valid ASCII, or `Err` in two
+/// cases refused outright rather than tolerated: more than one occurrence
+/// (ambiguous which is authoritative — a proxy bug or smuggling attempt
+/// could produce this) and a value that isn't valid ASCII (treating it as
+/// "no header" would silently accept as a plain bearer token what the
+/// client believes is sender-constrained). Mirrors the identical helper in
+/// `authkestra-axum`/`authkestra-actix`'s `/token` handlers.
+fn extract_dpop_header(headers: &http::HeaderMap) -> Result<Option<&str>, ValidationError> {
+    let mut dpop_headers = headers.get_all("DPoP").iter();
+    match (dpop_headers.next(), dpop_headers.next()) {
+        (None, _) => Ok(None),
+        (Some(_), Some(_)) => Err(ValidationError::InvalidToken(
+            "multiple DPoP headers were presented".to_string(),
+        )),
+        (Some(v), None) => v.to_str().map(Some).map_err(|_| {
+            ValidationError::InvalidToken("DPoP header value is not valid ASCII".to_string())
+        }),
+    }
+}
+
+/// RFC 9449 §4.2's `ath` claim is `base64url(SHA256(access_token))` — the
+/// exact same computation `x5t_s256_thumbprint` already does, just over the
+/// access token's UTF-8 bytes instead of a certificate's DER bytes. Reusing
+/// it avoids a second three-line SHA-256-then-base64url helper for an
+/// identical operation.
+fn compute_ath(access_token: &str) -> String {
+    x5t_s256_thumbprint(access_token.as_bytes())
+}
+
+/// Verifies RFC 9449 DPoP key binding for a decoded token's `cnf` claim.
+///
+/// - If the token carries no `cnf.jkt` claim at all, it is not DPoP-bound;
+///   this always succeeds (nothing to check) — mirrors
+///   [`verify_cert_binding`]'s identical "absent means not bound" shape.
+/// - If it does, `dpop_header` must be present, and the proof it contains
+///   must: verify (signature, `typ`, freshness), bind to `access_token` via
+///   `ath`, and carry the same key as `cnf.jkt`. `htu` is deliberately not
+///   checked — see [`ValidationConfig::require_dpop`]'s doc comment.
+/// - Finally, the proof's `jti` is checked and recorded via
+///   `replay_store`: a DPoP-bound token is **never** accepted with a reused
+///   proof, and a proof that can't be recorded at all (e.g. no replay store
+///   configured) is refused rather than let through unchecked.
+pub async fn verify_dpop_binding(
+    dpop_header: Option<&str>,
+    htm: &str,
+    access_token: &str,
+    cnf: Option<&serde_json::Value>,
+    replay_store: &dyn crate::dpop::DpopReplayStore,
+) -> Result<(), ValidationError> {
+    let Some(expected_jkt) = cnf.and_then(|v| v.get("jkt")).and_then(|v| v.as_str()) else {
+        return Ok(());
+    };
+
+    let Some(proof) = dpop_header else {
+        return Err(ValidationError::InvalidToken(
+            "token is DPoP-bound (cnf.jkt) but no DPoP proof was presented".to_string(),
+        ));
+    };
+
+    let ath = compute_ath(access_token);
+    let verified = authkestra_engine::token::dpop::verify_dpop_proof(
+        proof,
+        htm,
+        None,
+        Some(&ath),
+        chrono::Duration::seconds(crate::dpop::DPOP_PROOF_MAX_AGE_SECS),
+    )
+    .map_err(|e| ValidationError::InvalidToken(format!("invalid DPoP proof: {e}")))?;
+
+    if !constant_time_eq(&verified.jkt, expected_jkt) {
+        return Err(ValidationError::InvalidToken(
+            "DPoP proof key does not match the token's cnf.jkt".to_string(),
+        ));
+    }
+
+    let expires_at =
+        chrono::Utc::now() + chrono::Duration::seconds(crate::dpop::DPOP_PROOF_MAX_AGE_SECS);
+    match replay_store
+        .check_and_record_dpop_jti(&verified.jti, expires_at)
+        .await
+    {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(ValidationError::InvalidToken(
+            "DPoP proof has already been used".to_string(),
+        )),
+        Err(e) => Err(e),
     }
 }
 
@@ -961,5 +1132,282 @@ mod tests {
             map.resolve(None).await,
             Err(ValidationError::MissingIssuer)
         ));
+    }
+
+    // --- DPoP (RFC 9449) key binding — authkestra#274 Phase C ---
+
+    mod dpop_binding_tests {
+        use super::*;
+        use crate::dpop::{DpopJtiRecord, NoDpopReplayStore};
+        use authkestra_engine::store::memory::MemoryStore;
+        use ed25519_dalek::{Signer, SigningKey};
+
+        fn b64(bytes: &[u8]) -> String {
+            URL_SAFE_NO_PAD.encode(bytes)
+        }
+        fn b64_json(v: &serde_json::Value) -> String {
+            b64(serde_json::to_vec(v).unwrap().as_slice())
+        }
+
+        /// Builds a real, genuinely Ed25519-signed DPoP proof. Mirrors
+        /// `authkestra_engine::token::dpop`'s own (private) `ProofBuilder`
+        /// test helper — re-authored here since that one isn't reachable
+        /// across the crate boundary.
+        struct DpopProofBuilder {
+            signing_key: SigningKey,
+            jti: String,
+            ath: Option<String>,
+        }
+
+        impl DpopProofBuilder {
+            fn with_key_seed(seed: u8, jti: &str) -> Self {
+                Self {
+                    signing_key: SigningKey::from_bytes(&[seed; 32]),
+                    jti: jti.to_string(),
+                    ath: None,
+                }
+            }
+
+            fn with_ath(mut self, ath: &str) -> Self {
+                self.ath = Some(ath.to_string());
+                self
+            }
+
+            fn jwk(&self) -> serde_json::Value {
+                serde_json::json!({
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "x": b64(self.signing_key.verifying_key().as_bytes()),
+                })
+            }
+
+            fn expected_jkt(&self) -> String {
+                authkestra_engine::token::dpop::compute_jwk_thumbprint(
+                    &serde_json::from_value(self.jwk()).unwrap(),
+                )
+                .unwrap()
+            }
+
+            fn build(&self) -> String {
+                let header = serde_json::json!({
+                    "typ": "dpop+jwt",
+                    "alg": "EdDSA",
+                    "jwk": self.jwk(),
+                });
+                let mut payload = serde_json::json!({
+                    "htm": "GET",
+                    "htu": "https://resource.example.com/protected",
+                    "iat": chrono::Utc::now().timestamp(),
+                    "jti": self.jti,
+                });
+                if let Some(ath) = &self.ath {
+                    payload["ath"] = serde_json::Value::String(ath.clone());
+                }
+                let signing_input = format!("{}.{}", b64_json(&header), b64_json(&payload));
+                let signature = self.signing_key.sign(signing_input.as_bytes());
+                format!("{signing_input}.{}", b64(&signature.to_bytes()))
+            }
+        }
+
+        fn cnf_with_jkt(jkt: &str) -> serde_json::Value {
+            serde_json::json!({ "jkt": jkt })
+        }
+
+        #[tokio::test]
+        async fn accepts_when_no_cnf_jkt_present() {
+            // Not a DPoP-bound token: nothing to check, with or without a
+            // presented proof, and even with the fail-closed default store
+            // wired — it must never be consulted for a token that isn't
+            // DPoP-bound in the first place.
+            assert!(
+                verify_dpop_binding(None, "GET", "token", None, &NoDpopReplayStore)
+                    .await
+                    .is_ok()
+            );
+            assert!(verify_dpop_binding(
+                Some("some-proof"),
+                "GET",
+                "token",
+                Some(&serde_json::json!({ "x5t#S256": "unrelated" })),
+                &NoDpopReplayStore,
+            )
+            .await
+            .is_ok());
+        }
+
+        #[tokio::test]
+        async fn accepts_a_valid_proof_bound_to_this_token() {
+            let store = MemoryStore::<DpopJtiRecord>::new();
+            let access_token = "the-access-token-string";
+            let builder = DpopProofBuilder::with_key_seed(11, "jti-1")
+                .with_ath(&x5t_s256_thumbprint(access_token.as_bytes()));
+            let cnf = cnf_with_jkt(&builder.expected_jkt());
+
+            verify_dpop_binding(
+                Some(&builder.build()),
+                "GET",
+                access_token,
+                Some(&cnf),
+                &store,
+            )
+            .await
+            .expect("a valid proof, bound to this token, for the cnf.jkt key must be accepted");
+        }
+
+        #[tokio::test]
+        async fn rejects_a_missing_dpop_header_for_a_bound_token() {
+            let builder = DpopProofBuilder::with_key_seed(11, "jti-2");
+            let cnf = cnf_with_jkt(&builder.expected_jkt());
+
+            let err = verify_dpop_binding(None, "GET", "token", Some(&cnf), &NoDpopReplayStore)
+                .await
+                .expect_err("a DPoP-bound token presented with no proof must be refused");
+            assert!(matches!(err, ValidationError::InvalidToken(_)));
+        }
+
+        #[tokio::test]
+        async fn rejects_a_proof_for_a_different_key_than_cnf_jkt() {
+            let store = MemoryStore::<DpopJtiRecord>::new();
+            let access_token = "the-access-token-string";
+            let ath = x5t_s256_thumbprint(access_token.as_bytes());
+
+            // `cnf.jkt` names the key from seed 11; the presented proof is
+            // genuinely signed, just by a different key (seed 22).
+            let bound = DpopProofBuilder::with_key_seed(11, "jti-3");
+            let presented = DpopProofBuilder::with_key_seed(22, "jti-3").with_ath(&ath);
+            let cnf = cnf_with_jkt(&bound.expected_jkt());
+
+            let err = verify_dpop_binding(
+                Some(&presented.build()),
+                "GET",
+                access_token,
+                Some(&cnf),
+                &store,
+            )
+            .await
+            .expect_err("a proof for a different key than cnf.jkt must be refused");
+            assert!(matches!(err, ValidationError::InvalidToken(_)));
+        }
+
+        #[tokio::test]
+        async fn rejects_a_proof_bound_to_a_different_access_token() {
+            let store = MemoryStore::<DpopJtiRecord>::new();
+            let builder = DpopProofBuilder::with_key_seed(11, "jti-4")
+                .with_ath(&x5t_s256_thumbprint(b"a-completely-different-token"));
+            let cnf = cnf_with_jkt(&builder.expected_jkt());
+
+            let err = verify_dpop_binding(
+                Some(&builder.build()),
+                "GET",
+                "the-actual-access-token",
+                Some(&cnf),
+                &store,
+            )
+            .await
+            .expect_err("a proof whose ath binds a different access token must be refused");
+            assert!(matches!(err, ValidationError::InvalidToken(_)));
+        }
+
+        #[tokio::test]
+        async fn rejects_a_replayed_proof() {
+            let store = MemoryStore::<DpopJtiRecord>::new();
+            let access_token = "the-access-token-string";
+            let builder = DpopProofBuilder::with_key_seed(11, "jti-5")
+                .with_ath(&x5t_s256_thumbprint(access_token.as_bytes()));
+            let cnf = cnf_with_jkt(&builder.expected_jkt());
+            let proof = builder.build();
+
+            verify_dpop_binding(Some(&proof), "GET", access_token, Some(&cnf), &store)
+                .await
+                .expect("first presentation of a fresh proof must succeed");
+
+            let err = verify_dpop_binding(Some(&proof), "GET", access_token, Some(&cnf), &store)
+                .await
+                .expect_err("replaying the same proof must be refused");
+            assert!(matches!(err, ValidationError::InvalidToken(_)));
+        }
+
+        #[tokio::test]
+        async fn fails_closed_without_a_replay_store_wired() {
+            let access_token = "the-access-token-string";
+            let builder = DpopProofBuilder::with_key_seed(11, "jti-6")
+                .with_ath(&x5t_s256_thumbprint(access_token.as_bytes()));
+            let cnf = cnf_with_jkt(&builder.expected_jkt());
+
+            let err = verify_dpop_binding(
+                Some(&builder.build()),
+                "GET",
+                access_token,
+                Some(&cnf),
+                &NoDpopReplayStore,
+            )
+            .await
+            .expect_err("no replay store is wired; an otherwise-valid proof must be refused");
+            assert!(matches!(err, ValidationError::InvalidToken(_)));
+        }
+
+        #[tokio::test]
+        async fn rejects_a_proof_for_the_wrong_method() {
+            let store = MemoryStore::<DpopJtiRecord>::new();
+            let access_token = "the-access-token-string";
+            // `DpopProofBuilder::build` always signs "GET" as `htm`.
+            let builder = DpopProofBuilder::with_key_seed(11, "jti-7")
+                .with_ath(&x5t_s256_thumbprint(access_token.as_bytes()));
+            let cnf = cnf_with_jkt(&builder.expected_jkt());
+
+            let err = verify_dpop_binding(
+                Some(&builder.build()),
+                "POST",
+                access_token,
+                Some(&cnf),
+                &store,
+            )
+            .await
+            .expect_err("a proof signed for a different HTTP method must be refused");
+            assert!(matches!(err, ValidationError::InvalidToken(_)));
+        }
+    }
+
+    mod dpop_header_tests {
+        use super::{extract_dpop_header, ValidationError};
+
+        #[test]
+        fn no_header_is_none() {
+            let headers = http::HeaderMap::new();
+            assert_eq!(extract_dpop_header(&headers).unwrap(), None);
+        }
+
+        #[test]
+        fn exactly_one_header_is_returned() {
+            let mut headers = http::HeaderMap::new();
+            headers.insert("DPoP", http::HeaderValue::from_static("proof-value"));
+            assert_eq!(extract_dpop_header(&headers).unwrap(), Some("proof-value"));
+        }
+
+        /// RFC 9449 §4.1 expects exactly one `DPoP` header; a duplicate is
+        /// refused outright rather than silently resolved by picking one.
+        #[test]
+        fn two_headers_are_rejected() {
+            let mut headers = http::HeaderMap::new();
+            headers.append("DPoP", http::HeaderValue::from_static("first"));
+            headers.append("DPoP", http::HeaderValue::from_static("second"));
+            let err =
+                extract_dpop_header(&headers).expect_err("a duplicate header must be refused");
+            assert!(matches!(err, ValidationError::InvalidToken(_)));
+        }
+
+        /// A header value that isn't valid ASCII must be refused, not
+        /// silently treated as "no header present".
+        #[test]
+        fn non_ascii_header_is_rejected() {
+            let mut headers = http::HeaderMap::new();
+            headers.insert(
+                "DPoP",
+                http::HeaderValue::from_bytes(&[0xff, 0xfe]).unwrap(),
+            );
+            let err =
+                extract_dpop_header(&headers).expect_err("a non-ASCII header must be refused");
+            assert!(matches!(err, ValidationError::InvalidToken(_)));
+        }
     }
 }

--- a/crates/authkestra-resource/src/jwt.rs
+++ b/crates/authkestra-resource/src/jwt.rs
@@ -507,19 +507,16 @@ impl ValidationConfigBuilder {
     /// single-issuer endpoint".
     ///
     /// Also panics if [`dpop_resource_origin`](Self::dpop_resource_origin)
-    /// was set to a value with no scheme, or with a trailing slash. Both
-    /// shapes are easy typos (`"api.example.com"` instead of
-    /// `"https://api.example.com"`; `"https://api.example.com/"` instead of
-    /// without the trailing `/`) that would otherwise silently break every
-    /// DPoP request once `require_dpop` is on: the request's own path
-    /// (which always starts with `/`) is joined directly onto this value at
-    /// check time, so a trailing slash produces a doubled `//` that will
-    /// never match any proof's genuine `htu`, and a missing scheme produces
-    /// a string `url::Url` can't parse as absolute, falling back to an
-    /// exact-string comparison that also never matches. Either mistake
-    /// fails every single request with only a `tracing::warn!`,
-    /// indistinguishable from an actual attack — checking the shape here,
-    /// once, at startup, is cheaper than debugging that in production.
+    /// isn't a bare `scheme://host` with no path, query, or fragment.
+    /// Every one of those shapes is an easy typo
+    /// (`"api.example.com"` with no scheme; `"https://api.example.com/"`
+    /// with a trailing slash; `"https://api.example.com?x=1"` with a
+    /// query) that would otherwise silently break *every* DPoP request
+    /// once `require_dpop` is on, with nothing but a `tracing::warn!` per
+    /// request to show for it — indistinguishable from an actual attack.
+    /// Checking the shape here, once, at startup, is cheaper than
+    /// debugging that in production. See the panicking checks themselves
+    /// for exactly which failure mode each one closes.
     pub fn build(self) -> ValidationConfig {
         let jwks_url = match self.jwks_url {
             Some(jwks_url) => jwks_url,
@@ -533,11 +530,44 @@ impl ValidationConfigBuilder {
         };
 
         if let Some(origin) = &self.dpop_resource_origin {
+            let parsed = url::Url::parse(origin).unwrap_or_else(|e| {
+                panic!(
+                    "ValidationConfigBuilder::dpop_resource_origin must be a valid absolute \
+                     URL (e.g. \"https://api.example.com\"), got {origin:?}: {e}"
+                )
+            });
+            // `Url::parse` requires a scheme to succeed at all, and
+            // normalizes it to lowercase — so this is naturally
+            // case-insensitive, matching `strip_scheme_ci`'s treatment of
+            // the `Authorization` header's own scheme elsewhere in this
+            // file, and rejects non-HTTP schemes a resource server could
+            // never actually be reached on.
             assert!(
-                origin.starts_with("http://") || origin.starts_with("https://"),
-                "ValidationConfigBuilder::dpop_resource_origin must include a scheme \
-                 (e.g. \"https://api.example.com\"), got {origin:?}"
+                parsed.scheme() == "http" || parsed.scheme() == "https",
+                "ValidationConfigBuilder::dpop_resource_origin must use http or https, got \
+                 {origin:?}"
             );
+            assert!(
+                parsed.host().is_some(),
+                "ValidationConfigBuilder::dpop_resource_origin must include a host, got \
+                 {origin:?}"
+            );
+            // `htu` canonicalization (on the request side) strips query and
+            // fragment before comparing, so either one here could never
+            // survive into a match against a genuine proof — same
+            // always-fails-every-request class as the other checks here.
+            assert!(
+                parsed.query().is_none() && parsed.fragment().is_none(),
+                "ValidationConfigBuilder::dpop_resource_origin must not include a query or \
+                 fragment, got {origin:?}"
+            );
+            // Checked on the raw string, not `parsed`: `Url::parse` treats
+            // "https://api.example.com" and "https://api.example.com/" as
+            // the same path ("/"), but the runtime check concatenates
+            // this *string* directly with the request's own leading-`/`
+            // path, so a trailing slash here still produces a `//` that a
+            // genuine proof's `htu` never has, regardless of how `Url`
+            // would normalize it.
             assert!(
                 !origin.ends_with('/'),
                 "ValidationConfigBuilder::dpop_resource_origin must not end with a trailing \
@@ -1740,7 +1770,7 @@ mod tests {
         /// falling back to an exact-string comparison against the proof's
         /// genuine (scheme-carrying) `htu`, which can never match.
         #[test]
-        #[should_panic(expected = "must include a scheme")]
+        #[should_panic(expected = "must be a valid absolute URL")]
         fn a_scheme_less_origin_panics() {
             ValidationConfig::builder()
                 .jwks_url("https://issuer.example.com/.well-known/jwks.json")
@@ -1757,6 +1787,50 @@ mod tests {
             ValidationConfig::builder()
                 .jwks_url("https://issuer.example.com/.well-known/jwks.json")
                 .dpop_resource_origin("https://api.example.com/")
+                .build();
+        }
+
+        /// A query or fragment on the origin never survives `htu`
+        /// canonicalization on the request side, so it could never match
+        /// a genuine proof either — the same always-fails-every-request
+        /// class as a missing scheme or a trailing slash.
+        #[test]
+        #[should_panic(expected = "query or fragment")]
+        fn an_origin_with_a_query_panics() {
+            ValidationConfig::builder()
+                .jwks_url("https://issuer.example.com/.well-known/jwks.json")
+                .dpop_resource_origin("https://api.example.com?x=1")
+                .build();
+        }
+
+        #[test]
+        #[should_panic(expected = "query or fragment")]
+        fn an_origin_with_a_fragment_panics() {
+            ValidationConfig::builder()
+                .jwks_url("https://issuer.example.com/.well-known/jwks.json")
+                .dpop_resource_origin("https://api.example.com#section")
+                .build();
+        }
+
+        /// RFC 9110 §11.1's case-insensitive scheme applies just as much
+        /// to this URL's own scheme as it does to the `Authorization`
+        /// header's auth-scheme (`strip_scheme_ci`, elsewhere in this
+        /// file) — `url::Url::parse` already normalizes it, so this must
+        /// not panic.
+        #[test]
+        fn an_uppercase_scheme_is_accepted() {
+            ValidationConfig::builder()
+                .jwks_url("https://issuer.example.com/.well-known/jwks.json")
+                .dpop_resource_origin("HTTPS://api.example.com")
+                .build();
+        }
+
+        #[test]
+        #[should_panic(expected = "must use http or https")]
+        fn a_non_http_scheme_panics() {
+            ValidationConfig::builder()
+                .jwks_url("https://issuer.example.com/.well-known/jwks.json")
+                .dpop_resource_origin("ftp://api.example.com")
                 .build();
         }
     }

--- a/crates/authkestra-resource/src/lib.rs
+++ b/crates/authkestra-resource/src/lib.rs
@@ -4,6 +4,12 @@ use http::request::Parts;
 
 pub mod jwt;
 
+/// DPoP (RFC 9449) proof replay tracking for [`jwt::JwtStrategy`]. See the
+/// module doc for why this is independent of `authkestra-op`'s own replay
+/// guard.
+pub mod dpop;
+pub use dpop::{DpopJtiRecord, DpopReplayStore, NoDpopReplayStore, DPOP_PROOF_MAX_AGE_SECS};
+
 /// Policy for controlling the behavior of chained authentication strategies.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum AuthPolicy {

--- a/crates/authkestra-resource/tests/jwt_test.rs
+++ b/crates/authkestra-resource/tests/jwt_test.rs
@@ -954,6 +954,7 @@ fn dpop_b64_json(v: &serde_json::Value) -> String {
 struct DpopProofBuilder {
     signing_key: ed25519_dalek::SigningKey,
     htm: String,
+    htu: String,
     jti: String,
     ath: Option<String>,
 }
@@ -963,6 +964,7 @@ impl DpopProofBuilder {
         Self {
             signing_key: ed25519_dalek::SigningKey::from_bytes(&[seed; 32]),
             htm: htm.to_string(),
+            htu: "https://resource.example.com/protected".to_string(),
             jti: jti.to_string(),
             ath: None,
         }
@@ -970,6 +972,11 @@ impl DpopProofBuilder {
 
     fn with_ath(mut self, ath: &str) -> Self {
         self.ath = Some(ath.to_string());
+        self
+    }
+
+    fn with_htu(mut self, htu: &str) -> Self {
+        self.htu = htu.to_string();
         self
     }
 
@@ -997,7 +1004,7 @@ impl DpopProofBuilder {
         });
         let mut payload = serde_json::json!({
             "htm": self.htm,
-            "htu": "https://resource.example.com/protected",
+            "htu": self.htu,
             "iat": chrono::Utc::now().timestamp(),
             "jti": self.jti,
         });
@@ -1017,7 +1024,21 @@ fn scheme_request_parts(
     token: &str,
     dpop_proof: Option<&str>,
 ) -> http::request::Parts {
-    let mut builder = Request::builder().header(AUTHORIZATION, format!("{scheme} {token}"));
+    scheme_request_parts_with_uri(scheme, token, dpop_proof, "/")
+}
+
+/// As [`scheme_request_parts`], but lets the caller set the request's own
+/// path — needed to exercise `ValidationConfig::dpop_resource_origin`,
+/// which reconstructs the expected `htu` from this path.
+fn scheme_request_parts_with_uri(
+    scheme: &str,
+    token: &str,
+    dpop_proof: Option<&str>,
+    uri: &str,
+) -> http::request::Parts {
+    let mut builder = Request::builder()
+        .uri(uri)
+        .header(AUTHORIZATION, format!("{scheme} {token}"));
     if let Some(proof) = dpop_proof {
         builder = builder.header("DPoP", proof);
     }
@@ -1182,5 +1203,130 @@ async fn dpop_replay_store_outage_surfaces_as_err_not_ok_none() {
         result.is_err(),
         "no replay store is configured; this must surface as Err(AuthError), not be swallowed \
          as Ok(None)"
+    );
+}
+
+/// RFC 9449 §7.1's other direction: a request presented via the `DPoP`
+/// scheme is a claim that the token is DPoP-bound. A token with no
+/// `cnf.jkt` at all can't back that claim, so it must be refused too, not
+/// silently treated the same as if it had arrived via `Bearer`.
+#[tokio::test]
+async fn dpop_rejects_dpop_scheme_presentation_of_an_unbound_token() {
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+
+    let config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .require_dpop(true)
+        .build();
+    let strategy: JwtStrategy<DpopBoundClaims> = JwtStrategy::new(config);
+
+    // No `cnf` claim at all — an ordinary, unbound token.
+    let claims = DpopBoundClaims {
+        sub: "user-a".to_string(),
+        exp: future_exp(),
+        aud: None,
+        cnf: None,
+    };
+    let token = sign_token(&key.encoding_key, Some("kid-1"), &claims);
+    let parts = scheme_request_parts("DPoP", &token, None);
+
+    let result = strategy
+        .authenticate(&parts)
+        .await
+        .expect("authenticate should not error");
+    assert!(
+        result.is_none(),
+        "a token with no cnf.jkt presented via the DPoP scheme must be refused, not silently \
+         accepted as an ordinary bearer token"
+    );
+}
+
+/// `ValidationConfig::dpop_resource_origin` opt-in: with it configured, a
+/// proof minted for this exact URL (origin + request path) is accepted.
+#[tokio::test]
+async fn dpop_htu_check_accepts_when_configured_origin_matches() {
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+
+    let config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .require_dpop(true)
+        .dpop_resource_origin("https://api.example.com")
+        .build();
+    let strategy: JwtStrategy<DpopBoundClaims> = JwtStrategy::new(config).with_dpop_replay_store(
+        Arc::new(authkestra_engine::store::memory::MemoryStore::<
+            authkestra_resource::dpop::DpopJtiRecord,
+        >::new()),
+    );
+
+    let proof_builder = DpopProofBuilder::with_key_seed(11, "GET", "jti-htu-1")
+        .with_htu("https://api.example.com/widgets/42");
+    let claims = DpopBoundClaims {
+        sub: "user-a".to_string(),
+        exp: future_exp(),
+        aud: None,
+        cnf: Some(serde_json::json!({ "jkt": proof_builder.expected_jkt() })),
+    };
+    let token = sign_token(&key.encoding_key, Some("kid-1"), &claims);
+    let proof = proof_builder
+        .with_ath(&x5t_s256_thumbprint(token.as_bytes()))
+        .build();
+    let parts = scheme_request_parts_with_uri("DPoP", &token, Some(&proof), "/widgets/42");
+
+    let result = strategy
+        .authenticate(&parts)
+        .await
+        .expect("authenticate should not error");
+    assert!(
+        result.is_some(),
+        "a proof minted for this exact configured-origin URL must be accepted"
+    );
+}
+
+/// The other half: with `dpop_resource_origin` configured, a proof minted
+/// for a *different* URL — e.g. one forwarded from another resource server
+/// within its freshness window — must be refused. This is exactly the
+/// cross-service forwarding gap that leaving `dpop_resource_origin` unset
+/// does not close.
+#[tokio::test]
+async fn dpop_htu_check_rejects_when_configured_origin_url_mismatches() {
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+
+    let config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .require_dpop(true)
+        .dpop_resource_origin("https://api.example.com")
+        .build();
+    let strategy: JwtStrategy<DpopBoundClaims> = JwtStrategy::new(config).with_dpop_replay_store(
+        Arc::new(authkestra_engine::store::memory::MemoryStore::<
+            authkestra_resource::dpop::DpopJtiRecord,
+        >::new()),
+    );
+
+    // The proof was minted for a different resource server's URL entirely.
+    let proof_builder = DpopProofBuilder::with_key_seed(11, "GET", "jti-htu-2")
+        .with_htu("https://a-different-service.example.com/widgets/42");
+    let claims = DpopBoundClaims {
+        sub: "user-a".to_string(),
+        exp: future_exp(),
+        aud: None,
+        cnf: Some(serde_json::json!({ "jkt": proof_builder.expected_jkt() })),
+    };
+    let token = sign_token(&key.encoding_key, Some("kid-1"), &claims);
+    let proof = proof_builder
+        .with_ath(&x5t_s256_thumbprint(token.as_bytes()))
+        .build();
+    let parts = scheme_request_parts_with_uri("DPoP", &token, Some(&proof), "/widgets/42");
+
+    let result = strategy
+        .authenticate(&parts)
+        .await
+        .expect("authenticate should not error");
+    assert!(
+        result.is_none(),
+        "a proof minted for a different resource server's URL must be refused once \
+         dpop_resource_origin is configured"
     );
 }

--- a/crates/authkestra-resource/tests/jwt_test.rs
+++ b/crates/authkestra-resource/tests/jwt_test.rs
@@ -910,4 +910,277 @@ fn builder_defaults_match_documented_behaviour() {
         "require_cert_binding must stay off by default: turning it on would reject every \
          certificate-bound token not presented over a matching mTLS connection"
     );
+    assert!(
+        !config.require_dpop,
+        "require_dpop must stay off by default: turning it on would reject every DPoP-bound \
+         token not presented over the DPoP auth-scheme with a matching proof"
+    );
+}
+
+// --- RFC 9449 DPoP key-bound (`cnf.jkt`) access token tests — authkestra#274
+// Phase C -------------------------------------------------------------------
+//
+// Covers the same shape of gap #224/cert-binding closed for RFC 8705: a
+// token stamped with `cnf.jkt` (see `authkestra-op`'s DPoP `/token` wiring)
+// must be rejected by `JwtStrategy::require_dpop` unless the request
+// presents a fresh, valid DPoP proof for that same key, bound to this
+// specific access token — and, per RFC 9449 §7.1, presented via the `DPoP`
+// auth-scheme, never `Bearer`.
+
+/// Claims shape carrying an optional `cnf` confirmation claim, separate from
+/// `CertBoundClaims` so a claims payload can be reused verbatim across both
+/// binding checks if a future test wants both at once.
+#[derive(Debug, Serialize, Deserialize)]
+struct DpopBoundClaims {
+    sub: String,
+    exp: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    aud: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cnf: Option<serde_json::Value>,
+}
+
+fn dpop_b64(bytes: &[u8]) -> String {
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+fn dpop_b64_json(v: &serde_json::Value) -> String {
+    dpop_b64(serde_json::to_vec(v).unwrap().as_slice())
+}
+
+/// Builds a real, genuinely Ed25519-signed DPoP proof. Mirrors the
+/// (private, so unreachable from this integration-test binary)
+/// `DpopProofBuilder` in `authkestra_resource::jwt`'s own unit tests, and
+/// `authkestra_engine::token::dpop`'s before that.
+struct DpopProofBuilder {
+    signing_key: ed25519_dalek::SigningKey,
+    htm: String,
+    jti: String,
+    ath: Option<String>,
+}
+
+impl DpopProofBuilder {
+    fn with_key_seed(seed: u8, htm: &str, jti: &str) -> Self {
+        Self {
+            signing_key: ed25519_dalek::SigningKey::from_bytes(&[seed; 32]),
+            htm: htm.to_string(),
+            jti: jti.to_string(),
+            ath: None,
+        }
+    }
+
+    fn with_ath(mut self, ath: &str) -> Self {
+        self.ath = Some(ath.to_string());
+        self
+    }
+
+    fn jwk(&self) -> serde_json::Value {
+        serde_json::json!({
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "x": dpop_b64(self.signing_key.verifying_key().as_bytes()),
+        })
+    }
+
+    fn expected_jkt(&self) -> String {
+        authkestra_engine::token::dpop::compute_jwk_thumbprint(
+            &serde_json::from_value(self.jwk()).unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn build(&self) -> String {
+        use ed25519_dalek::Signer;
+        let header = serde_json::json!({
+            "typ": "dpop+jwt",
+            "alg": "EdDSA",
+            "jwk": self.jwk(),
+        });
+        let mut payload = serde_json::json!({
+            "htm": self.htm,
+            "htu": "https://resource.example.com/protected",
+            "iat": chrono::Utc::now().timestamp(),
+            "jti": self.jti,
+        });
+        if let Some(ath) = &self.ath {
+            payload["ath"] = serde_json::Value::String(ath.clone());
+        }
+        let signing_input = format!("{}.{}", dpop_b64_json(&header), dpop_b64_json(&payload));
+        let signature = self.signing_key.sign(signing_input.as_bytes());
+        format!("{signing_input}.{}", dpop_b64(&signature.to_bytes()))
+    }
+}
+
+/// Builds `http::request::Parts` presenting `token` via the given
+/// auth-scheme, with `dpop_proof`, if any, as the `DPoP` header.
+fn scheme_request_parts(
+    scheme: &str,
+    token: &str,
+    dpop_proof: Option<&str>,
+) -> http::request::Parts {
+    let mut builder = Request::builder().header(AUTHORIZATION, format!("{scheme} {token}"));
+    if let Some(proof) = dpop_proof {
+        builder = builder.header("DPoP", proof);
+    }
+    let request = builder.body(()).unwrap();
+    let (parts, _) = request.into_parts();
+    parts
+}
+
+#[tokio::test]
+async fn dpop_accepts_a_valid_proof_presented_via_the_dpop_scheme() {
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+
+    let config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .require_dpop(true)
+        .build();
+    let strategy: JwtStrategy<DpopBoundClaims> = JwtStrategy::new(config).with_dpop_replay_store(
+        Arc::new(authkestra_engine::store::memory::MemoryStore::<
+            authkestra_resource::dpop::DpopJtiRecord,
+        >::new()),
+    );
+
+    let proof_builder = DpopProofBuilder::with_key_seed(11, "GET", "jti-e2e-1");
+    let claims = DpopBoundClaims {
+        sub: "user-a".to_string(),
+        exp: future_exp(),
+        aud: None,
+        cnf: Some(serde_json::json!({ "jkt": proof_builder.expected_jkt() })),
+    };
+    let token = sign_token(&key.encoding_key, Some("kid-1"), &claims);
+    let proof = proof_builder
+        .with_ath(&x5t_s256_thumbprint(token.as_bytes()))
+        .build();
+    let parts = scheme_request_parts("DPoP", &token, Some(&proof));
+
+    let result = strategy
+        .authenticate(&parts)
+        .await
+        .expect("authenticate should not error");
+    let identity = result.expect(
+        "a DPoP-bound token, presented via the DPoP scheme with a valid matching proof, must be accepted",
+    );
+    assert_eq!(identity.sub, "user-a");
+}
+
+/// The regression test for the exact gap this whole test module is about:
+/// RFC 9449 §7.1 requires a DPoP-bound token be presented via the `DPoP`
+/// scheme, never `Bearer` — and before this fix, `authenticate` only ever
+/// looked for `Bearer`, so no request shaped the way a spec-compliant DPoP
+/// client actually sends one could ever reach the DPoP check at all.
+#[tokio::test]
+async fn dpop_rejects_a_bound_token_presented_via_the_bearer_scheme() {
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+
+    let config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .require_dpop(true)
+        .build();
+    let strategy: JwtStrategy<DpopBoundClaims> = JwtStrategy::new(config).with_dpop_replay_store(
+        Arc::new(authkestra_engine::store::memory::MemoryStore::<
+            authkestra_resource::dpop::DpopJtiRecord,
+        >::new()),
+    );
+
+    let proof_builder = DpopProofBuilder::with_key_seed(11, "GET", "jti-e2e-2");
+    let claims = DpopBoundClaims {
+        sub: "user-a".to_string(),
+        exp: future_exp(),
+        aud: None,
+        cnf: Some(serde_json::json!({ "jkt": proof_builder.expected_jkt() })),
+    };
+    let token = sign_token(&key.encoding_key, Some("kid-1"), &claims);
+    // A genuinely valid proof is attached too — the point of this test is
+    // that the *scheme* alone must be enough to refuse it, independent of
+    // whether a valid proof also happens to be present.
+    let proof = proof_builder
+        .with_ath(&x5t_s256_thumbprint(token.as_bytes()))
+        .build();
+    let parts = scheme_request_parts("Bearer", &token, Some(&proof));
+
+    let result = strategy
+        .authenticate(&parts)
+        .await
+        .expect("authenticate should not error");
+    assert!(
+        result.is_none(),
+        "a DPoP-bound token presented via the Bearer scheme must be rejected, even with a \
+         genuinely valid DPoP proof attached"
+    );
+}
+
+#[tokio::test]
+async fn dpop_is_not_enforced_when_require_dpop_is_false() {
+    // Backward compatibility: a DPoP-bound token is still accepted as a
+    // plain bearer token when the resource server has not opted into
+    // `require_dpop` — mirrors `cert_binding_is_not_enforced_when_require_
+    // cert_binding_is_false` above.
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+
+    let config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .build();
+    assert!(!config.require_dpop);
+    let strategy: JwtStrategy<DpopBoundClaims> = JwtStrategy::new(config);
+
+    let proof_builder = DpopProofBuilder::with_key_seed(11, "GET", "jti-e2e-3");
+    let claims = DpopBoundClaims {
+        sub: "user-a".to_string(),
+        exp: future_exp(),
+        aud: None,
+        cnf: Some(serde_json::json!({ "jkt": proof_builder.expected_jkt() })),
+    };
+    let token = sign_token(&key.encoding_key, Some("kid-1"), &claims);
+    let parts = scheme_request_parts("Bearer", &token, None);
+
+    let result = strategy
+        .authenticate(&parts)
+        .await
+        .expect("authenticate should not error")
+        .expect("without require_dpop, a DPoP-bound token is still a valid bearer token");
+    assert_eq!(result.sub, "user-a");
+}
+
+/// The other regression this test module is about: a replay-store outage
+/// (or, as here, the fail-closed `NoDpopReplayStore` default) must surface
+/// as `Err(AuthError)`, never `Ok(None)`. `Ok(None)` means "this strategy
+/// declined, try the next one" under `AuthPolicy::FirstSuccess` — treating
+/// an infrastructure failure that way would let a `Guard` chain silently
+/// authenticate the request via some other strategy with the DPoP check
+/// skipped entirely, rather than surfacing the outage.
+#[tokio::test]
+async fn dpop_replay_store_outage_surfaces_as_err_not_ok_none() {
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+
+    let config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .require_dpop(true)
+        .build();
+    // Deliberately not wiring `with_dpop_replay_store` — this strategy's
+    // replay store is the fail-closed `NoDpopReplayStore` default.
+    let strategy: JwtStrategy<DpopBoundClaims> = JwtStrategy::new(config);
+
+    let proof_builder = DpopProofBuilder::with_key_seed(11, "GET", "jti-e2e-4");
+    let claims = DpopBoundClaims {
+        sub: "user-a".to_string(),
+        exp: future_exp(),
+        aud: None,
+        cnf: Some(serde_json::json!({ "jkt": proof_builder.expected_jkt() })),
+    };
+    let token = sign_token(&key.encoding_key, Some("kid-1"), &claims);
+    let proof = proof_builder
+        .with_ath(&x5t_s256_thumbprint(token.as_bytes()))
+        .build();
+    let parts = scheme_request_parts("DPoP", &token, Some(&proof));
+
+    let result = strategy.authenticate(&parts).await;
+    assert!(
+        result.is_err(),
+        "no replay store is configured; this must surface as Err(AuthError), not be swallowed \
+         as Ok(None)"
+    );
 }


### PR DESCRIPTION
## Summary

Phase C of #274. Phases A (#277) and B (#286) built and wired DPoP proof verification into `authkestra-op`'s `/token` endpoint: an OP can verify a client's proof and stamp `cnf.jkt` onto the tokens it issues. Nothing on the resource-server side checked that claim — a DPoP-bound access token was accepted by `authkestra-resource`'s `JwtStrategy` as an ordinary bearer token, with no proof-of-possession check at all. This PR closes that gap.

Targets `next`, not `main`, per the same release-timing reasoning as every other PR in this series.

## What's here

- **`authkestra_engine::token::dpop::verify_dpop_proof`'s `expected_htu` is now `Option<&str>`** instead of `&str`. An authorization server has exactly one, statically-known `/token` endpoint (still `Some(...)` at that call site), but a resource server protects many routes, commonly behind a reverse proxy or load balancer where the exact absolute URL a client used isn't always reconstructible from the request alone. `None` skips just that one check; `htm`, freshness, and (when supplied) `ath` are still verified — mirrors how `expected_ath` already models "not applicable here" as `None`.
- **New `authkestra_resource::dpop` module**: a `DpopReplayStore` trait with a blanket impl over any `KvStore + AtomicInsert` backend (Memory/Redis/Postgres/Sqlite/MySQL all get it for free), and a fail-closed `NoDpopReplayStore` default — deliberately independent from `authkestra-op`'s own replay guard, since an authorization server and a resource server are commonly separate deployments, each needing its own record of which proof `jti`s it has seen.
- **`ValidationConfig` gains `require_dpop: bool`** (off by default, mirroring `require_cert_binding`'s exact shape and rationale): when on, a token carrying `cnf.jkt` must be redeemed with a DPoP proof that verifies, binds to *this* access token via `ath`, carries the same key, and hasn't been seen before. A token with no `cnf.jkt` is untouched regardless of this setting.
- **`JwtStrategy` gains a `with_dpop_replay_store` builder** (mirrors `CompositeOpStore::with_dpop_replay_store` on the OP side) and a new `verify_dpop_binding` check in `authenticate()`, sharing the single `cnf` re-decode already done for certificate binding rather than decoding twice.
- **Both HTTP adapters' `extract_dpop_header` hardening** (reject a duplicate or non-ASCII `DPoP` header outright — from the `/token` endpoint's own review round) is mirrored here for the resource-server request path.
- **`with_dpop_support()`'s discovery doc comment updated**: the resource-server gap it flagged is now closeable via `require_dpop`/`with_dpop_replay_store`, but remains its own deployment-side opt-in — advertising DPoP support says nothing about whether a given resource server has actually turned enforcement on.

## Deliberate scope boundary

`htm`/`htu` verification at the resource server is out of scope here, documented on `ValidationConfig::require_dpop` — same reverse-proxy reasoning as the `expected_htu: None` change above. Key binding + `ath` + `jti` replay together still mean a captured proof cannot be reused for a different token, or reused at all; only "replay against a different route on the same server" is not caught. Flagging explicitly rather than silently shipping partial.

## Test plan

- [x] New `authkestra-resource` tests: valid proof accepted and its `jti` recorded; missing header, wrong key, wrong `ath`, wrong method, and replay all rejected; `NoDpopReplayStore` fails closed; a token with no `cnf.jkt` is unaffected regardless of `require_dpop`.
- [x] New `extract_dpop_header` unit tests (absent/one/duplicate/non-ASCII), mirroring the `/token` endpoint's own adapter tests.
- [x] New `authkestra-engine` test proving `expected_htu: None` skips the check; all 21 existing `verify_dpop_proof` call sites (engine tests) updated to `Some(...)` with zero behavior change.
- [x] `cargo test -p authkestra-resource --lib`: 25 passed (up from 13).
- [x] `cargo test -p authkestra-engine --lib token::dpop`: 23 passed (up from 22).
- [x] `cargo test -p authkestra-op --lib`: 174 passed, unchanged.
- [x] `cargo test --workspace --all-features`: clean.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- [x] `cargo fmt --all -- --check`: clean.
- [x] `cargo doc -p authkestra-resource -p authkestra-op -p authkestra-engine --no-deps`: no new warnings.

## Follow-up

- `htm`/`htu` verification at the resource server, if a deployment topology allows reliably reconstructing the request's absolute URL (see the scope boundary above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)