### PR TITLE
fix(op)!: re-validate refresh token scope against the client's registration

### DIFF
--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -1426,6 +1426,36 @@ pub(crate) async fn default_handle_refresh_token<S: OpStore + ?Sized>(
             });
         }
     }
+    // RFC 6749 §6: a refresh token's scope is fixed at issuance, but the
+    // client's *registration* is not — an operator can narrow `scopes` at
+    // any time, and authkestra#278 made that narrowing the mechanism for
+    // revoking a scope. Without re-checking here, a refresh token issued
+    // before the narrowing keeps minting access tokens for the removed
+    // scope indefinitely, rotating a fresh 30-day token forward on every
+    // use, so the narrowing never takes effect for exactly the clients
+    // that already hold long-lived credentials. Every sibling grant
+    // already validates against the live registration (`handle_authorize`,
+    // `handle_device_authorization`, `handle_client_credentials`,
+    // `default_handle_token_exchange`); this was the one path that did
+    // not.
+    //
+    // Checked here, against the non-destructive `candidate`, rather than
+    // after `consume_token` below: a request that is refused must not
+    // destroy the token it had no right to consume (authkestra#287).
+    for scope in candidate.scope.split_whitespace() {
+        if !client.allows_scope(scope) {
+            tracing::warn!(
+                client_id = %client_id,
+                scope = %scope,
+                "Refresh token carries a scope the client is no longer registered for"
+            );
+            return Err(TokenErrorResponse {
+                error: "invalid_scope".to_string(),
+                error_description: format!("Scope {} is not allowed for this client", scope),
+            });
+        }
+    }
+
     // Carries the rotated token's binding forward. Deliberately reads from
     // `candidate.jkt` rather than `req.dpop_jkt` when the token was already
     // bound (the branch above already proved they're equal) — the stored,
@@ -3080,7 +3110,7 @@ mod tests {
                     client_secret_hash: None,
                     redirect_uris: vec![],
                     grant_types: vec![GrantType::RefreshToken],
-                    scopes: vec![],
+                    scopes: vec!["openid".to_string()],
                     require_pkce: false,
                     allowed_audiences: vec![],
                     token_endpoint_auth_method: None,
@@ -3263,13 +3293,159 @@ mod tests {
         }
     }
 
