### PR TITLE
fix(op): close the #290 review findings — migration races, probe fail-open, lock churn

### DIFF
--- a/crates/authkestra-op/Cargo.toml
+++ b/crates/authkestra-op/Cargo.toml
@@ -59,14 +59,6 @@ rustls-no-provider = [
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
-# `migrate` only, not a full `sqlx` re-declaration: Cargo unifies this with
-# the optional main-dependency `sqlx` above for test/bench/example builds
-# only, so downstream consumers never get this feature. Used exclusively by
-# a regression test in `sqlx_store.rs` reproducing a host application's own
-# `sqlx::migrate!` running against the same pool as `SqlxOpStore::migrate`
-# (authkestra#290) — the collision that motivated moving `SqlxOpStore` off
-# `sqlx::migrate!` entirely in favor of introspection-guarded ALTERs.
-sqlx = { version = "0.8", features = ["migrate"] }
 testcontainers = "0.27.3"
 testcontainers-modules = { version = "0.15.0", features = ["postgres", "mysql", "redis"] }
 # Test-only: generating real EC P-256 keypairs and signing enrolment

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -1071,10 +1071,23 @@ pub fn merge_dpop_cnf(extra: &mut HashMap<String, serde_json::Value>, dpop_jkt: 
 enum RefreshTokenStoreOutcome {
     /// Stored, and — if it was meant to be DPoP-bound — confirmed bound.
     Stored,
-    /// The store call itself failed and the token was never meant to be
-    /// DPoP-bound. Every call site already tolerates this exactly as it
-    /// did before this feature existed: log it, omit `refresh_token` from
-    /// the response, and otherwise succeed.
+    /// Persistence could not be confirmed, but nothing positively
+    /// disproves it either. Two cases: the store call itself failed for a
+    /// token that was never meant to be DPoP-bound, or — since
+    /// authkestra#290's review — the DPoP read-back probe could not be
+    /// completed at all (it errored, or found no row yet). Every call site
+    /// already tolerates this exactly as it did before this feature
+    /// existed: log it, omit `refresh_token` from the response, and
+    /// otherwise succeed.
+    ///
+    /// That "omit" is the whole reason the inconclusive cases land here
+    /// rather than on `Stored`: at the two pre-consumption call sites
+    /// nothing has been spent yet, so declining to *advertise* a binding
+    /// no read has confirmed costs at most a re-authentication. At
+    /// `default_handle_refresh_token`'s rotation site this arm and
+    /// `Stored` have identical bodies and the response returns the rotated
+    /// token either way, so an unconfirmable probe there cannot destroy
+    /// the session of a predecessor token that has already been consumed.
     NonFatalStorageFailure,
     /// The token was meant to be DPoP-bound (`jkt: Some(_)`) but the
     /// read-back *positively* found a different (or absent) `jkt` on the
@@ -1094,11 +1107,16 @@ enum RefreshTokenStoreOutcome {
 /// persisted.
 ///
 /// A backend can silently drop `jkt` on write without `store_token`
-/// itself ever returning an error: exactly the case `sqlx_store.rs`'s
-/// `RefreshTokenStore` impl is in right now (its schema has no `jkt`
-/// column yet, so it accepts a token with `jkt: Some(_)` and simply
-/// never persists that field — see the comment on its `get_token`). If
-/// nothing ever checked, that token's RFC 9449 §5 continuity guarantee
+/// itself ever returning an error — accepting a token with
+/// `jkt: Some(_)` and simply never persisting that field.
+/// `sqlx_store.rs` was exactly that case when this check was written
+/// (authkestra#286): its schema had no `jkt` column. authkestra#287 has
+/// since given it one and wired `store_token`/`get_token`/`consume_token`
+/// to it, so that in-tree example no longer applies — but any
+/// out-of-crate `RefreshTokenStore` written against the pre-0.7
+/// `RefreshToken`, or any hand-managed SQL schema that skipped the 0.7
+/// `ALTER`s, still behaves exactly this way. If nothing ever checked,
+/// that token's RFC 9449 §5 continuity guarantee
 /// would quietly not exist: `default_handle_refresh_token` would see
 /// `jkt: None` on redemption and treat it as though it never asked for a
 /// DPoP-bound refresh token in the first place, while the client's
@@ -1110,19 +1128,27 @@ enum RefreshTokenStoreOutcome {
 /// an unverifiable proof, the consume-before-validate ordering fix, and
 /// so on).
 ///
-/// Only a read-back that actually returns a row with the *wrong* `jkt`
-/// counts as a confirmed drop. A read-back that errors, or that (unlike
-/// the write moments earlier) finds no row at all, is inconclusive rather
-/// than a confirmed failure — most plausibly a transient read issue (a
-/// pool blip, or a read served by a lagging replica that the just-completed
-/// write hasn't reached yet), not evidence the write didn't happen. By the
-/// time this probe runs, `store_token` has already returned `Ok`, so the
-/// write itself is not in question; treating an inconclusive *read* the
-/// same as a *positive* mismatch matters most for
-/// `default_handle_refresh_token`'s rotation path, which calls this only
-/// after already consuming the single-use predecessor token — failing the
-/// request here on a transient read hiccup would destroy that already-spent
-/// token's session for a write that in fact succeeded.
+/// Three outcomes, not two. Only a read-back that actually returns a row
+/// with the *wrong* `jkt` counts as a confirmed drop and yields
+/// [`RefreshTokenStoreOutcome::DpopBindingFailed`]. A read-back that
+/// errors, or that (unlike the write moments earlier) finds no row at all,
+/// is inconclusive — most plausibly a transient read issue, a pool blip,
+/// or a read served by a lagging replica the just-completed write hasn't
+/// reached — and yields
+/// [`RefreshTokenStoreOutcome::NonFatalStorageFailure`].
+///
+/// Inconclusive is deliberately neither of the other two (authkestra#290
+/// review). Reporting it as `DpopBindingFailed` would fail
+/// `default_handle_refresh_token`'s rotation path *after* it has already
+/// consumed the single-use predecessor token, destroying a live session
+/// over a read hiccup. But reporting it as `Stored` is wrong in the other
+/// direction: `store_token` returning `Ok` proves a write happened, not
+/// that `jkt` survived it — and a store that silently drops `jkt` is the
+/// exact failure this probe exists to catch, so an unreadable probe
+/// against such a store must not be read as confirmation. Routing it to
+/// `NonFatalStorageFailure` gives each call site the right answer without
+/// a parameter: the pre-consumption sites omit the unconfirmed token, and
+/// the rotation site (where that arm is a no-op) is unaffected.
 async fn store_refresh_token_verifying_dpop_binding<S: OpStore + ?Sized>(
     op_store: &S,
     rt: RefreshToken,
@@ -1158,25 +1184,33 @@ async fn store_refresh_token_verifying_dpop_binding<S: OpStore + ?Sized>(
             RefreshTokenStoreOutcome::DpopBindingFailed
         }
         Ok(None) => {
-            // The write already succeeded — this is a confirmation gap,
-            // not evidence the binding was dropped. Most plausibly a
-            // lagging read replica hasn't caught up to the write yet.
-            // Trust the write rather than fail a request that has already
-            // consumed a predecessor token.
+            // Inconclusive, not a confirmed drop: `store_token` already
+            // returned `Ok`, so this is most plausibly a lagging read
+            // replica. But it is equally the shape of a store that simply
+            // didn't persist, so don't *advertise* a binding nothing has
+            // confirmed — `NonFatalStorageFailure` omits the refresh token
+            // at the pre-consumption call sites while leaving the rotation
+            // path (which treats it identically to `Stored`) untouched.
             tracing::warn!(
                 "could not confirm refresh token's DPoP binding: the token was not found on \
                  read-back immediately after a successful write (possible replica lag); \
-                 trusting the write rather than failing an already-committed rotation"
+                 omitting the unconfirmed refresh token rather than advertising a binding \
+                 no read has confirmed"
             );
-            RefreshTokenStoreOutcome::Stored
+            RefreshTokenStoreOutcome::NonFatalStorageFailure
         }
         Err(e) => {
+            // Same reasoning as `Ok(None)` above. Notably *not* treated as
+            // proof the write is fine: a store whose `store_token` drops
+            // `jkt` is exactly what this probe hunts for, and its
+            // `get_token` erroring tells us nothing either way.
             tracing::warn!(
                 error = ?e,
                 "could not confirm refresh token's DPoP binding after a successful write; \
-                 trusting the write rather than failing an already-committed rotation"
+                 omitting the unconfirmed refresh token rather than advertising a binding \
+                 no read has confirmed"
             );
-            RefreshTokenStoreOutcome::Stored
+            RefreshTokenStoreOutcome::NonFatalStorageFailure
         }
     }
 }
@@ -5738,6 +5772,168 @@ mod tests {
             assert_eq!(err.error, "server_error");
         }
 
+        // --- An unconfirmable read-back is neither a confirmed failure nor
+        // a confirmation (authkestra#290 review, findings #2 and #3) ---
+
+        /// Wraps any `OpStore`, persisting `store_token` faithfully (so
+        /// the binding really *is* stored) but answering every `get_token`
+        /// with `Ok(None)` — the shape a read served by a lagging replica
+        /// produces immediately after a write lands on the primary, and
+        /// equally the shape of a store that quietly persisted nothing.
+        ///
+        /// Only the authorization-code path is exercised with this, and
+        /// that path calls `get_token` exactly once (the confirmation
+        /// probe), so blanketing the method is unambiguous here in a way
+        /// it would not be on the rotation path, which also uses
+        /// `get_token` for its pre-consumption candidate lookup.
+        struct UnreadableProbeStore<Inner> {
+            inner: Inner,
+        }
+
+        #[async_trait::async_trait]
+        impl<Inner: OpStore> crate::client::ClientStore for UnreadableProbeStore<Inner> {
+            async fn find_client(
+                &self,
+                client_id: &str,
+            ) -> Result<Option<ClientRegistration>, OpError> {
+                self.inner.find_client(client_id).await
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl<Inner: OpStore> crate::code::AuthorizationCodeStore for UnreadableProbeStore<Inner> {
+            async fn store_code(&self, code: AuthorizationCode) -> Result<(), OpError> {
+                self.inner.store_code(code).await
+            }
+
+            async fn consume_code(&self, code: &str) -> Result<Option<AuthorizationCode>, OpError> {
+                self.inner.consume_code(code).await
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl<Inner: OpStore> RefreshTokenStore for UnreadableProbeStore<Inner> {
+            async fn store_token(&self, token: RefreshToken) -> Result<(), OpError> {
+                self.inner.store_token(token).await
+            }
+
+            async fn get_token(&self, _token: &str) -> Result<Option<RefreshToken>, OpError> {
+                Ok(None)
+            }
+
+            async fn revoke_token(&self, token: &str) -> Result<(), OpError> {
+                self.inner.revoke_token(token).await
+            }
+
+            async fn consume_token(&self, token: &str) -> Result<Option<RefreshToken>, OpError> {
+                self.inner.consume_token(token).await
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl<Inner: OpStore> crate::device::DeviceCodeStore for UnreadableProbeStore<Inner> {
+            async fn store_device_code(
+                &self,
+                session: crate::device::DeviceCodeSession,
+            ) -> Result<(), OpError> {
+                self.inner.store_device_code(session).await
+            }
+
+            async fn get_device_code(
+                &self,
+                device_code: &str,
+            ) -> Result<Option<crate::device::DeviceCodeSession>, OpError> {
+                self.inner.get_device_code(device_code).await
+            }
+
+            async fn get_by_user_code(
+                &self,
+                user_code: &str,
+            ) -> Result<Option<crate::device::DeviceCodeSession>, OpError> {
+                self.inner.get_by_user_code(user_code).await
+            }
+
+            async fn update_device_code(
+                &self,
+                session: crate::device::DeviceCodeSession,
+            ) -> Result<(), OpError> {
+                self.inner.update_device_code(session).await
+            }
+
+            async fn delete_device_code(&self, device_code: &str) -> Result<(), OpError> {
+                self.inner.delete_device_code(device_code).await
+            }
+
+            async fn consume_device_code(
+                &self,
+                device_code: &str,
+            ) -> Result<Option<crate::device::DeviceCodeSession>, OpError> {
+                self.inner.consume_device_code(device_code).await
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl<Inner: OpStore> OpStore for UnreadableProbeStore<Inner> {
+            async fn check_and_record_dpop_jti(
+                &self,
+                jti: &str,
+                expires_at: chrono::DateTime<Utc>,
+            ) -> Result<bool, OpError> {
+                self.inner.check_and_record_dpop_jti(jti, expires_at).await
+            }
+        }
+
+        /// The call-site half of findings #2 and #3, which the helper-level
+        /// tests below cannot see: what the *client* actually receives.
+        ///
+        /// An authorization-code exchange requesting `offline_access` with
+        /// a valid DPoP proof, against a store whose confirmation read-back
+        /// comes back empty, must return a successful response that simply
+        /// omits `refresh_token` — not a token whose advertised binding no
+        /// read has confirmed, and not a `server_error` either.
+        ///
+        /// This pins the fix in both directions at once. Route the
+        /// inconclusive arm back to `Stored` and the `refresh_token`
+        /// assertion fails on `Some(_)`; route it to `DpopBindingFailed`
+        /// (the pre-authkestra#290 behaviour) and the `expect` fails on
+        /// `server_error`.
+        #[tokio::test]
+        #[allow(deprecated)]
+        async fn an_unconfirmable_read_back_omits_the_refresh_token_instead_of_advertising_it() {
+            let (inner, verifier) = dpop_refresh_continuity_store().await;
+            let store = UnreadableProbeStore { inner };
+            let tokens = test_tokens();
+
+            let proof =
+                DpopProofBuilder::new("https://auth.example.com/token", "jti-unreadable-1").build();
+
+            let issued = handle_token_with_client_cert(
+                dpop_refresh_continuity_code_req(&verifier),
+                None,
+                &test_config(false),
+                &store,
+                &tokens,
+                None,
+                Some(&proof),
+            )
+            .await
+            .expect(
+                "an unconfirmable read-back must not fail a request whose write succeeded — \
+                 that is the session-destroying behaviour authkestra#290 finding #1 removed",
+            );
+
+            assert_eq!(
+                issued.token_type, "DPoP",
+                "the access token is still DPoP-bound; only the refresh token is in doubt"
+            );
+            assert!(
+                issued.refresh_token.is_none(),
+                "a refresh token whose DPoP binding no read has confirmed must be omitted, \
+                 not advertised: got {:?}",
+                issued.refresh_token
+            );
+        }
+
         // --- The read-back confirmation probe itself failing must not be
         // treated as a confirmed dropped binding (PR #290 review) ---
 
@@ -5886,9 +6082,11 @@ mod tests {
                     .await;
 
             assert!(
-                matches!(outcome, RefreshTokenStoreOutcome::Stored),
+                matches!(outcome, RefreshTokenStoreOutcome::NonFatalStorageFailure),
                 "a transient read error confirming a binding that was already \
-                 successfully written must not be treated as a confirmed failure"
+                 successfully written is inconclusive: neither a confirmed failure \
+                 (which would destroy an already-rotated session) nor a confirmation \
+                 (which would advertise a binding no read has seen)"
             );
         }
 
@@ -5908,9 +6106,9 @@ mod tests {
                     .await;
 
             assert!(
-                matches!(outcome, RefreshTokenStoreOutcome::Stored),
+                matches!(outcome, RefreshTokenStoreOutcome::NonFatalStorageFailure),
                 "a confirmation read that simply hasn't caught up to an already-successful \
-                 write must not be treated as a confirmed failure"
+                 write is inconclusive: neither a confirmed failure nor a confirmation"
             );
         }
     }

--- a/crates/authkestra-op/src/sqlx_store.rs
+++ b/crates/authkestra-op/src/sqlx_store.rs
@@ -15,6 +15,77 @@ pub struct SqlxOpStore<DB: sqlx::Database> {
     pool: sqlx::Pool<DB>,
 }
 
+/// Add `column` to `table` (in the `authkestra` schema) if it isn't
+/// already there.
+///
+/// Postgres *does* support `ADD COLUMN IF NOT EXISTS`, but it still takes
+/// an ACCESS EXCLUSIVE lock on the relation before discovering there is
+/// nothing to do — and because Postgres lock requests are FIFO, an ALTER
+/// that queues behind a long-running transaction blocks every subsequent
+/// read of that table until the blocker clears. `migrate()` runs at every
+/// startup, so probing the catalog first keeps the steady state lock-free.
+/// The `IF NOT EXISTS` is retained *inside* the guard so a concurrently
+/// starting replica racing the same ALTER is still handled by Postgres
+/// itself, under the lock — which is why this backend needs no equivalent
+/// of `is_sqlite_duplicate_column`/`is_mysql_duplicate_column`.
+///
+/// `table_schema` is not optional here: `information_schema.columns` spans
+/// every schema the role can see, so an unqualified probe would be
+/// satisfied by a host application's own same-named table in `public` and
+/// would skip an ALTER that `authkestra`'s table still needs.
+#[cfg(feature = "sqlx-postgres")]
+async fn ensure_postgres_column(
+    pool: &sqlx::PgPool,
+    table: &str,
+    column: &str,
+    add_column_ddl: &str,
+) -> Result<(), sqlx::Error> {
+    let exists: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM information_schema.columns
+         WHERE table_schema = 'authkestra' AND table_name = $1 AND column_name = $2",
+    )
+    .bind(table)
+    .bind(column)
+    .fetch_one(pool)
+    .await?;
+    if exists == 0 {
+        sqlx::query(&format!(
+            "ALTER TABLE authkestra.{table} ADD COLUMN IF NOT EXISTS {add_column_ddl}"
+        ))
+        .execute(pool)
+        .await?;
+    }
+    Ok(())
+}
+
+/// True only for "the column is already there" — the exact error the loser
+/// of a check-then-ALTER race gets when another process added the column
+/// between our `pragma_table_info` probe and our `ALTER`.
+///
+/// SQLite reports this as plain `SQLITE_ERROR` (1), the same extended
+/// result code as a syntax error or a missing table, so `code()` cannot
+/// discriminate it. The message is the only reliable signal, and its text
+/// is fixed in SQLite's `alter.c` as `duplicate column name: <name>`.
+#[cfg(feature = "sqlx-sqlite")]
+fn is_sqlite_duplicate_column(e: &sqlx::Error) -> bool {
+    // `message()` resolves through the `dyn DatabaseError` object itself, so
+    // no trait import is needed here (nor in the MySQL classifier below).
+    e.as_database_error()
+        .is_some_and(|db| db.message().starts_with("duplicate column name:"))
+}
+
+/// True only for MySQL `ER_DUP_FIELDNAME` (1060, SQLSTATE 42S21) — see the
+/// SQLite equivalent above for why this narrow tolerance exists.
+///
+/// Matched on the error *number*, not the message or SQLSTATE: a missing
+/// table (1146) or a bad column type (1064) stays fatal.
+#[cfg(feature = "sqlx-mysql")]
+fn is_mysql_duplicate_column(e: &sqlx::Error) -> bool {
+    e.as_database_error()
+        .and_then(|db| db.try_downcast_ref::<sqlx::mysql::MySqlDatabaseError>())
+        .is_some_and(|db| db.number() == 1060)
+}
+
 /// Add `column` to `table` if it isn't already there.
 ///
 /// SQLite has no `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` (unlike
@@ -35,9 +106,18 @@ async fn ensure_sqlite_column(
     .fetch_one(pool)
     .await?;
     if exists == 0 {
-        sqlx::query(&format!("ALTER TABLE {table} ADD COLUMN {add_column_ddl}"))
+        // A concurrently-starting replica may have added the column between
+        // the probe above and here; that is the *intended* end state, so it
+        // is success, not a failed migration. Nothing else is tolerated —
+        // see `is_sqlite_duplicate_column`.
+        if let Err(e) = sqlx::query(&format!("ALTER TABLE {table} ADD COLUMN {add_column_ddl}"))
             .execute(pool)
-            .await?;
+            .await
+        {
+            if !is_sqlite_duplicate_column(&e) {
+                return Err(e);
+            }
+        }
     }
     Ok(())
 }
@@ -65,9 +145,16 @@ async fn ensure_mysql_column(
     .fetch_one(pool)
     .await?;
     if exists == 0 {
-        sqlx::query(&format!("ALTER TABLE {table} ADD COLUMN {add_column_ddl}"))
+        // See `ensure_sqlite_column`'s identical comment: only the losing
+        // side of a check-then-ALTER race is tolerated here.
+        if let Err(e) = sqlx::query(&format!("ALTER TABLE {table} ADD COLUMN {add_column_ddl}"))
             .execute(pool)
-            .await?;
+            .await
+        {
+            if !is_mysql_duplicate_column(&e) {
+                return Err(e);
+            }
+        }
     }
     Ok(())
 }
@@ -544,7 +631,6 @@ impl_opstore_sql! {
                 expires_at TIMESTAMPTZ NOT NULL,
                 last_polled_at TIMESTAMPTZ
             );
-
             -- authkestra#291: RFC 9449 §11.1 DPoP proof replay tracking.
             -- No foreign key to oauth_clients: a `jti` is client-generated
             -- and checked before the grant is dispatched, so it is not
@@ -554,18 +640,19 @@ impl_opstore_sql! {
                 jti VARCHAR(255) PRIMARY KEY,
                 expires_at TIMESTAMPTZ NOT NULL
             );
-
-            -- authkestra#287: additive columns for RFC 9449 DPoP
-            -- refresh-token key continuity and RFC 7523 private_key_jwt.
-            -- `IF NOT EXISTS` makes this safe to run on every startup,
-            -- against both a fresh install (just created above) and an
-            -- existing deployment upgrading from before these columns
-            -- existed.
-            ALTER TABLE authkestra.oauth_refresh_tokens ADD COLUMN IF NOT EXISTS jkt VARCHAR(255);
-            ALTER TABLE authkestra.oauth_clients ADD COLUMN IF NOT EXISTS token_endpoint_auth_method JSONB;
-            ALTER TABLE authkestra.oauth_clients ADD COLUMN IF NOT EXISTS jwks JSONB;
             "#
         ).await?;
+
+        // authkestra#287: additive columns for RFC 9449 DPoP refresh-token
+        // key continuity and RFC 7523 private_key_jwt. Safe to run on every
+        // startup, against both a fresh install (just created above) and an
+        // existing deployment upgrading from before these columns existed —
+        // and catalog-guarded so the steady-state startup takes no ACCESS
+        // EXCLUSIVE lock on either table. See `ensure_postgres_column`.
+        ensure_postgres_column(&self.pool, "oauth_refresh_tokens", "jkt", "jkt VARCHAR(255)").await?;
+        ensure_postgres_column(&self.pool, "oauth_clients", "token_endpoint_auth_method", "token_endpoint_auth_method JSONB").await?;
+        ensure_postgres_column(&self.pool, "oauth_clients", "jwks", "jwks JSONB").await?;
+
         Ok(())
     },
     // consume_code (Postgres specific)
@@ -1554,6 +1641,93 @@ mod postgres_tests {
         }
         assert_eq!(winners, 1, "exactly one concurrent claim may win");
     }
+
+    /// authkestra#290 (PR review, finding #4): `ensure_postgres_column`
+    /// probes `information_schema.columns`, which spans every schema the
+    /// role can see. Without the `table_schema = 'authkestra'` predicate a
+    /// host application's own `public.oauth_clients` satisfies the probe
+    /// and the ALTER that `authkestra.oauth_clients` still needs is
+    /// skipped — silently, with the breakage surfacing later as a storage
+    /// error on every `find_client`.
+    ///
+    /// Drop the qualifier from the probe and this test fails on
+    /// `find_client`, not on `migrate()`, which is exactly what makes the
+    /// unqualified version dangerous.
+    #[tokio::test]
+    async fn test_postgres_migration_is_not_confused_by_a_same_named_table_in_public() {
+        let container = Postgres::default()
+            .with_env_var("POSTGRES_PASSWORD", "postgres")
+            .with_env_var("POSTGRES_USER", "postgres")
+            .with_env_var("POSTGRES_DB", "postgres")
+            .start()
+            .await
+            .unwrap();
+        let port = container.get_host_port_ipv4(5432).await.unwrap();
+        let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .connect(&url)
+            .await
+            .unwrap();
+
+        // The pre-#287 authkestra schema (no new columns), plus an
+        // unrelated host-app table of the same name in `public` that
+        // *does* already have a `jwks` column.
+        use sqlx::Executor;
+        pool.execute(
+            "CREATE SCHEMA IF NOT EXISTS authkestra;
+             CREATE TABLE authkestra.oauth_clients (
+                client_id VARCHAR(255) PRIMARY KEY,
+                client_secret_hash VARCHAR(255),
+                require_pkce BOOLEAN NOT NULL DEFAULT TRUE,
+                redirect_uris JSONB NOT NULL,
+                grant_types JSONB NOT NULL,
+                scopes JSONB NOT NULL,
+                allowed_audiences JSONB NOT NULL
+            );
+            CREATE TABLE authkestra.oauth_refresh_tokens (
+                token VARCHAR(255) PRIMARY KEY,
+                client_id VARCHAR(255) NOT NULL REFERENCES authkestra.oauth_clients(client_id) ON DELETE CASCADE,
+                identity JSONB NOT NULL,
+                scope TEXT NOT NULL,
+                expires_at TIMESTAMPTZ NOT NULL,
+                revoked_at TIMESTAMPTZ
+            );
+            CREATE TABLE public.oauth_clients (
+                client_id VARCHAR(255) PRIMARY KEY,
+                jwks JSONB
+            );",
+        )
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO authkestra.oauth_clients
+             (client_id, client_secret_hash, require_pkce, redirect_uris, grant_types, scopes, allowed_audiences)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)"
+        )
+        .bind("shadowed_client")
+        .bind("hash")
+        .bind(true)
+        .bind(sqlx::types::Json(vec!["http://localhost/cb"]))
+        .bind(sqlx::types::Json(vec!["authorization_code"]))
+        .bind(sqlx::types::Json(vec!["openid"]))
+        .bind(sqlx::types::Json(vec!["aud"]))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let store = SqlxOpStore::<sqlx::Postgres>::new(pool);
+        store.migrate().await.expect("migrate must succeed");
+
+        let client = store
+            .find_client("shadowed_client")
+            .await
+            .expect("find_client must not fail: the ALTER must have been applied to authkestra.oauth_clients, not skipped because public.oauth_clients happened to have a jwks column")
+            .expect("the client must be found");
+        assert_eq!(client.jwks, None);
+        assert_eq!(client.token_endpoint_auth_method, None);
+    }
 }
 
 #[cfg(all(test, feature = "sqlx-sqlite"))]
@@ -2072,6 +2246,46 @@ mod sqlite_tests {
             "exactly one concurrent claim of the same jti may win"
         );
     }
+
+    /// authkestra#290 (PR review, finding #1): `ensure_sqlite_column`'s
+    /// probe-then-ALTER is not atomic. Two replicas calling `migrate()` at
+    /// the same time both see the column as absent and both issue the
+    /// `ALTER`; the loser must treat "it's already there" as the intended
+    /// end state, not as a failed migration that aborts startup.
+    ///
+    /// Driven deterministically rather than by racing two tasks: the probe
+    /// is asked about a name that genuinely doesn't exist while the DDL
+    /// names one that does, which produces byte-for-byte the error the
+    /// losing replica receives.
+    #[tokio::test]
+    async fn test_sqlite_ensure_column_tolerates_a_concurrent_duplicate_add() {
+        let store = setup_db().await;
+
+        ensure_sqlite_column(
+            &store.pool,
+            "authkestra_oauth_clients",
+            "not_a_real_column",
+            "client_id TEXT",
+        )
+        .await
+        .expect("a duplicate-column ALTER must be treated as already-migrated");
+    }
+
+    /// The other half of the finding #1 fix, and the reason it can't be a
+    /// blanket `.ok()`: everything that is *not* a duplicate column must
+    /// still abort the migration.
+    #[tokio::test]
+    async fn test_sqlite_ensure_column_still_propagates_unrelated_alter_failures() {
+        let store = setup_db().await;
+
+        let err = ensure_sqlite_column(&store.pool, "no_such_table", "c", "c TEXT")
+            .await
+            .expect_err("a missing table must stay fatal");
+        assert!(
+            !is_sqlite_duplicate_column(&err),
+            "a missing table must not be classified as a duplicate column: {err:?}"
+        );
+    }
 }
 
 #[cfg(all(test, feature = "sqlx-mysql"))]
@@ -2491,5 +2705,38 @@ mod mysql_tests {
             }
         }
         assert_eq!(winners, 1, "exactly one concurrent claim may win");
+    }
+
+    /// authkestra#290 (PR review, finding #1) — the MySQL half. See
+    /// `sqlite_tests`'s identically named test for the reasoning and for
+    /// why the race is driven deterministically instead of with two tasks.
+    /// MySQL reports this as `ER_DUP_FIELDNAME` (1060, SQLSTATE 42S21).
+    #[tokio::test]
+    async fn test_mysql_ensure_column_tolerates_a_concurrent_duplicate_add() {
+        let (store, _c) = setup_db().await;
+
+        ensure_mysql_column(
+            &store.pool,
+            "authkestra_oauth_clients",
+            "not_a_real_column",
+            "client_id VARCHAR(255)",
+        )
+        .await
+        .expect("a duplicate-column ALTER must be treated as already-migrated");
+    }
+
+    /// The other half of the finding #1 fix: a missing table is MySQL 1146,
+    /// not 1060, and must still abort the migration.
+    #[tokio::test]
+    async fn test_mysql_ensure_column_still_propagates_unrelated_alter_failures() {
+        let (store, _c) = setup_db().await;
+
+        let err = ensure_mysql_column(&store.pool, "no_such_table", "c", "c VARCHAR(255)")
+            .await
+            .expect_err("a missing table must stay fatal");
+        assert!(
+            !is_mysql_duplicate_column(&err),
+            "a missing table must not be classified as a duplicate column: {err:?}"
+        );
     }
 }

