### PR TITLE
fix(op)!: enforce RFC 9449 DPoP key binding at the /userinfo endpoint

### DIFF
--- a/crates/authkestra-actix/src/op.rs
+++ b/crates/authkestra-actix/src/op.rs
@@ -203,27 +203,72 @@ pub async fn actix_userinfo_handler(
     http_req: HttpRequest,
     config: web::Data<OpConfig>,
     tokens: web::Data<Arc<TokenManager>>,
+    // `/userinfo` is a protected resource, so a DPoP-bound token presented
+    // here needs the same replay guard `/token` uses (RFC 9449 §11.1).
+    op_store: web::Data<Arc<dyn authkestra_op::OpStore>>,
 ) -> impl Responder {
     tracing::debug!("Handling OP userinfo request (actix)");
+
+    let unauthorized = |scheme: &str, desc: &str| {
+        HttpResponse::Unauthorized()
+            .insert_header(("WWW-Authenticate", scheme.to_string()))
+            .json(UserInfoErrorResponse::new(
+                "invalid_request".to_string(),
+                desc.to_string(),
+            ))
+    };
+
+    // RFC 9110 §11.1 makes the auth-scheme token case-insensitive, and
+    // RFC 9449 §7.1 requires a DPoP-bound token to arrive under the `DPoP`
+    // scheme rather than `Bearer`. Which scheme was used is passed through
+    // to the handler, which refuses the two mismatches.
     let auth_header = match http_req
         .headers()
         .get(actix_web::http::header::AUTHORIZATION)
         .and_then(|h| h.to_str().ok())
     {
-        Some(h) if h.starts_with("Bearer ") => h,
-        _ => {
-            return HttpResponse::Unauthorized()
-                .insert_header(("WWW-Authenticate", "Bearer"))
-                .json(UserInfoErrorResponse::new(
-                    "invalid_request".to_string(),
-                    "Missing or invalid Authorization header".to_string(),
-                ));
-        }
+        Some(h) => h,
+        None => return unauthorized("Bearer", "Missing or invalid Authorization header"),
+    };
+    let (token, presented_as_dpop) = match auth_header.split_once(' ') {
+        Some((scheme, rest)) if scheme.eq_ignore_ascii_case("bearer") => (rest.trim(), false),
+        Some((scheme, rest)) if scheme.eq_ignore_ascii_case("dpop") => (rest.trim(), true),
+        _ => return unauthorized("Bearer", "Missing or invalid Authorization header"),
+    };
+    if token.is_empty() {
+        return unauthorized("Bearer", "Missing or invalid Authorization header");
+    }
+
+    let req = if presented_as_dpop {
+        let proof = match extract_dpop_header(http_req.headers()) {
+            Ok(p) => p.map(|p| p.to_string()),
+            Err(e) => {
+                return HttpResponse::Unauthorized()
+                    .insert_header(("WWW-Authenticate", "DPoP"))
+                    .json(UserInfoErrorResponse::new(e.error, e.error_description));
+            }
+        };
+        // `htu` is left `None`: behind a reverse proxy this handler cannot
+        // reconstruct the absolute URL the client signed. See
+        // `UserInfoRequest::htu`.
+        UserInfoRequest::new_dpop(
+            token.to_string(),
+            proof,
+            Some(http_req.method().as_str().to_string()),
+            None,
+        )
+    } else {
+        UserInfoRequest::new(token.to_string())
     };
 
-    let req = UserInfoRequest::new(auth_header[7..].to_string());
-
-    match handle_userinfo(req, config.get_ref(), tokens.get_ref().as_ref()).await {
+    match handle_userinfo(
+        req,
+        config.get_ref(),
+        tokens.get_ref().as_ref(),
+        op_store.get_ref().as_ref(),
+    )
+    .await
+    {
         Ok(resp) => HttpResponse::Ok().json(resp),
         Err(err) => {
             let status = match err.error.as_str() {

--- a/crates/authkestra-axum/src/op.rs
+++ b/crates/authkestra-axum/src/op.rs
@@ -250,10 +250,12 @@ where
 /// Handler for the userinfo endpoint.
 pub async fn axum_userinfo_handler<AppState>(
     State(state): State<AppState>,
+    method: axum::http::Method,
     headers: HeaderMap,
 ) -> Response
 where
     AppState: Clone + Send + Sync + 'static,
+    Result<Arc<dyn authkestra_op::OpStore>, AxumError>: FromRef<AppState>,
     Result<Arc<TokenManager>, AxumError>: FromRef<AppState>,
     OpConfig: FromRef<AppState>,
 {
@@ -262,30 +264,73 @@ where
         Ok(t) => t,
         Err(e) => return e.into_response(),
     };
+    // `/userinfo` is a protected resource, so a DPoP-bound token presented
+    // here needs the same replay guard `/token` uses (RFC 9449 §11.1).
+    let op_store = match <Result<Arc<dyn authkestra_op::OpStore>, AxumError>>::from_ref(&state) {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
 
+    let unauthorized = |scheme: &str, desc: &str| {
+        (
+            StatusCode::UNAUTHORIZED,
+            [("WWW-Authenticate", scheme.to_string())],
+            Json(UserInfoErrorResponse::new(
+                "invalid_request".to_string(),
+                desc.to_string(),
+            )),
+        )
+            .into_response()
+    };
+
+    // RFC 9110 §11.1 makes the auth-scheme token case-insensitive, and
+    // RFC 9449 §7.1 requires a DPoP-bound token to arrive under the `DPoP`
+    // scheme rather than `Bearer`. Which scheme was used is passed through
+    // to the handler, which refuses the two mismatches.
     let auth_header = match headers
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|h| h.to_str().ok())
     {
-        Some(h) if h.starts_with("Bearer ") => h,
-        _ => {
-            return (
-                StatusCode::UNAUTHORIZED,
-                [("WWW-Authenticate", "Bearer")],
-                Json(UserInfoErrorResponse::new(
-                    "invalid_request".to_string(),
-                    "Missing or invalid Authorization header".to_string(),
-                )),
-            )
-                .into_response();
-        }
+        Some(h) => h,
+        None => return unauthorized("Bearer", "Missing or invalid Authorization header"),
     };
+    let (token, presented_as_dpop) = match auth_header.split_once(' ') {
+        Some((scheme, rest)) if scheme.eq_ignore_ascii_case("bearer") => (rest.trim(), false),
+        Some((scheme, rest)) if scheme.eq_ignore_ascii_case("dpop") => (rest.trim(), true),
+        _ => return unauthorized("Bearer", "Missing or invalid Authorization header"),
+    };
+    if token.is_empty() {
+        return unauthorized("Bearer", "Missing or invalid Authorization header");
+    }
 
-    let req = UserInfoRequest::new(auth_header[7..].to_string());
+    let req = if presented_as_dpop {
+        let proof = match extract_dpop_header(&headers) {
+            Ok(p) => p.map(|p| p.to_string()),
+            Err(e) => {
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    [("WWW-Authenticate", "DPoP")],
+                    Json(UserInfoErrorResponse::new(e.error, e.error_description)),
+                )
+                    .into_response();
+            }
+        };
+        // `htu` is left `None`: behind a reverse proxy this handler cannot
+        // reconstruct the absolute URL the client signed. See
+        // `UserInfoRequest::htu`.
+        UserInfoRequest::new_dpop(
+            token.to_string(),
+            proof,
+            Some(method.as_str().to_string()),
+            None,
+        )
+    } else {
+        UserInfoRequest::new(token.to_string())
+    };
 
     let config = OpConfig::from_ref(&state);
 
-    match handle_userinfo(req, &config, tokens.as_ref()).await {
+    match handle_userinfo(req, &config, tokens.as_ref(), op_store.as_ref()).await {
         Ok(resp) => (StatusCode::OK, Json(resp)).into_response(),
         Err(err) => {
             let status = match err.error.as_str() {

--- a/crates/authkestra-op/src/handlers/userinfo.rs
+++ b/crates/authkestra-op/src/handlers/userinfo.rs
@@ -1,4 +1,5 @@
 use crate::config::OpConfig;
+use crate::store::OpStore;
 use authkestra_engine::token::TokenManager;
 use serde::Serialize;
 
@@ -8,6 +9,26 @@ use serde::Serialize;
 pub struct UserInfoRequest {
     /// The access token provided in the Authorization header.
     pub access_token: String,
+    /// Whether the token arrived under the `DPoP` auth-scheme rather than
+    /// `Bearer` (RFC 9449 §7.1).
+    ///
+    /// Tracked separately from `dpop_proof` because the two mismatches this
+    /// endpoint must reject are different: a DPoP-bound token presented as
+    /// `Bearer` (caught by this flag being `false`), and the `DPoP` scheme
+    /// used for a token that is not bound at all (caught by it being
+    /// `true`). A single `Option<proof>` cannot distinguish them.
+    pub presented_as_dpop: bool,
+    /// The request's `DPoP` header, if any.
+    pub dpop_proof: Option<String>,
+    /// The HTTP method of this userinfo request, for the proof's `htm`.
+    pub htm: Option<String>,
+    /// The absolute URL of this userinfo request, for the proof's `htu`.
+    ///
+    /// `None` skips the `htu` check — see
+    /// `authkestra_resource::ValidationConfig::dpop_resource_origin` for why
+    /// a resource server usually cannot reconstruct this behind a reverse
+    /// proxy, and what forwarding it leaves open.
+    pub htu: Option<String>,
 }
 
 /// Success response for the userinfo endpoint.
@@ -38,10 +59,18 @@ pub struct UserInfoErrorResponse {
 }
 
 /// Handles userinfo requests.
-pub async fn handle_userinfo(
+///
+/// `/userinfo` is a protected resource, so an access token this OP issued
+/// with a `cnf.jkt` confirmation claim must be proven here the same way
+/// `authkestra-resource` proves one — otherwise a stolen DPoP-bound token
+/// is refused at a hardened resource server and accepted at the issuing
+/// OP's own endpoint, which is the weaker of the two paths an attacker
+/// gets to choose from.
+pub async fn handle_userinfo<S: OpStore + ?Sized>(
     req: UserInfoRequest,
     _config: &OpConfig,
     tokens: &TokenManager,
+    op_store: &S,
 ) -> Result<UserInfoResponse, UserInfoErrorResponse> {
     tracing::debug!("Processing userinfo request");
 
@@ -56,6 +85,10 @@ pub async fn handle_userinfo(
             });
         }
     };
+
+    // 1b. RFC 9449 §7.1 key binding, before any claim of this token is
+    // acted on.
+    verify_dpop_binding(&req, claims.extra.get("cnf"), op_store).await?;
 
     // 2. Check scopes
     let scope_str = claims.scope.unwrap_or_default();
@@ -102,10 +135,167 @@ pub async fn handle_userinfo(
     Ok(response)
 }
 
+/// Reads `cnf.jkt` — the single "is this token DPoP-bound" predicate, so the
+/// scheme check and the proof check cannot drift on what "bound" means.
+fn dpop_bound_jkt(cnf: Option<&serde_json::Value>) -> Option<&str> {
+    cnf.and_then(|v| v.get("jkt")).and_then(|v| v.as_str())
+}
+
+/// Enforces RFC 9449 §7.1 for a userinfo request, in both directions.
+///
+/// - Token not bound, presented as `Bearer` — nothing to check.
+/// - Token **bound**, presented as `Bearer` — refused. This is the case
+///   that matters: without it a stolen DPoP-bound access token is fully
+///   usable at this endpoint just by dropping the scheme down to `Bearer`,
+///   which defeats the binding entirely.
+/// - Token not bound, presented as `DPoP` — refused. The RFC expects a
+///   server handling the `DPoP` scheme to validate a proof; silently
+///   ignoring one would let a client believe it had sender-constrained a
+///   request that in fact was not.
+/// - Token bound, presented as `DPoP` — the proof must verify, bind to this
+///   token via `ath`, carry the same key as `cnf.jkt`, and have a `jti` not
+///   already spent.
+async fn verify_dpop_binding<S: OpStore + ?Sized>(
+    req: &UserInfoRequest,
+    cnf: Option<&serde_json::Value>,
+    op_store: &S,
+) -> Result<(), UserInfoErrorResponse> {
+    let bound_jkt = dpop_bound_jkt(cnf);
+
+    let expected_jkt = match (bound_jkt, req.presented_as_dpop) {
+        (None, false) => return Ok(()),
+        (None, true) => {
+            tracing::warn!(
+                "userinfo request used the DPoP auth-scheme for a token with no cnf.jkt"
+            );
+            return Err(UserInfoErrorResponse {
+                error: "invalid_token".to_string(),
+                error_description: "This access token is not DPoP-bound; present it as Bearer"
+                    .to_string(),
+            });
+        }
+        (Some(_), false) => {
+            tracing::warn!(
+                "DPoP-bound access token presented to userinfo under the Bearer scheme; \
+                 refusing rather than honouring a binding the request never proved"
+            );
+            return Err(UserInfoErrorResponse {
+                error: "invalid_token".to_string(),
+                error_description:
+                    "This access token is DPoP-bound and must be presented with the DPoP scheme"
+                        .to_string(),
+            });
+        }
+        (Some(jkt), true) => jkt,
+    };
+
+    let Some(proof) = req.dpop_proof.as_deref() else {
+        tracing::warn!("DPoP-bound access token presented to userinfo with no DPoP proof header");
+        return Err(UserInfoErrorResponse {
+            error: "invalid_token".to_string(),
+            error_description: "A DPoP proof is required for this access token".to_string(),
+        });
+    };
+
+    // `ath` is what stops a proof minted for one access token being replayed
+    // with another: it is the SHA-256 of this exact token.
+    let ath =
+        authkestra_engine::token::cert_binding::x5t_s256_thumbprint(req.access_token.as_bytes());
+
+    let verified = match authkestra_engine::token::dpop::verify_dpop_proof(
+        proof,
+        req.htm.as_deref().unwrap_or("GET"),
+        req.htu.as_deref(),
+        Some(&ath),
+        chrono::Duration::seconds(crate::dpop::DPOP_PROOF_MAX_AGE_SECS),
+    ) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = ?e, "Invalid DPoP proof at userinfo");
+            return Err(UserInfoErrorResponse {
+                error: "invalid_token".to_string(),
+                error_description: "The DPoP proof is invalid".to_string(),
+            });
+        }
+    };
+
+    if !crate::attestation::constant_time_eq(&verified.jkt, expected_jkt) {
+        tracing::warn!("DPoP proof key does not match the access token's cnf.jkt at userinfo");
+        return Err(UserInfoErrorResponse {
+            error: "invalid_token".to_string(),
+            error_description: "The DPoP proof key does not match this access token".to_string(),
+        });
+    }
+
+    // Anchored to the proof's own `iat`, not `Utc::now()`: anchoring to now
+    // lets the replay record expire before the proof's own freshness
+    // boundary (`iat + max_age`) whenever the request is processed even
+    // slightly after `iat`, leaving a narrow but real replay window. Same
+    // reasoning, and the same `+ 1s` boundary guard, as the `/token` and
+    // resource-server paths.
+    let expires_at = chrono::DateTime::<chrono::Utc>::from_timestamp(verified.iat, 0)
+        .unwrap_or_else(chrono::Utc::now)
+        + chrono::Duration::seconds(crate::dpop::DPOP_PROOF_MAX_AGE_SECS)
+        + chrono::Duration::seconds(1);
+
+    match op_store
+        .check_and_record_dpop_jti(&verified.jti, expires_at)
+        .await
+    {
+        Ok(true) => Ok(()),
+        Ok(false) => {
+            tracing::warn!("Replayed DPoP proof at userinfo");
+            Err(UserInfoErrorResponse {
+                error: "invalid_token".to_string(),
+                error_description: "This DPoP proof has already been used".to_string(),
+            })
+        }
+        // Fails closed, and distinguishably: a replay store that is down is
+        // an availability problem, not a bad token, so it must not be
+        // reported to the client as one.
+        Err(e) => {
+            tracing::error!(error = ?e, "DPoP replay store unavailable at userinfo");
+            Err(UserInfoErrorResponse {
+                error: "temporarily_unavailable".to_string(),
+                error_description: "Unable to verify the DPoP proof at this time".to_string(),
+            })
+        }
+    }
+}
+
 impl UserInfoRequest {
-    /// Creates a new UserInfoRequest.
+    /// Creates a new `UserInfoRequest` for a token presented as `Bearer`.
+    ///
+    /// A DPoP-bound token presented this way is **refused** by
+    /// [`handle_userinfo`]; use [`UserInfoRequest::new_dpop`] for the
+    /// `DPoP` auth-scheme.
     pub fn new(access_token: String) -> Self {
-        Self { access_token }
+        Self {
+            access_token,
+            presented_as_dpop: false,
+            dpop_proof: None,
+            htm: None,
+            htu: None,
+        }
+    }
+
+    /// Creates a new `UserInfoRequest` for a token presented under the
+    /// `DPoP` auth-scheme (RFC 9449 §7.1), carrying the proof from the
+    /// request's `DPoP` header and the request's own method/URL for the
+    /// proof's `htm`/`htu` claims.
+    pub fn new_dpop(
+        access_token: String,
+        dpop_proof: Option<String>,
+        htm: Option<String>,
+        htu: Option<String>,
+    ) -> Self {
+        Self {
+            access_token,
+            presented_as_dpop: true,
+            dpop_proof,
+            htm,
+            htu,
+        }
     }
 }
 
@@ -143,6 +333,24 @@ mod tests {
         TokenManager::new(b"secret", Some("issuer".to_string()))
     }
 
+    /// A store whose `check_and_record_dpop_jti` is the trait's
+    /// fail-closed default — exactly right for the non-DPoP tests: they
+    /// must never reach it, and if a refactor makes them, they fail loudly
+    /// rather than silently skipping the binding check.
+    fn test_store() -> crate::store::CompositeOpStore<
+        authkestra_engine::store::memory::MemoryStore<crate::client::ClientRegistration>,
+        authkestra_engine::store::memory::MemoryStore<crate::code::AuthorizationCode>,
+        authkestra_engine::store::memory::MemoryStore<crate::refresh::RefreshToken>,
+        authkestra_engine::store::memory::MemoryStore<crate::device::DeviceCodeSession>,
+    > {
+        crate::store::CompositeOpStore::new(
+            authkestra_engine::store::memory::MemoryStore::new(),
+            authkestra_engine::store::memory::MemoryStore::new(),
+            authkestra_engine::store::memory::MemoryStore::new(),
+            authkestra_engine::store::memory::MemoryStore::new(),
+        )
+    }
+
     fn test_identity() -> Identity {
         Identity {
             provider_id: "local".to_string(),
@@ -163,9 +371,9 @@ mod tests {
             .issue_user_token(test_identity(), 3600, Some("profile".to_string()), None)
             .unwrap();
 
-        let req = UserInfoRequest { access_token };
+        let req = UserInfoRequest::new(access_token);
 
-        let result = handle_userinfo(req, &config, &tokens).await;
+        let result = handle_userinfo(req, &config, &tokens, &test_store()).await;
         assert_eq!(result.unwrap_err().error, "insufficient_scope");
     }
 
@@ -174,11 +382,9 @@ mod tests {
         let config = test_config();
         let tokens = test_tokens();
 
-        let req = UserInfoRequest {
-            access_token: "invalid.token.here".to_string(),
-        };
+        let req = UserInfoRequest::new("invalid.token.here".to_string());
 
-        let result = handle_userinfo(req, &config, &tokens).await;
+        let result = handle_userinfo(req, &config, &tokens, &test_store()).await;
         assert_eq!(result.unwrap_err().error, "invalid_token");
     }
 
@@ -197,9 +403,11 @@ mod tests {
             )
             .unwrap();
 
-        let req = UserInfoRequest { access_token };
+        let req = UserInfoRequest::new(access_token);
 
-        let result = handle_userinfo(req, &config, &tokens).await.unwrap();
+        let result = handle_userinfo(req, &config, &tokens, &test_store())
+            .await
+            .unwrap();
         assert_eq!(result.sub, "user-123");
         assert_eq!(result.email.as_deref(), Some("user@example.com"));
         assert_eq!(result.name.as_deref(), Some("Test User"));
@@ -220,11 +428,311 @@ mod tests {
             )
             .unwrap();
 
-        let req = UserInfoRequest { access_token };
+        let req = UserInfoRequest::new(access_token);
 
-        let result = handle_userinfo(req, &config, &tokens).await.unwrap();
+        let result = handle_userinfo(req, &config, &tokens, &test_store())
+            .await
+            .unwrap();
         assert_eq!(result.sub, "user-123");
         assert_eq!(result.email, None); // Should be None because email scope wasn't requested
         assert_eq!(result.name.as_deref(), Some("Test User"));
+    }
+
+    // ---- RFC 9449 §7.1 key binding at /userinfo (authkestra#291) ----
+
+    mod dpop_binding {
+        use super::*;
+        use base64::Engine as _;
+        use ed25519_dalek::{Signer, SigningKey};
+
+        fn b64(bytes: &[u8]) -> String {
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+        }
+        fn b64_json(v: &serde_json::Value) -> String {
+            b64(serde_json::to_vec(v).unwrap().as_slice())
+        }
+
+        /// A real Ed25519-signed DPoP proof for a *resource* request, so it
+        /// carries `ath` — the claim that binds a proof to one specific
+        /// access token, which the token-endpoint proofs in `token.rs` have
+        /// no need for.
+        struct ResourceProof {
+            key: SigningKey,
+            jti: String,
+            ath: Option<String>,
+            htm: String,
+        }
+
+        impl ResourceProof {
+            fn new(jti: &str, access_token: &str) -> Self {
+                Self::with_key_seed(7, jti, Some(access_token))
+            }
+            fn with_key_seed(seed: u8, jti: &str, access_token: Option<&str>) -> Self {
+                Self {
+                    key: SigningKey::from_bytes(&[seed; 32]),
+                    jti: jti.to_string(),
+                    ath: access_token.map(|t| {
+                        authkestra_engine::token::cert_binding::x5t_s256_thumbprint(t.as_bytes())
+                    }),
+                    htm: "GET".to_string(),
+                }
+            }
+            fn jwk(&self) -> serde_json::Value {
+                serde_json::json!({
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "x": b64(self.key.verifying_key().as_bytes()),
+                })
+            }
+            fn jkt(&self) -> String {
+                authkestra_engine::token::dpop::compute_jwk_thumbprint(
+                    &serde_json::from_value(self.jwk()).unwrap(),
+                )
+                .unwrap()
+            }
+            fn build(&self) -> String {
+                let header = serde_json::json!({
+                    "typ": "dpop+jwt", "alg": "EdDSA", "jwk": self.jwk(),
+                });
+                let mut payload = serde_json::json!({
+                    "htm": self.htm,
+                    "htu": "https://op.example.com/userinfo",
+                    "iat": chrono::Utc::now().timestamp(),
+                    "jti": self.jti,
+                });
+                if let Some(ath) = &self.ath {
+                    payload["ath"] = serde_json::Value::String(ath.clone());
+                }
+                let input = format!("{}.{}", b64_json(&header), b64_json(&payload));
+                let sig = self.key.sign(input.as_bytes());
+                format!("{input}.{}", b64(&sig.to_bytes()))
+            }
+        }
+
+        /// Issues an access token carrying `cnf.jkt`, exactly as
+        /// `/token` does for a DPoP request.
+        fn bound_token(tokens: &TokenManager, jkt: &str) -> String {
+            let mut extra = std::collections::HashMap::new();
+            crate::handlers::token::merge_dpop_cnf(&mut extra, Some(jkt));
+            tokens
+                .issue_user_token_with_extra(
+                    test_identity(),
+                    3600,
+                    Some("openid profile email".to_string()),
+                    None,
+                    extra,
+                )
+                .unwrap()
+        }
+
+        /// The `CompositeOpStore` shape with a real replay store wired.
+        /// Aliased because the fully-spelled generic is what clippy's
+        /// `type_complexity` lint objects to, and naming it also documents
+        /// which slot the replay store occupies.
+        type StoreWithReplay = crate::store::CompositeOpStore<
+            authkestra_engine::store::memory::MemoryStore<crate::client::ClientRegistration>,
+            authkestra_engine::store::memory::MemoryStore<crate::code::AuthorizationCode>,
+            authkestra_engine::store::memory::MemoryStore<crate::refresh::RefreshToken>,
+            authkestra_engine::store::memory::MemoryStore<crate::device::DeviceCodeSession>,
+            crate::client_assertion::NoClientAssertionStore,
+            authkestra_engine::store::memory::MemoryStore<crate::dpop::DpopJtiRecord>,
+        >;
+
+        fn store_with_replay() -> StoreWithReplay {
+            test_store().with_dpop_replay_store(authkestra_engine::store::memory::MemoryStore::<
+                crate::dpop::DpopJtiRecord,
+            >::new())
+        }
+
+        /// **The finding.** A DPoP-bound access token must not be usable at
+        /// `/userinfo` just by presenting it as `Bearer`. Before
+        /// authkestra#291 this returned 200 with the user's claims, so a
+        /// stolen bound token was refused at a hardened resource server and
+        /// accepted at the issuing OP's own endpoint.
+        #[tokio::test]
+        async fn dpop_bound_token_presented_as_bearer_is_refused() {
+            let tokens = test_tokens();
+            let proof = ResourceProof::with_key_seed(7, "j1", None);
+            let token = bound_token(&tokens, &proof.jkt());
+
+            let err = handle_userinfo(
+                UserInfoRequest::new(token),
+                &test_config(),
+                &tokens,
+                &store_with_replay(),
+            )
+            .await
+            .expect_err("a bound token must not be accepted as Bearer");
+            assert_eq!(err.error, "invalid_token");
+            assert!(
+                err.error_description.contains("DPoP"),
+                "the error must say why: {}",
+                err.error_description
+            );
+        }
+
+        /// The other direction of RFC 9449 §7.1: a server handling the
+        /// `DPoP` scheme is expected to validate a proof, so accepting the
+        /// scheme for an unbound token would let a client believe it had
+        /// sender-constrained a request that in fact was not.
+        #[tokio::test]
+        async fn dpop_scheme_for_an_unbound_token_is_refused() {
+            let tokens = test_tokens();
+            let token = tokens
+                .issue_user_token(test_identity(), 3600, Some("openid".to_string()), None)
+                .unwrap();
+            let proof = ResourceProof::new("j2", &token);
+
+            let err = handle_userinfo(
+                UserInfoRequest::new_dpop(
+                    token,
+                    Some(proof.build()),
+                    Some("GET".to_string()),
+                    None,
+                ),
+                &test_config(),
+                &tokens,
+                &store_with_replay(),
+            )
+            .await
+            .expect_err("the DPoP scheme must not be accepted for an unbound token");
+            assert_eq!(err.error, "invalid_token");
+        }
+
+        /// The positive path: bound token + a valid proof for the same key,
+        /// bound to this token via `ath`.
+        #[tokio::test]
+        async fn dpop_bound_token_with_a_matching_proof_succeeds() {
+            let tokens = test_tokens();
+            let seed_proof = ResourceProof::with_key_seed(7, "j3", None);
+            let token = bound_token(&tokens, &seed_proof.jkt());
+            let proof = ResourceProof::new("j3", &token);
+
+            let resp = handle_userinfo(
+                UserInfoRequest::new_dpop(
+                    token,
+                    Some(proof.build()),
+                    Some("GET".to_string()),
+                    None,
+                ),
+                &test_config(),
+                &tokens,
+                &store_with_replay(),
+            )
+            .await
+            .expect("a bound token with a matching proof must be accepted");
+            assert_eq!(resp.sub, "user-123");
+        }
+
+        /// A proof for a *different* key than the token's `cnf.jkt` — the
+        /// stolen-token-plus-attacker's-own-proof case.
+        #[tokio::test]
+        async fn a_proof_for_a_different_key_is_refused() {
+            let tokens = test_tokens();
+            let victim = ResourceProof::with_key_seed(7, "j4", None);
+            let token = bound_token(&tokens, &victim.jkt());
+            // Attacker holds the token string but signs with their own key.
+            let attacker = ResourceProof::with_key_seed(11, "j4", Some(&token));
+
+            let err = handle_userinfo(
+                UserInfoRequest::new_dpop(
+                    token,
+                    Some(attacker.build()),
+                    Some("GET".to_string()),
+                    None,
+                ),
+                &test_config(),
+                &tokens,
+                &store_with_replay(),
+            )
+            .await
+            .expect_err("a proof for another key must be refused");
+            assert_eq!(err.error, "invalid_token");
+        }
+
+        /// `ath` is what stops a proof minted for one access token being
+        /// presented with another. Here the proof is validly signed by the
+        /// right key but its `ath` names a different token.
+        #[tokio::test]
+        async fn a_proof_whose_ath_names_another_token_is_refused() {
+            let tokens = test_tokens();
+            let seed = ResourceProof::with_key_seed(7, "j5", None);
+            let token = bound_token(&tokens, &seed.jkt());
+            let other_token = bound_token(&tokens, &seed.jkt());
+            let proof = ResourceProof::with_key_seed(7, "j5", Some(&other_token));
+
+            let err = handle_userinfo(
+                UserInfoRequest::new_dpop(
+                    token,
+                    Some(proof.build()),
+                    Some("GET".to_string()),
+                    None,
+                ),
+                &test_config(),
+                &tokens,
+                &store_with_replay(),
+            )
+            .await
+            .expect_err("a proof bound to a different access token must be refused");
+            assert_eq!(err.error, "invalid_token");
+        }
+
+        /// RFC 9449 §11.1: the same proof must not work twice.
+        #[tokio::test]
+        async fn a_replayed_proof_is_refused() {
+            let tokens = test_tokens();
+            let seed = ResourceProof::with_key_seed(7, "j6", None);
+            let token = bound_token(&tokens, &seed.jkt());
+            let proof = ResourceProof::new("j6", &token).build();
+            let store = store_with_replay();
+
+            let first = handle_userinfo(
+                UserInfoRequest::new_dpop(
+                    token.clone(),
+                    Some(proof.clone()),
+                    Some("GET".to_string()),
+                    None,
+                ),
+                &test_config(),
+                &tokens,
+                &store,
+            )
+            .await;
+            assert!(first.is_ok(), "first presentation must succeed");
+
+            let err = handle_userinfo(
+                UserInfoRequest::new_dpop(token, Some(proof), Some("GET".to_string()), None),
+                &test_config(),
+                &tokens,
+                &store,
+            )
+            .await
+            .expect_err("replaying the same proof must be refused");
+            assert_eq!(err.error, "invalid_token");
+        }
+
+        /// A replay store that is down is an availability problem, not a bad
+        /// token, and must not be reported to the client as one. The
+        /// fail-closed `NoDpopReplayStore` default stands in for an outage.
+        #[tokio::test]
+        async fn an_unavailable_replay_store_is_not_reported_as_an_invalid_token() {
+            let tokens = test_tokens();
+            let seed = ResourceProof::with_key_seed(7, "j7", None);
+            let token = bound_token(&tokens, &seed.jkt());
+            let proof = ResourceProof::new("j7", &token).build();
+
+            let err = handle_userinfo(
+                UserInfoRequest::new_dpop(token, Some(proof), Some("GET".to_string()), None),
+                &test_config(),
+                &tokens,
+                &test_store(),
+            )
+            .await
+            .expect_err("must fail closed");
+            assert_eq!(
+                err.error, "temporarily_unavailable",
+                "an outage must be distinguishable from a bad proof"
+            );
+        }
     }
 }


### PR DESCRIPTION
Found reviewing the `next` → `main` range (#292).

## The bug

`handle_userinfo` called `validate_token` and **never looked at `cnf`**, and both adapters gated on `Some(h) if h.starts_with("Bearer ")`.

#286 mints access tokens carrying `cnf.jkt`. #288 taught `authkestra-resource` to enforce them. Nobody taught the issuing OP's *own* protected resource — so:

- a stolen DPoP-bound access token is **refused** at a hardened resource server, and
- **accepted** at `/userinfo`, returning the user's full claims,

which hands an attacker the choice of the weaker path. Contrary to RFC 9449 §7.1, which requires a bound token to arrive under the `DPoP` scheme and forbids `Bearer` for it.

The mutation run below prints it plainly. With the Bearer-rejection arm removed, presenting a `cnf.jkt` token as `Bearer` yields:

```
UserInfoResponse { sub: "user-123", email: Some("user@example.com"), name: Some("Test User"), extra: {} }
```

## The fix

Enforces §7.1 **in both directions**, mirroring `authkestra_resource::verify_dpop_binding` rather than inventing a second scheme for the same job:

| Token | Scheme | Result |
|---|---|---|
| unbound | `Bearer` | accepted — unchanged |
| **bound** | **`Bearer`** | **refused** — the finding |
| unbound | `DPoP` | refused — a server handling the scheme is expected to validate a proof; ignoring one lets a client believe it sender-constrained a request that it did not |
| bound | `DPoP` | proof must verify, bind to this token via `ath`, match `cnf.jkt` in constant time, and have an unspent `jti` |

Details that matter, each learned earlier in this release:

- **Replay record anchored to the proof's `iat`**, not `Utc::now()`, with the same `+ 1s` boundary guard as `/token` and the resource server. Anchoring to now lets the record expire before the proof's own freshness boundary (`iat + max_age`), reopening a narrow replay window.
- **A replay-store outage returns `temporarily_unavailable`, not `invalid_token`.** It still fails closed, but an availability problem must not be reported to a client as a bad credential — the same distinction #288 drew in the resource crate.
- **One `dpop_bound_jkt` predicate** for both the scheme check and the proof check, so they cannot drift on what "bound" means.
- **Schemes matched case-insensitively** per RFC 9110 §11.1, and the adapters reuse their existing `extract_dpop_header`, which already rejects duplicate and non-ASCII `DPoP` headers.
- **`htu` is left `None`.** Behind a reverse proxy a handler cannot reconstruct the absolute URL the client signed. Documented on `UserInfoRequest::htu`, pointing at `ValidationConfig::dpop_resource_origin` for what forwarding this leaves open.

## Verification

Seven new tests, including real Ed25519-signed proofs carrying `ath` (the token-endpoint proof helper in `token.rs` has no need for `ath`, so this adds a resource-flavoured builder):

- bound token as `Bearer` → refused ← **the finding**
- `DPoP` scheme for an unbound token → refused
- bound token + matching proof → succeeds
- proof for a *different* key → refused (stolen token + attacker's own proof)
- proof whose `ath` names another token → refused
- same proof twice → refused
- replay store down → `temporarily_unavailable`, not `invalid_token`

Mutation-checked: removing the Bearer-rejection arm fails **exactly one** test, `dpop_bound_token_presented_as_bearer_is_refused`, with the full-claims response above. The four pre-existing userinfo tests pass throughout, so unbound `Bearer` access is genuinely unchanged.

Gates: `cargo test --workspace --all-features` 0 failures (`authkestra-op` lib 183); `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; `cargo fmt --all -- --check` clean.

## Breaking change

`handle_userinfo` takes a fourth argument, `&impl OpStore`, for the replay guard.

The axum and actix userinfo handlers now require the `OpStore` in application state — **the same bound their token handlers already require**, so an application already serving `/token` (i.e. any OP) needs no state changes. Marked `!` regardless, since `handle_userinfo` is `pub` and callable directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)