+    /// authkestra#278 made narrowing a client's registered `scopes` the way
+    /// to revoke a scope. A refresh token issued before the narrowing must
+    /// not keep minting access tokens for the removed scope.
+    #[tokio::test]
+    async fn test_refresh_token_rejects_a_scope_the_client_lost() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<ClientRegistration>::new();
+        let mut narrowed = refresh_test_client();
+        // The operator has since revoked `profile`.
+        narrowed.scopes = vec!["openid".to_string()];
+        clients
+            .set(
+                "client1",
+                narrowed,
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let refresh =
+            authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new();
+        refresh
+            .store_token(RefreshToken {
+                token: "rt-narrowed".to_string(),
+                client_id: "client1".to_string(),
+                identity: test_identity(),
+                scope: "openid profile".to_string(),
+                expires_at: Utc::now() + Duration::days(1),
+                jkt: None,
+            })
+            .await
+            .unwrap();
+
+        let res = handle_token(
+            refresh_test_req("rt-narrowed"),
+            None,
+            &test_config(false),
+            &crate::store::CompositeOpStore::new(
+                clients,
+                authkestra_engine::store::memory::MemoryStore::<AuthorizationCode>::new(),
+                refresh,
+                authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(),
+            ),
+            &test_tokens(),
+        )
+        .await;
+
+        let err = res.expect_err("a revoked scope must not be renewable");
+        assert_eq!(err.error, "invalid_scope");
+        assert!(
+            err.error_description.contains("profile"),
+            "the error must name the offending scope, not just the class: {}",
+            err.error_description
+        );
+    }
+
+    /// The placement half of the fix, and the reason the check sits against
+    /// the non-destructive `candidate` rather than after `consume_token`:
+    /// a request that is refused must not destroy the token it had no right
+    /// to consume (authkestra#287). Moving the check below `consume_token`
+    /// passes the test above and fails this one.
+    #[tokio::test]
+    async fn test_refresh_token_scope_rejection_does_not_consume_the_token() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<ClientRegistration>::new();
+        let mut narrowed = refresh_test_client();
+        narrowed.scopes = vec!["openid".to_string()];
+        clients
+            .set(
+                "client1",
+                narrowed.clone(),
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let refresh =
+            authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new();
+        refresh
+            .store_token(RefreshToken {
+                token: "rt-survives".to_string(),
+                client_id: "client1".to_string(),
+                identity: test_identity(),
+                scope: "openid profile".to_string(),
+                expires_at: Utc::now() + Duration::days(1),
+                jkt: None,
+            })
+            .await
+            .unwrap();
+
+        let store = crate::store::CompositeOpStore::new(
+            clients.clone(),
+            authkestra_engine::store::memory::MemoryStore::<AuthorizationCode>::new(),
+            refresh.clone(),
+            authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new(
+            ),
+        );
+
+        let err = handle_token(
+            refresh_test_req("rt-survives"),
+            None,
+            &test_config(false),
+            &store,
+            &test_tokens(),
+        )
+        .await
+        .expect_err("must be refused");
+        assert_eq!(err.error, "invalid_scope");
+
+        // The refused request must have left the token intact.
+        assert!(
+            crate::refresh::RefreshTokenStore::get_token(&refresh, "rt-survives")
+                .await
+                .unwrap()
+                .is_some(),
+            "a refused request must not consume the refresh token"
+        );
+
+        // And once the operator restores the scope, the very same token
+        // still works — proving the rejection was non-destructive rather
+        // than merely leaving a row behind.
+        clients
+            .set(
+                "client1",
+                refresh_test_client(),
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+        let ok = handle_token(
+            refresh_test_req("rt-survives"),
+            None,
+            &test_config(false),
+            &store,
+            &test_tokens(),
+        )
+        .await;
+        assert!(
+            ok.is_ok(),
+            "the same token must still be redeemable after the scope is restored"
+        );
+    }
+
     fn refresh_test_client() -> ClientRegistration {
         ClientRegistration {
             client_id: "client1".to_string(),
             client_secret_hash: None,
             redirect_uris: vec![],
             grant_types: vec![GrantType::RefreshToken],
-            scopes: vec![],
+            // Registered for the scopes these fixtures' refresh tokens
+            // carry. Previously `vec![]`, which authkestra#278 made
+            // self-contradictory: a client registered for no scopes can no
+            // longer obtain a scoped token in the first place, so the
+            // fixture described a state the OP cannot produce.
+            scopes: vec!["openid".to_string(), "profile".to_string()],
             require_pkce: false,
             allowed_audiences: vec![],
             token_endpoint_auth_method: None,


### PR DESCRIPTION
Found reviewing the `next` → `main` range (#292).

## The bug

`default_handle_refresh_token` referenced only `old_rt.scope` — the scope frozen into the token at issuance — and never compared it against the client's *current* registration.

That matters because #279/#278 made narrowing a client's `scopes` the mechanism for revoking a scope. Every other grant honours it:

| Grant | Validates against live registration |
|---|---|
| `handle_authorize` | ✅ |
| `handle_device_authorization` | ✅ |
| `handle_client_credentials` | ✅ |
| `default_handle_token_exchange` | ✅ |
| **`default_handle_refresh_token`** | ❌ |

So an operator who revoked `profile` from a client found that any client already holding a refresh token kept minting access tokens carrying `profile` — and rotated a **fresh 30-day** refresh token forward on every use. The revocation never took effect, indefinitely, for exactly the clients holding long-lived credentials.

The mutation run below shows it plainly. With the check removed, the response is:

```
scope: Some("openid profile"),  refresh_token: Some("a915da73-…")
```

`profile` had been revoked before that request.

## The fix

Reject with `invalid_scope`, naming the offending scope, matching `handle_client_credentials`'s existing shape.

**Not narrowed to the intersection.** RFC 6749 §3.3 permits either, but rejecting is what the rest of this crate does, and a narrowing that silently downgraded a token's authority would be a surprising way to discover a scope had been revoked.

**Placement is the subtle half.** The check sits against the non-destructive `candidate` (from `get_token`), *above* `consume_token` — so a refused request does not destroy the token it had no right to consume. That is the invariant #287 established after the earlier consume-before-check bug, and this fix would have quietly re-introduced that bug if the check had gone in the obvious place.

## Verification

Two new tests, and both mutation-checked, because the second one exists solely to pin a decision a passing test would not otherwise capture:

| Mutation | `rejects_a_scope_the_client_lost` | `scope_rejection_does_not_consume_the_token` |
|---|---|---|
| Remove the check entirely | **FAILS** (token minted with the revoked scope) | passes |
| Move the check below `consume_token` | passes | **FAILS** — "a refused request must not consume the refresh token" |

Neither test alone pins the fix: one catches the missing check, the other catches putting it in the wrong place. The second also re-redeems the *same* token after the operator restores the scope, proving the rejection was genuinely non-destructive rather than merely leaving a row behind.

Gates: `cargo test --workspace --all-features` 0 failures (`authkestra-op` lib 178); `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; `cargo fmt --all -- --check` clean.

## Breaking change

A client whose registered `scopes` no longer cover a scope its outstanding refresh tokens carry now receives `invalid_scope` on refresh instead of a renewed token. Deployments that narrowed a client's scopes and relied on existing sessions continuing must either re-widen the registration or let those sessions re-authorize.

Marked `!` so release-plz cuts the right version — worth flagging since #286 shipped a source-breaking `RefreshToken::new` signature change under a plain `feat(op):`.

## Note on the test fixtures

Five existing refresh tests failed on first run. Not a false positive in the check: they registered `scopes: vec![]` while storing tokens scoped `openid`/`profile`. That combination has been self-contradictory since #278 — a client registered for no scopes can no longer obtain a scoped token in the first place, so the fixtures described a state the OP cannot produce. They now register the scopes their tokens carry, which is what makes them exercise the real code path rather than an impossible one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)