--- a/website/src/content/docs/storage/sql-store.md
+++ b/website/src/content/docs/storage/sql-store.md
@@ -98,9 +98,39 @@ ALTER TABLE authkestra_oauth_clients ADD COLUMN token_endpoint_auth_method JSON;
 ALTER TABLE authkestra_oauth_clients ADD COLUMN jwks JSON;
 ```
 
-All three are nullable and additive: existing rows simply have `NULL` in them, read back as
-`jkt: None` / `token_endpoint_auth_method: None` / `jwks: None`, exactly as if the client or
+All three columns are nullable and additive: existing rows simply have `NULL` in them, read back
+as `jkt: None` / `token_endpoint_auth_method: None` / `jwks: None`, exactly as if the client or
 refresh token predates this release.
+
+**`token_endpoint_auth_method` and `jwks` hold JSON, not bare text.** `find_client` decodes both
+through `sqlx`'s `Json` type and — deliberately — returns a storage error rather than silently
+falling back to `None` when a non-`NULL` value fails to decode, because `None` means "no client
+authentication configured". On Postgres and MySQL the `JSONB`/`JSON` column type rejects a
+malformed value at `INSERT` time; on SQLite the column is plain `TEXT` and will accept anything,
+so the mistake only surfaces later, as a `500` on every authorize and token request for that
+client.
+
+`token_endpoint_auth_method` is a JSON **string**, so it must carry its quotes, and its value is
+one of `"client_secret_basic"`, `"client_secret_post"`, `"private_key_jwt"`, or `"none"`:
+
+```sql
+-- correct
+UPDATE authkestra_oauth_clients SET token_endpoint_auth_method = '"private_key_jwt"' WHERE client_id = 'my-client';
+-- WRONG: not valid JSON — every lookup of this client now fails with a storage error
+UPDATE authkestra_oauth_clients SET token_endpoint_auth_method = 'private_key_jwt' WHERE client_id = 'my-client';
+-- WRONG: valid JSON, but not a method this release models — also a storage error, by design
+UPDATE authkestra_oauth_clients SET token_endpoint_auth_method = '"client_secret_jwt"' WHERE client_id = 'my-client';
+```
+
+`jwks` is the client's JWK Set **object**, exactly as RFC 7517 §5 defines it — `{"keys": [ ... ]}`,
+not a bare array and not a URL:
+
+```sql
+-- correct
+UPDATE authkestra_oauth_clients SET jwks = '{"keys":[{"kty":"EC","crv":"P-256","x":"...","y":"...","kid":"k1"}]}' WHERE client_id = 'my-client';
+-- WRONG: bare array, missing the "keys" wrapper
+UPDATE authkestra_oauth_clients SET jwks = '[{"kty":"EC","crv":"P-256","x":"...","y":"..."}]' WHERE client_id = 'my-client';
+```
 
 ### Initialization & Migration
 


### PR DESCRIPTION
Post-merge review of #290 surfaced six issues; this closes all of them, plus one stale doc comment.

## Findings

**1 — `migrate()` was not concurrency-safe (could stop a replica booting).** `ensure_sqlite_column`/`ensure_mysql_column` did `SELECT COUNT(*)` then `ALTER TABLE ADD COLUMN`. Two replicas starting together (rolling deploy, scale-up) both observed the column absent, both ALTERed, and the loser got `Duplicate column name` — a fatal error out of a call the docs call idempotent two lines above the snippet. The pre-#290 `CREATE TABLE IF NOT EXISTS` body had no such window.

Each backend now tolerates *only* the duplicate-column error:
- **SQLite** — matched on the message `duplicate column name:`. Verified empirically: `code()` returns the extended result code, which for this is plain `SQLITE_ERROR` (1), identical to a syntax error or a missing table. There is no code-level discriminator; the message is the only reliable signal, and its text is fixed in SQLite's `alter.c`.
- **MySQL** — matched on error number 1060 (`ER_DUP_FIELDNAME`), not the message or SQLSTATE. A missing table (1146) or bad column type (1064) stays fatal.

**2 + 3 — the DPoP read-back probe failed open on the case it exists for.** Both inconclusive outcomes returned `Stored`. The probe exists to catch a `RefreshTokenStore` whose `store_token` returns `Ok` while dropping `jkt` — and for such a store a successful write is exactly compatible with the binding being absent, so `Err` from its `get_token` is not inconclusive in the intended sense. The result was a `token_type: "DPoP"` response whose refresh token later skipped the RFC 9449 §5 continuity check entirely.

Both arms now return `NonFatalStorageFailure`. **No parameter or second entry point was needed** — the call sites already encode the distinction: the rotation site treats that arm identically to `Stored`, so its post-consumption behaviour is byte-identical to before, while the two pre-consumption sites omit a refresh token whose binding could not be confirmed. This does not reintroduce the session destruction fixed in #290: at the rotation site the arm is a no-op.

**4 — Postgres ALTERs took ACCESS EXCLUSIVE on every startup.** `ADD COLUMN IF NOT EXISTS` still locks the relation before discovering there is nothing to do, and because Postgres lock requests are FIFO, an ALTER queued behind a long transaction blocks every subsequent read of that table — stalling all token issuance and client lookup. Now guarded by an `information_schema` probe.

The `table_schema = 'authkestra'` qualifier is load-bearing, not cosmetic: `information_schema.columns` spans every visible schema, so unqualified, a host app's own `public.oauth_clients` would satisfy the count and the guard would skip an ALTER that `authkestra.oauth_clients` still needs — after which every `find_client` fails. `IF NOT EXISTS` is retained inside the guard so a concurrent replica is still handled by Postgres, under the lock.

**5 — the sqlx dev-dependency was unnecessary and its comment was wrong.** It claimed to supply `migrate`. It didn't: `migrate` is in sqlx 0.8's default feature set and the main dependency does not set `default-features = false`, so `sqlx/migrate` was already on whenever the `sqlx` feature was. Being non-optional, it made every feature-less test build of this crate compile all of sqlx — in a configuration with no `runtime-tokio`.

**6 — the hand-managed-schema docs omitted the required value encoding.** `find_client` decodes `token_endpoint_auth_method`/`jwks` through `Json<T>` and, by design in #290, fails closed on a decode error rather than falling back to `None` (which means "no client authentication"). On Postgres/MySQL the column type rejects malformed values at INSERT; on SQLite the column is plain `TEXT` and accepts anything, so the mistake surfaces later as a 500 on every authorize and token request for that client. Now documented with correct/incorrect examples for both columns.

Also drops a doc comment added in #286 citing `sqlx_store.rs` as a live example of a backend that drops `jkt` "right now" — falsified by #290 four commits later.

## Verification

Every fix landed with tests, and the ones where a passing test proves little were mutation-checked in **both** directions:

| Check | Result |
|---|---|
| #1 SQLite: revert the tolerance | duplicate-column test FAILS, missing-table passes |
| #1 SQLite: broaden to blanket `.ok()` | missing-table test FAILS, duplicate passes |
| #1 MySQL: both of the above | same, on 1060 vs 1146 |
| #2+3: revert to `Stored` | call-site test FAILS on `refresh_token: Some(_)` |
| #2+3: set to `DpopBindingFailed` | call-site test FAILS on `server_error` |
| #4: drop `table_schema = 'authkestra'` | public-schema test FAILS on `find_client … : Storage` |
| #5 | ran the existing collision test rather than trusting the manifest — passes with the dev-dep gone |

The #1 pair is the point: neither test alone pins the fix — one catches reverting it, the other catches over-broadening it.

Gates: `cargo test --workspace --all-features` 41 suites, 0 failures (container-backed Postgres/MySQL/Redis all ran); `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)