### PR TITLE
fix(op): allow any port on loopback redirect URIs (RFC 8252 §7.3)

### DIFF
--- a/crates/authkestra-op/src/client.rs
+++ b/crates/authkestra-op/src/client.rs
@@ -273,8 +273,28 @@ fn loopback_match(registered: &str, presented: &str) -> bool {
 /// Deliberately not `Ipv4Addr::is_loopback()`: that accepts all of
 /// `127.0.0.0/8`, and §7.3 enumerates the two addresses rather than the
 /// ranges. `Host::Domain` is always false — that is what keeps `localhost`
-/// out, per §8.3, since resolving it depends on a name service the app does
-/// not control.
+/// out, since resolving it depends on a name service the app does not
+/// control.
+///
+/// Two of the exclusions here are narrower than the RFC and are **meant to
+/// stay that way** — neither is an oversight to be tidied up later:
+///
+/// - **IPv4-mapped IPv6 loopback (`http://[::ffff:127.0.0.1]/cb`) is not
+///   exempt.** `Ipv6Addr::LOCALHOST` is `::1`, so the mapped form compares
+///   unequal and falls through to exact `==`. It is a second spelling of an
+///   address §7.3 already covers in two canonical forms, no OS hands one to
+///   an app that binds `127.0.0.1:0` or `[::1]:0`, and admitting it would
+///   mean either accepting a third literal or normalising mapped to plain
+///   IPv4 — the latter being exactly the kind of pre-comparison rewriting
+///   that redirect-URI matching should not be doing. Add it only with a test
+///   that pins which spellings become equivalent to which.
+/// - **`localhost` is refused outright**, which is stricter than §8.3: the
+///   RFC says NOT RECOMMENDED, not MUST NOT. The stricter line is chosen
+///   because the whole security argument for this exemption is that the host
+///   is unambiguously the user's own machine; `localhost` reaches that host
+///   only via a resolver the app does not control, and it is `Host::Domain`
+///   here, so it can never be told apart from any other name. Relaxing it
+///   would need a fresh argument, not just a citation of §8.3's wording.
 fn is_loopback_ip(host: &Host<&str>) -> bool {
     match host {
         Host::Ipv4(addr) => *addr == Ipv4Addr::LOCALHOST,
@@ -469,7 +489,10 @@ mod tests {
         assert!(registered_localhost.allows_redirect_uri("http://localhost/cb"));
     }
 
-    /// §7.3 names `127.0.0.1`, not `127.0.0.0/8`.
+    /// §7.3 names `127.0.0.1`, not `127.0.0.0/8` — and names it in that one
+    /// spelling, so the IPv4-mapped IPv6 form is out too. Both exclusions are
+    /// deliberate; see `is_loopback_ip` for why, and change this test only
+    /// alongside that reasoning.
     #[test]
     fn other_addresses_in_127_slash_8_never_qualify() {
         let client = client_with_redirect_uris(&["http://127.0.0.2/cb"]);
@@ -477,6 +500,14 @@ mod tests {
 
         let client = client_with_redirect_uris(&["http://127.0.0.1/cb"]);
         assert!(!client.allows_redirect_uri("http://127.0.0.2:54321/cb"));
+
+        // IPv4-mapped IPv6 loopback: not `::1`, so no exemption in either
+        // position. Exact `==` still works, as for any other URI.
+        assert!(!client.allows_redirect_uri("http://[::ffff:127.0.0.1]:54321/cb"));
+        let client = client_with_redirect_uris(&["http://[::ffff:127.0.0.1]/cb"]);
+        assert!(!client.allows_redirect_uri("http://[::ffff:127.0.0.1]:54321/cb"));
+        assert!(!client.allows_redirect_uri("http://127.0.0.1:54321/cb"));
+        assert!(client.allows_redirect_uri("http://[::ffff:127.0.0.1]/cb"));
     }
 
     #[test]

--- a/crates/authkestra-op/src/client.rs
+++ b/crates/authkestra-op/src/client.rs
@@ -5,6 +5,8 @@ use argon2::{
 };
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::net::{Ipv4Addr, Ipv6Addr};
+use url::{Host, Url};
 
 /// OAuth2/OIDC grant types a client may be permitted to use.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -88,7 +90,9 @@ pub enum TokenEndpointAuthMethod {
 ///
 /// `redirect_uris` are matched **exactly** (no prefix/wildcard matching) —
 /// see RFC-003 §7. This is the single most important invariant in this
-/// type; do not relax it for convenience.
+/// type; do not relax it for convenience. The one exception, which RFC 8252
+/// §7.3 makes mandatory, is the port of a loopback IP redirect URI; see
+/// [`ClientRegistration::allows_redirect_uri`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClientRegistration {
     /// Public client identifier.
@@ -97,6 +101,15 @@ pub struct ClientRegistration {
     /// `None` for public clients (e.g. SPAs, native apps using PKCE).
     pub client_secret_hash: Option<String>,
     /// Exact-match redirect URIs this client is permitted to use.
+    ///
+    /// One entry, one URI, compared byte-for-byte — with a single exception:
+    /// registering a loopback IP URI (`http://127.0.0.1/...` or
+    /// `http://[::1]/...`) means "this client may redirect to that host and
+    /// path on **any** port", because RFC 8252 §7.3 requires it for native
+    /// apps that take an ephemeral port from the OS at request time. Whatever
+    /// port is written here is therefore not binding, and writing one is only
+    /// a documentation aid. See
+    /// [`ClientRegistration::allows_redirect_uri`] (authkestra#291).
     pub redirect_uris: Vec<String>,
     /// Grant types this client is permitted to use.
     pub grant_types: Vec<GrantType>,
@@ -142,11 +155,42 @@ pub struct ClientRegistration {
 }
 
 impl ClientRegistration {
-    /// Returns true if `redirect_uri` exactly matches one of this client's
-    /// registered URIs. Intentionally a plain `==` comparison — no
-    /// normalization, no prefix matching.
+    /// Returns true if `redirect_uri` matches one of this client's registered
+    /// URIs.
+    ///
+    /// The first and normal check is a plain `==` comparison — no
+    /// normalization, no prefix matching. That exactness is the defence
+    /// against open redirects and is not negotiable for ordinary URIs.
+    ///
+    /// The one relaxation is the port of a **loopback IP** redirect URI, which
+    /// RFC 8252 §7.3 makes a MUST: a native app binds `127.0.0.1:0`, gets a
+    /// kernel-assigned port, and cannot possibly have registered it. So a
+    /// registered `http://127.0.0.1/cb` also matches
+    /// `http://127.0.0.1:54321/cb`. Only the port is ignored; scheme, host,
+    /// userinfo, path, query and fragment must still be equal, and both sides
+    /// must be `http` on the IP literal `127.0.0.1` or `::1`. The name
+    /// `localhost` deliberately does **not** qualify (RFC 8252 §8.3: it
+    /// resolves through a name service the app does not control), nor does any
+    /// other address in `127.0.0.0/8`. Since the exemption cannot apply to a
+    /// non-loopback host, it does not widen the open-redirect surface: an
+    /// attacker able to bind a port on the user's own loopback interface
+    /// already has code execution there. See authkestra#291.
     pub fn allows_redirect_uri(&self, redirect_uri: &str) -> bool {
-        self.redirect_uris.iter().any(|u| u == redirect_uri)
+        self.redirect_uris.iter().any(|registered| {
+            if registered == redirect_uri {
+                return true;
+            }
+            if loopback_match(registered, redirect_uri) {
+                tracing::debug!(
+                    client_id = %self.client_id,
+                    registered_uri = %registered,
+                    presented_uri = %redirect_uri,
+                    "redirect_uri accepted on the RFC 8252 §7.3 loopback any-port exemption"
+                );
+                return true;
+            }
+            false
+        })
     }
 
     /// Checks if the client is allowed to use a specific grant type.
@@ -181,6 +225,61 @@ impl ClientRegistration {
             // No secret stored means public client; shouldn't be used for confidential flows
             false
         }
+    }
+}
+
+/// RFC 8252 §7.3: compares a registered against a presented redirect URI on
+/// every component **except** the port, and only when both are loopback IP
+/// URIs. Returns false for anything else, so the caller's exact `==` remains
+/// the only path by which a non-loopback URI can match.
+///
+/// Both sides are re-checked independently and symmetrically on purpose: a
+/// loopback *registration* must not let a non-loopback URI through, and a
+/// loopback URI presented against a non-loopback registration must not match
+/// either. Everything the URI carries other than the port — including
+/// userinfo, which no legitimate loopback redirect uses — has to be equal, so
+/// the only authority this grants a caller is "some port on the user's own
+/// machine".
+fn loopback_match(registered: &str, presented: &str) -> bool {
+    let (Ok(registered), Ok(presented)) = (Url::parse(registered), Url::parse(presented)) else {
+        // A URI that does not parse cannot be reasoned about; it can still
+        // match byte-for-byte at the call site, but never here.
+        return false;
+    };
+
+    if registered.scheme() != "http" || presented.scheme() != "http" {
+        return false;
+    }
+
+    let (Some(registered_host), Some(presented_host)) = (registered.host(), presented.host())
+    else {
+        return false;
+    };
+    if !is_loopback_ip(&registered_host) || !is_loopback_ip(&presented_host) {
+        return false;
+    }
+
+    registered_host == presented_host
+        && registered.path() == presented.path()
+        && registered.query() == presented.query()
+        && registered.fragment() == presented.fragment()
+        && registered.username() == presented.username()
+        && registered.password() == presented.password()
+}
+
+/// True only for the two IP literals RFC 8252 §7.3 names: `127.0.0.1` and
+/// `::1`.
+///
+/// Deliberately not `Ipv4Addr::is_loopback()`: that accepts all of
+/// `127.0.0.0/8`, and §7.3 enumerates the two addresses rather than the
+/// ranges. `Host::Domain` is always false — that is what keeps `localhost`
+/// out, per §8.3, since resolving it depends on a name service the app does
+/// not control.
+fn is_loopback_ip(host: &Host<&str>) -> bool {
+    match host {
+        Host::Ipv4(addr) => *addr == Ipv4Addr::LOCALHOST,
+        Host::Ipv6(addr) => *addr == Ipv6Addr::LOCALHOST,
+        Host::Domain(_) => false,
     }
 }
 
@@ -312,5 +411,141 @@ mod tests {
         assert!(serialized.contains("\"client_credentials\""));
         assert!(serialized.contains("\"authorization_code\""));
         assert!(serialized.contains("\"my_custom_grant\""));
+    }
+
+    fn client_with_redirect_uris(uris: &[&str]) -> ClientRegistration {
+        ClientRegistration {
+            client_id: "native-app".to_string(),
+            client_secret_hash: None,
+            redirect_uris: uris.iter().map(|u| (*u).to_string()).collect(),
+            grant_types: vec![GrantType::AuthorizationCode],
+            scopes: vec![],
+            require_pkce: false,
+            allowed_audiences: vec![],
+            token_endpoint_auth_method: None,
+            jwks: None,
+        }
+    }
+
+    /// The authkestra#291 regression: a native app binds an ephemeral port it
+    /// could not have registered, and RFC 8252 §7.3 makes accepting it a MUST.
+    #[test]
+    fn loopback_registration_accepts_any_ephemeral_port() {
+        let client = client_with_redirect_uris(&["http://127.0.0.1/cb"]);
+        assert!(client.allows_redirect_uri("http://127.0.0.1:54321/cb"));
+        assert!(client.allows_redirect_uri("http://127.0.0.1:1/cb"));
+        // The registered value itself must keep working.
+        assert!(client.allows_redirect_uri("http://127.0.0.1/cb"));
+    }
+
+    /// A port written at registration time is not binding — §7.3 is about the
+    /// port being unknowable, so a registered port is documentation, not a
+    /// constraint.
+    #[test]
+    fn loopback_registration_with_a_port_accepts_a_different_port() {
+        let client = client_with_redirect_uris(&["http://127.0.0.1:8080/cb"]);
+        assert!(client.allows_redirect_uri("http://127.0.0.1:9090/cb"));
+        assert!(client.allows_redirect_uri("http://127.0.0.1/cb"));
+    }
+
+    #[test]
+    fn ipv6_loopback_literal_gets_the_same_exemption() {
+        let client = client_with_redirect_uris(&["http://[::1]/cb"]);
+        assert!(client.allows_redirect_uri("http://[::1]:54321/cb"));
+    }
+
+    /// RFC 8252 §8.3: `localhost` resolves through a name service the app does
+    /// not control, so it never earns the exemption — in either position.
+    #[test]
+    fn localhost_never_qualifies() {
+        let registered_localhost = client_with_redirect_uris(&["http://localhost/cb"]);
+        assert!(!registered_localhost.allows_redirect_uri("http://localhost:54321/cb"));
+        assert!(!registered_localhost.allows_redirect_uri("http://127.0.0.1:54321/cb"));
+
+        let registered_ip = client_with_redirect_uris(&["http://127.0.0.1/cb"]);
+        assert!(!registered_ip.allows_redirect_uri("http://localhost:54321/cb"));
+
+        // Exact equality still applies to `localhost`, as to anything else.
+        assert!(registered_localhost.allows_redirect_uri("http://localhost/cb"));
+    }
+
+    /// §7.3 names `127.0.0.1`, not `127.0.0.0/8`.
+    #[test]
+    fn other_addresses_in_127_slash_8_never_qualify() {
+        let client = client_with_redirect_uris(&["http://127.0.0.2/cb"]);
+        assert!(!client.allows_redirect_uri("http://127.0.0.2:54321/cb"));
+
+        let client = client_with_redirect_uris(&["http://127.0.0.1/cb"]);
+        assert!(!client.allows_redirect_uri("http://127.0.0.2:54321/cb"));
+    }
+
+    #[test]
+    fn scheme_must_match_and_must_be_http() {
+        let client = client_with_redirect_uris(&["https://127.0.0.1/cb"]);
+        assert!(!client.allows_redirect_uri("http://127.0.0.1:54321/cb"));
+        assert!(!client.allows_redirect_uri("https://127.0.0.1:54321/cb"));
+
+        let client = client_with_redirect_uris(&["http://127.0.0.1/cb"]);
+        assert!(!client.allows_redirect_uri("https://127.0.0.1:54321/cb"));
+    }
+
+    #[test]
+    fn only_the_port_is_ignored() {
+        let client = client_with_redirect_uris(&["http://127.0.0.1/cb?x=1#frag"]);
+        // Different path.
+        assert!(!client.allows_redirect_uri("http://127.0.0.1:54321/other?x=1#frag"));
+        // Different query.
+        assert!(!client.allows_redirect_uri("http://127.0.0.1:54321/cb?x=2#frag"));
+        // Missing query.
+        assert!(!client.allows_redirect_uri("http://127.0.0.1:54321/cb#frag"));
+        // Different fragment.
+        assert!(!client.allows_redirect_uri("http://127.0.0.1:54321/cb?x=1#other"));
+        // Only the port differs.
+        assert!(client.allows_redirect_uri("http://127.0.0.1:54321/cb?x=1#frag"));
+    }
+
+    #[test]
+    fn userinfo_must_match() {
+        let client = client_with_redirect_uris(&["http://127.0.0.1/cb"]);
+        assert!(!client.allows_redirect_uri("http://attacker@127.0.0.1:54321/cb"));
+        assert!(!client.allows_redirect_uri("http://:secret@127.0.0.1:54321/cb"));
+    }
+
+    /// The exemption must not leak into ordinary URIs: for anything that is
+    /// not loopback, the port is part of the exact match as it always was.
+    #[test]
+    fn non_loopback_uris_still_match_exactly_including_the_port() {
+        let client = client_with_redirect_uris(&["https://app.example.com/cb"]);
+        assert!(!client.allows_redirect_uri("https://app.example.com:8443/cb"));
+        assert!(client.allows_redirect_uri("https://app.example.com/cb"));
+
+        let client = client_with_redirect_uris(&["http://app.example.com:8080/cb"]);
+        assert!(!client.allows_redirect_uri("http://app.example.com:9090/cb"));
+    }
+
+    /// A loopback registration must not become a wildcard for other hosts.
+    #[test]
+    fn loopback_registration_does_not_admit_a_non_loopback_uri() {
+        let client = client_with_redirect_uris(&["http://127.0.0.1/cb"]);
+        assert!(!client.allows_redirect_uri("http://evil.example.com/cb"));
+        assert!(!client.allows_redirect_uri("http://evil.example.com:54321/cb"));
+        assert!(!client.allows_redirect_uri("http://127.0.0.1.evil.example.com:54321/cb"));
+    }
+
+    #[test]
+    fn malformed_presented_uri_does_not_match() {
+        let client = client_with_redirect_uris(&["http://127.0.0.1/cb"]);
+        assert!(!client.allows_redirect_uri("not a url"));
+        assert!(!client.allows_redirect_uri("127.0.0.1:54321/cb"));
+        assert!(!client.allows_redirect_uri(""));
+    }
+
+    /// A registration that does not parse as a URL is still usable through the
+    /// exact `==` path; it just never reaches the loopback comparison.
+    #[test]
+    fn unparseable_registration_still_matches_exactly() {
+        let client = client_with_redirect_uris(&["not a url"]);
+        assert!(client.allows_redirect_uri("not a url"));
+        assert!(!client.allows_redirect_uri("http://127.0.0.1:54321/cb"));
     }
 }

--- a/crates/authkestra-op/src/code.rs
+++ b/crates/authkestra-op/src/code.rs
@@ -19,7 +19,11 @@ pub struct AuthorizationCode {
     /// The client this code was issued to.
     pub client_id: String,
     /// The exact redirect_uri presented at `/authorize`; `/token` must
-    /// receive the same value.
+    /// receive the same value. For a loopback IP redirect this is the URI
+    /// *with* the ephemeral port the client actually bound, not the portless
+    /// registered form it was matched against (RFC 8252 §7.3,
+    /// authkestra#291), which is what keeps `/token`'s exact comparison
+    /// (RFC 6749 §4.1.3) both correct and unchanged.
     pub redirect_uri: String,
     /// Space-delimited scopes granted.
     pub scope: String,

--- a/crates/authkestra-op/src/error.rs
+++ b/crates/authkestra-op/src/error.rs
@@ -7,9 +7,12 @@ pub enum OpError {
     #[error("unknown client: {0}")]
     UnknownClient(String),
 
-    /// The provided redirect_uri does not exactly match a registered URI
-    /// for this client. Always treat this as a hard failure — never fall
-    /// back to a "closest match" or prefix comparison.
+    /// The provided redirect_uri does not match a registered URI for this
+    /// client — exactly, or, for a loopback IP URI, on every component but
+    /// the port (RFC 8252 §7.3; see
+    /// [`crate::client::ClientRegistration::allows_redirect_uri`]). Always
+    /// treat this as a hard failure — never fall back to a "closest match"
+    /// or prefix comparison.
     #[error("redirect_uri does not match a registered URI for this client")]
     RedirectUriMismatch,
 

--- a/crates/authkestra-op/src/handlers/authorize.rs
+++ b/crates/authkestra-op/src/handlers/authorize.rs
@@ -14,7 +14,10 @@ use rand::RngCore;
 pub struct AuthorizeRequest {
     /// Client ID requesting authorization.
     pub client_id: String,
-    /// Exact match redirect URI.
+    /// The redirect URI the client is asking to be sent back to. Matched
+    /// against the registration by
+    /// [`crate::client::ClientRegistration::allows_redirect_uri`] — exactly,
+    /// save for a loopback IP URI's port (RFC 8252 §7.3).
     pub redirect_uri: String,
     /// Response type (must be "code").
     pub response_type: String,
@@ -68,7 +71,12 @@ pub async fn handle_authorize(
         }
     };
 
-    // 2. Validate exact redirect_uri
+    // 2. Validate the redirect_uri against the registration. Exact, except
+    // for a loopback IP URI's port (RFC 8252 §7.3, authkestra#291) — the
+    // carve-out lives in `allows_redirect_uri`, not here. Everything
+    // downstream (the redirect built below, and the value recorded on the
+    // code) uses the URI *as presented*, so the ephemeral port survives to
+    // `/token`.
     if !client.allows_redirect_uri(&req.redirect_uri) {
         tracing::warn!(
             client_id = %req.client_id,
@@ -532,6 +540,76 @@ mod tests {
         } else {
             panic!("Expected Redirect");
         }
+    }
+
+    /// authkestra#291, end to end: a native app registered
+    /// `http://127.0.0.1/callback` and binds whatever ephemeral port the OS
+    /// hands it. RFC 8252 §7.3 makes accepting that a MUST, and before the fix
+    /// this request could only ever be a `DirectError(RedirectUriMismatch)`.
+    ///
+    /// The second half of the assertion matters as much as the first: the
+    /// browser is redirected to — and the code is persisted with — the
+    /// *presented* URI including its port, not the registered portless one.
+    /// That is what keeps `/token`'s exact `auth_code.redirect_uri !=
+    /// req_redirect_uri` comparison (RFC 6749 §4.1.3) correct and untouched.
+    #[tokio::test]
+    async fn loopback_redirect_on_an_ephemeral_port_is_accepted() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<
+            crate::client::ClientRegistration,
+        >::new();
+        clients
+            .set(
+                "native-app",
+                ClientRegistration {
+                    client_id: "native-app".to_string(),
+                    client_secret_hash: None,
+                    redirect_uris: vec!["http://127.0.0.1/callback".to_string()],
+                    grant_types: vec![GrantType::AuthorizationCode],
+                    scopes: vec!["openid".to_string()],
+                    require_pkce: false,
+                    allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
+                },
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let codes =
+            authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new();
+        let config = test_config();
+
+        let req = AuthorizeRequest {
+            client_id: "native-app".to_string(),
+            redirect_uri: "http://127.0.0.1:54321/callback".to_string(),
+            response_type: "code".to_string(),
+            scope: "openid".to_string(),
+            state: Some("abc".to_string()),
+            code_challenge: Some("s256challenge".to_string()),
+            code_challenge_method: Some("S256".to_string()),
+            nonce: None,
+        };
+
+        let outcome = handle_authorize(req, test_identity(), &config, &crate::store::CompositeOpStore::new(clients, codes.clone(), authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(), authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new())).await;
+
+        let AuthorizeOutcome::Redirect(url) = outcome else {
+            panic!("expected a Redirect, got {outcome:?}");
+        };
+        assert!(
+            url.starts_with("http://127.0.0.1:54321/callback?code="),
+            "redirect must go to the presented port, got {url}"
+        );
+
+        let code_val = url
+            .split("code=")
+            .nth(1)
+            .unwrap()
+            .split('&')
+            .next()
+            .unwrap();
+        let persisted = codes.consume_code(code_val).await.unwrap().unwrap();
+        assert_eq!(persisted.redirect_uri, "http://127.0.0.1:54321/callback");
     }
 
     /// authkestra#280: an omitted `scope` (RFC 6749 §3.3 makes this legal)

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -878,7 +878,16 @@ pub async fn default_handle_authorization_code<S: OpStore + ?Sized>(
         });
     }
 
-    // 5. Validate redirect_uri matches
+    // 5. Validate redirect_uri matches. Deliberately an exact string
+    // comparison, and deliberately *not* routed through
+    // `ClientRegistration::allows_redirect_uri`: RFC 6749 §4.1.3 requires the
+    // token request to repeat the identical value from the authorization
+    // request, which is a different question from whether the client was
+    // allowed to use it at all. The RFC 8252 §7.3 loopback any-port carve-out
+    // (authkestra#291) has no business here — `auth_code.redirect_uri` already
+    // holds the concrete port the client presented at `/authorize`, so
+    // ignoring the port would only let one loopback port be swapped for
+    // another mid-flow.
     if auth_code.redirect_uri != req_redirect_uri {
         tracing::warn!(
             expected_uri = %auth_code.redirect_uri,

--- a/docs/book/ch09-security-and-threat-model.md
+++ b/docs/book/ch09-security-and-threat-model.md
@@ -19,7 +19,7 @@ To prevent user tracking and correlation between services:
 
 ## 4. Modern Hardened Defaults
 - **PKCE Mandatory**: No OAuth flows without Proof Key for Code Exchange.
-- **Exact Redirect Matching**: Preventing open redirector vulnerabilities.
+- **Exact Redirect Matching**: Preventing open redirector vulnerabilities. The only relaxation is the one RFC 8252 §7.3 requires: a registered loopback IP redirect URI (`http://127.0.0.1/...`, `http://[::1]/...`) matches on any port, since a native app is handed an ephemeral port by the OS at request time. Everything else about the URI still has to match exactly, `localhost` is not accepted as a substitute for the IP literal (§8.3), and the exemption cannot reach a non-loopback host — so it does not widen the open-redirect surface.
 - **Sender-Constrained Tokens**: Using DPoP to bind tokens to the client's cryptographic key.
 
 ## 5. SD-JWT: Fail-Closed Disclosure Verification

--- a/docs/rfc-003-oidc-provider.md
+++ b/docs/rfc-003-oidc-provider.md
@@ -96,6 +96,7 @@ pub struct ClientRegistration {
     pub client_id: String,
     pub client_secret_hash: String, // never store plaintext
     pub redirect_uris: Vec<String>, // exact-match only; no wildcard/prefix matching
+                                    // (except a loopback IP URI's port — see §7)
     pub grant_types: Vec<GrantType>,
     pub scopes: Vec<String>,
 }
@@ -137,6 +138,17 @@ pluggable backends, in-memory implementation ships first).
   string match** against the client's registered URIs — no partial or
   prefix matching. This is the single most common OAuth implementation bug
   (open redirect).
+  - **Amended by authkestra#291**: one carve-out, which RFC 8252 §7.3 makes a
+    MUST — a registered **loopback IP** redirect URI (`http://127.0.0.1/...`
+    or `http://[::1]/...`) matches on **any** port, because a native app takes
+    an ephemeral port from the OS at request time and cannot register it.
+    Only the port is ignored; scheme, host, userinfo, path, query and fragment
+    must still be equal, and the host must be the IP literal — `localhost` is
+    excluded per §8.3, as is the rest of `127.0.0.0/8`. This applies to the
+    registration check at `/authorize` only. The `/token` comparison of the
+    request's `redirect_uri` against the one recorded on the authorization
+    code stays an exact string match (RFC 6749 §4.1.3): the recorded value
+    already carries the concrete port the client used.
 - PKCE (`code_challenge`/`code_verifier`) is mandatory for public clients
   and recommended for all clients, per OAuth 2.1.
 - Authorization codes are single-use and short-lived (recommend ≤60s); the


### PR DESCRIPTION
## What

`ClientRegistration::allows_redirect_uri` compared redirect URIs by plain string equality with no loopback carve-out, so a native app that binds an ephemeral port — the case RFC 8252 §7.3 makes a **MUST** — could never authenticate. The port is not knowable at registration time, so no registered value could ever match and `/authorize` failed with `invalid redirect_uri` every time.

Exact `==` stays the first and normal check. It now falls back to a `loopback_match(registered, presented)` helper that applies **only** when:

- both URIs parse (`url` crate, already a direct dependency of `authkestra-op` — no `Cargo.toml` change),
- both have scheme `http`, and
- both have a host equal to the IP literal `127.0.0.1` (`url::Host::Ipv4`) or `::1` (`url::Host::Ipv6`).

Scheme, host, path, query and fragment must all be equal; **only the port is ignored**. Userinfo (`username`/`password`) is also compared — a small tightening beyond the issue's list, kept so that "only the port is ignored" is literally true and `http://attacker@127.0.0.1:1234/cb` cannot ride in on a registered `http://127.0.0.1/cb`.

Three spellings are deliberately excluded, and `is_loopback_ip`'s doc comment says why so a future reader does not "fix" them casually:

- `localhost` — refused outright, which is **stricter than §8.3** (the RFC says NOT RECOMMENDED, not MUST NOT). The whole security argument for the exemption is that the host is unambiguously the user's own machine; `localhost` gets there only via a resolver the app does not control, and it is `Host::Domain` here, so it cannot be told apart from any other name.
- the rest of `127.0.0.0/8` — `is_loopback_ip` deliberately does not use `Ipv4Addr::is_loopback()`, which would accept `127.0.0.2`.
- IPv4-mapped IPv6 loopback (`http://[::ffff:127.0.0.1]/cb`) — `Ipv6Addr::LOCALHOST` is `::1`, so the mapped form compares unequal and falls through to exact `==`. Admitting it would mean either a third literal or normalising mapped-to-plain-IPv4 before comparing, which is exactly the kind of pre-comparison rewriting redirect-URI matching should not do.

A `tracing::debug!` fires when the exemption — rather than exact equality — is what allowed the match, carrying `client_id`, `registered_uri` and `presented_uri`.

## Every other redirect_uri comparison, as requested

I grepped `redirect_uri` across `crates/authkestra-op/src`. There are exactly two comparison sites in the crate (`allows_redirect_uri` has exactly one caller, `handlers::authorize`):

1. **`handlers/authorize.rs` step 2** — `client.allows_redirect_uri(&req.redirect_uri)`. This is the registration check and is the one this PR fixes. Note that everything downstream of it (the redirect built from `parsed_uri`, and `AuthorizationCode::redirect_uri`) uses the URI **as presented**, so the ephemeral port survives into the stored code and into the 302.

2. **`handlers/token.rs` step 5** — `auth_code.redirect_uri != req_redirect_uri`. **Left exactly as it was, deliberately.** That is RFC 6749 §4.1.3 ("identical to the value included in the initial authorization request"), a different question from whether the client is *allowed* to use the URI at all, and it is not routed through `allows_redirect_uri`. The stored value already carries the concrete port the client bound at `/authorize`, so relaxing it would only permit swapping one loopback port for another mid-flow. I added a comment at that site saying so, so a future reader does not "fix" it for consistency.

Nothing else compares a redirect URI: `sqlx_store.rs`/`redis_store.rs` only persist and read the columns back, and `device_authorization.rs` does not use redirect URIs at all. `allows_redirect_uri` has no callers in `authkestra-axum`, `authkestra-actix`, or any other crate.

## Tests

`crates/authkestra-op/src/client.rs` — **12** new unit tests (an earlier revision of this description said 11; that was my miscount, corrected here):

- loopback registration accepts an ephemeral port (`http://127.0.0.1/cb` vs `http://127.0.0.1:54321/cb`), and a registered port is not binding either;
- `[::1]` gets the same treatment;
- `localhost` never qualifies, in either position, while exact `==` on `localhost` still works;
- `127.0.0.2` never qualifies, and neither does `[::ffff:127.0.0.1]` in either position;
- `https://127.0.0.1/cb` does not match `http://127.0.0.1:54321/cb`;
- different path / different query / missing query / different fragment / different userinfo all fail;
- a non-loopback URI with a different port does **not** match (`https://app.example.com/cb` vs `:8443`);
- a loopback registration does not admit `http://evil.example.com:54321/cb` or `http://127.0.0.1.evil.example.com:54321/cb`;
- a malformed presented URI (`"not a url"`, `"127.0.0.1:54321/cb"`, `""`) does not match, and an unparseable *registration* still matches through exact `==`.

`crates/authkestra-op/src/handlers/authorize.rs`: `loopback_redirect_on_an_ephemeral_port_is_accepted` proves it end to end — registered `http://127.0.0.1/callback`, presented `http://127.0.0.1:54321/callback`, asserts the outcome is a `Redirect` to `http://127.0.0.1:54321/callback?code=...` **and** that the persisted `AuthorizationCode::redirect_uri` is the presented value with the port (which is what keeps `/token`'s exact check correct).

Decisive check performed: with the `loopback_match` fallback short-circuited out, 4 of the new tests fail (`loopback_registration_accepts_any_ephemeral_port`, `loopback_registration_with_a_port_accepts_a_different_port`, `ipv6_loopback_literal_gets_the_same_exemption`, `only_the_port_is_ignored`); with it, all pass.

## Docs

Per the docs-are-not-compiled rule, I grepped `README.md`, `crates/*/README.md`, `docs/` and `website/` for statements of the exact-match rule. Two said it and are updated:

- `docs/rfc-003-oidc-provider.md` — the `redirect_uris` field comment in §6, and §7's first security bullet, which now carries an explicit "Amended by authkestra#291" sub-bullet that also states the `/token` check stays exact.
- `docs/book/ch09-security-and-threat-model.md` — the "Exact Redirect Matching" bullet.

The root `README.md` and `website/` only mention redirect URIs in the *client/RP* sense (`GithubProvider::new(..., redirect_uri)`, the callback endpoint) and never state the OP matching rule, so nothing there needed changing. `authkestra-op` has no README of its own (`readme.workspace = true`).

Doc comments updated on `ClientRegistration` (type-level), `redirect_uris` ("registering a loopback URI means any port"), `allows_redirect_uri`, `is_loopback_ip`, `OpError::RedirectUriMismatch`, `AuthorizationCode::redirect_uri` and `AuthorizeRequest::redirect_uri`.

## Verification

Run locally in this worktree, exactly as CI runs them:

| command | exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-features -- -D warnings` | 0 |
| `cargo test -p authkestra-op --all-features` | 0 (233 lib tests, 0 failed) |
| `cargo test --workspace --all-features` | 0 (0 failed; the 3 `ignored` are pre-existing `no_run`/`ignore` doctests) |

**`DOCKER_HOST` must be exported for these test runs.** The `sqlx_store` (Postgres/MySQL/SQLite) and `redis_store` suites use testcontainers, and under rootless Docker they fail with a `PermissionDenied` error unless `DOCKER_HOST` points at the user socket (e.g. `export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock`), as `CONTRIBUTING.md` notes. They are *not* skipped-and-green in that situation, they fail — but it is worth stating that the numbers above include them actually running.

`cargo deny check` was **not** run: no `Cargo.toml` changed. `url` was already a direct dependency of `authkestra-op`, so this adds nothing to the dependency graph. Coverage (`cargo llvm-cov`) was not run locally.

## Interaction with PR #300 (`next` → `main`) — this is a port, not a rebase

An earlier revision of this description called this "a small rebase". **That was wrong**, and I am correcting it here rather than leaving it to be discovered at merge time.

PR #300 moves `ClientRegistration`, `GrantType` and `AuthorizationCode` out of `authkestra-op` into `authkestra_engine::oauth2::{client, code}`, and reduces `crates/authkestra-op/src/client.rs` to a two-line re-export:

```rust
pub use authkestra_engine::oauth2::client::{
    ClientRegistration, GrantType, TokenEndpointAuthMethod,
};
pub use authkestra_engine::store::traits::ClientStore;
```

So if #300 lands first, landing this PR is **a port of `allows_redirect_uri`, `loopback_match`, `is_loopback_ip` and the 12 unit tests into `crates/authkestra-engine/src/oauth2/client.rs`** — a file that does not exist on `main` — plus the `AuthorizationCode` doc note into `crates/authkestra-engine/src/oauth2/code.rs`. Git will not resolve that for you; the conflict is a whole-file relocation, and a naive rebase would drop the fix on the floor while still applying the `authkestra-op` handler/doc hunks cleanly, which would look like success.

To make either merge order safe I have opened **#311**, a companion PR against `next` that has already done exactly that port. Exactly one of the two should survive into `main`: if #300 lands first, take #311 and close this PR as superseded; if this PR lands first, whoever merges `next` must keep the `authkestra-engine` copy. #311 is deliberately `Refs #291`, not `Closes`, so this PR remains the one that closes the issue.

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)
