### PR TITLE
feat(resource): let JwksCache fetch through a caller-supplied HTTP client

### DIFF
--- a/crates/authkestra-resource/src/jwt.rs
+++ b/crates/authkestra-resource/src/jwt.rs
@@ -76,8 +76,24 @@ pub struct Jwks {
 }
 
 impl Jwks {
+    /// Fetches a JWKS with a default [`reqwest::Client`], i.e. the platform trust store.
+    ///
+    /// Use [`Jwks::fetch_with`] when the endpoint is served by a CA the platform store does
+    /// not carry -- a JWKS published inside a cluster under a private CA, for example.
     pub async fn fetch(jwks_uri: &str) -> Result<Self, ValidationError> {
-        let client = reqwest::Client::new();
+        Self::fetch_with(&reqwest::Client::new(), jwks_uri).await
+    }
+
+    /// Fetches a JWKS with a caller-supplied [`reqwest::Client`].
+    ///
+    /// The client carries the TLS trust configuration, proxy settings and timeouts, so this is
+    /// the seam for reaching a JWKS endpoint whose certificate chains to a CA that is not in
+    /// the platform trust store. `reqwest::Error` is already part of this crate's public API
+    /// via [`ValidationError::Http`], so accepting a client here adds no new coupling.
+    pub async fn fetch_with(
+        client: &reqwest::Client,
+        jwks_uri: &str,
+    ) -> Result<Self, ValidationError> {
         let jwks = client.get(jwks_uri).send().await?.json::<Jwks>().await?;
         Ok(jwks)
     }
@@ -96,6 +112,10 @@ pub struct JwksCache {
     jwks: RwLock<Option<(Jwks, Instant)>>,
     ttl: Duration,
     require_kid: bool,
+    /// HTTP client used by [`JwksCache::refresh`]. Held for the cache's lifetime rather than
+    /// rebuilt per refresh, so the connection pool survives across refreshes, and settable via
+    /// [`JwksCache::with_client`] so a JWKS behind a private CA is reachable.
+    client: reqwest::Client,
 }
 
 impl JwksCache {
@@ -105,7 +125,33 @@ impl JwksCache {
             jwks: RwLock::new(None),
             ttl: refresh_interval,
             require_kid: false,
+            client: reqwest::Client::new(),
         }
+    }
+
+    /// Replaces the HTTP client used to fetch the JWKS.
+    ///
+    /// The default client trusts only the platform certificate store, which makes a JWKS served
+    /// under a private CA unreachable -- the common shape being a resource server validating
+    /// tokens against an issuer published inside its own cluster, where dialling the public
+    /// hostname means leaving and re-entering the network just to fetch keys. Supplying a client
+    /// built with that CA added (`reqwest::ClientBuilder::add_root_certificate`) keeps the trust
+    /// change scoped to this one fetch, rather than pushing it onto the whole process through
+    /// `SSL_CERT_FILE`, which replaces the trust store for every outbound connection.
+    ///
+    /// Mirrors [`Self::require_kid`]'s consuming-builder shape:
+    ///
+    /// ```no_run
+    /// # use authkestra_resource::jwt::JwksCache;
+    /// # use std::time::Duration;
+    /// # fn client() -> reqwest::Client { reqwest::Client::new() }
+    /// let cache = JwksCache::new("https://idp.internal/jwks".to_string(), Duration::from_secs(300))
+    ///     .with_client(client())
+    ///     .require_kid(true);
+    /// ```
+    pub fn with_client(mut self, client: reqwest::Client) -> Self {
+        self.client = client;
+        self
     }
 
     /// When set to `true`, tokens presented without a `kid` header will be rejected
@@ -149,7 +195,7 @@ impl JwksCache {
 
     pub async fn refresh(&self) -> Result<Jwks, ValidationError> {
         let mut write_guard = self.jwks.write().await;
-        let jwks = Jwks::fetch(&self.jwks_uri).await?;
+        let jwks = Jwks::fetch_with(&self.client, &self.jwks_uri).await?;
         *write_guard = Some((jwks.clone(), Instant::now()));
         Ok(jwks)
     }

--- a/crates/authkestra-resource/tests/jwt_test.rs
+++ b/crates/authkestra-resource/tests/jwt_test.rs
@@ -25,7 +25,7 @@ use rsa::RsaPrivateKey;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1328,5 +1328,75 @@ async fn dpop_htu_check_rejects_when_configured_origin_url_mismatches() {
         result.is_none(),
         "a proof minted for a different resource server's URL must be refused once \
          dpop_resource_origin is configured"
+    );
+}
+
+/// `JwksCache::with_client` must actually route the JWKS fetch through the supplied client.
+///
+/// The motivating shape is a resource server whose issuer publishes its JWKS inside the cluster
+/// under a private CA: the default client trusts only the platform store, so the endpoint is
+/// unreachable and the deployment is pushed toward dialling the public hostname (leaving and
+/// re-entering the network to fetch keys) or toward `SSL_CERT_FILE`, which swaps the trust store
+/// for every outbound connection in the process rather than this one fetch.
+///
+/// TLS itself is not what this asserts -- standing up a private CA and an HTTPS mock would test
+/// rustls, not this crate. What must be proven is the seam: that the injected client, and not an
+/// internally-constructed default, issues the request. A required header stands in for the
+/// client-carried configuration, since it is observable at the mock without any TLS setup.
+#[tokio::test]
+async fn with_client_routes_the_jwks_fetch_through_the_supplied_client() {
+    let key = generate_rsa_key(Some("client-injection"));
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/.well-known/jwks.json"))
+        .and(header("x-authkestra-client", "injected"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&JwksBody {
+            keys: vec![key.jwk.clone()],
+        }))
+        .mount(&server)
+        .await;
+
+    let mut headers = http::HeaderMap::new();
+    headers.insert(
+        "x-authkestra-client",
+        http::HeaderValue::from_static("injected"),
+    );
+    let client = reqwest::Client::builder()
+        .default_headers(headers)
+        .build()
+        .expect("a client with a static default header always builds");
+
+    let cache = JwksCache::new(jwks_url(&server), Duration::from_secs(300)).with_client(client);
+
+    let jwks = cache
+        .get_jwks()
+        .await
+        .expect("the mock only answers a request carrying the injected client's header");
+    assert_eq!(jwks.keys.len(), 1);
+}
+
+/// The control for the test above: without `with_client`, the default client sends no such header,
+/// so the same mock does not match and the fetch fails. Without this, the test above would still
+/// pass if `with_client` stored the client and `refresh` quietly ignored it -- the mock would be
+/// unmatched either way only if the header were genuinely required, and this proves it is.
+#[tokio::test]
+async fn default_client_does_not_carry_the_injected_configuration() {
+    let key = generate_rsa_key(Some("client-injection-control"));
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/.well-known/jwks.json"))
+        .and(header("x-authkestra-client", "injected"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&JwksBody {
+            keys: vec![key.jwk.clone()],
+        }))
+        .mount(&server)
+        .await;
+
+    let cache = JwksCache::new(jwks_url(&server), Duration::from_secs(300));
+
+    assert!(
+        cache.get_jwks().await.is_err(),
+        "the default client sends no injected header, so the mock must not match -- if this \
+         passes, the header is not actually discriminating and the sibling test proves nothing"
     );
 }


### PR DESCRIPTION
## What

Adds a seam for supplying the HTTP client that fetches a JWKS:

- `Jwks::fetch_with(&reqwest::Client, jwks_uri)` alongside the existing `Jwks::fetch`
- `JwksCache::with_client(reqwest::Client)`, mirroring `require_kid`'s consuming-builder shape

Purely additive. `Jwks::fetch` and `JwksCache::new` keep their exact signatures, and `JwksCache` is already `#[non_exhaustive]`, so the new field cannot break external construction.

## Why

`JwksCache` currently builds its client internally:

```rust
pub async fn fetch(jwks_uri: &str) -> Result<Self, ValidationError> {
    let client = reqwest::Client::new();
    ...
}
```

That client trusts only the platform certificate store, so a JWKS served under a **private CA is unreachable** and there is no hook to change it. The shape this blocks is ordinary: a resource server validating tokens against an issuer that publishes its JWKS inside the same cluster, under the cluster's own CA.

Today a deployment in that position has two options, and both are bad:

1. **Dial the issuer's public hostname instead.** The request leaves the network through public DNS and re-enters through the ingress, purely to fetch keys — so in-cluster token validation now depends on public DNS and ingress being up.
2. **Set `SSL_CERT_FILE`.** This works — reqwest resolves through `rustls-platform-verifier`, which on Linux calls `rustls_native_certs::load_native_certs()`, which honours it — but it **replaces** the trust store for *every* outbound TLS connection in the process, not just this fetch. Getting the concatenated bundle wrong silently drops the public roots and breaks unrelated things like OIDC discovery.

`with_client` makes the trust change scoped to the one fetch that needs it:

```rust
let client = reqwest::Client::builder()
    .add_root_certificate(cluster_ca)
    .build()?;

let cache = JwksCache::new(internal_jwks_url, Duration::from_secs(300))
    .with_client(client)
    .require_kid(true);
```

### On the API shape

I passed a `reqwest::Client` rather than, say, a `ca_bundle_path` on `ValidationConfig`, for two reasons:

- **No new coupling.** `reqwest::Error` is already part of this crate's public API via `ValidationError::Http`, so accepting a `reqwest::Client` does not newly tie the public surface to reqwest's major version.
- **It keeps this crate out of the PEM-reading business.** The caller already knows how to build its client — trust roots, timeouts, proxies — and a `ca_bundle_path` parameter would cover only the first of those.

Happy to reshape this if you'd rather the knob were narrower, or lived on `ValidationConfig` next to `jwks_url`.

## Incidental fix

The client is now held for the cache's lifetime instead of constructed inside every `refresh()`. Previously each refresh built a fresh `reqwest::Client` and discarded its connection pool, so the pool never survived a refresh. No behaviour change beyond connection reuse.

## Tests

Two tests, deliberately a matched pair (`crates/authkestra-resource/tests/jwt_test.rs`):

- `with_client_routes_the_jwks_fetch_through_the_supplied_client` — the mock only answers a request carrying a header that the injected client supplies.
- `default_client_does_not_carry_the_injected_configuration` — the control. Without it, the first test would still pass if `with_client` stored the client and `refresh()` quietly ignored it, so this pins that the header is genuinely discriminating.

I did not stand up a private CA and an HTTPS mock: that would be testing rustls, not this crate. What needs proving is the seam — that the injected client, and not an internally-constructed default, issues the request — and a required header is observable at the mock without any TLS setup.

**Verified by breaking it:** reverting `refresh()` to `Jwks::fetch(&self.jwks_uri)` (i.e. the "stored but ignored" bug) fails the primary test with `Http(reqwest::Error { kind: Decode, ... "EOF while parsing a value" })` — the mock declining to answer an unmatched request. Restoring it returns both to green.

## Checks

Per `AGENTS.md`:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-features -- -D warnings` — clean
- `cargo test --workspace --all-features` — see below
- `cargo test -p authkestra-resource --all-features --test jwt_test` — 30 passed

Docs: no public API name or signature changed, so per the "Docs Are Not Compiled" rule there is nothing to re-grep in `website/` or `docs/` — the two new items are additions.

## Downstream

This unblocks ADORSYS-GIS/lightbridge-authz, which wants its resource servers to validate against an in-cluster JWKS rather than hairpinning out through the public ingress. That repo hit a related failure yesterday (a config key that meant two different trust roots), so the narrow, explicitly-scoped option is the one worth having.
