### PR TITLE
feat(devsig): add DeviceIdentity::new so consumers can unit-test their principal mapping

### DIFF
--- a/crates/authkestra-devsig/README.md
+++ b/crates/authkestra-devsig/README.md
@@ -25,6 +25,27 @@ use authkestra_devsig::{IssuerJwks, InMemoryReplayStore, SignedRequest, Verifier
 let identity = verify(&request, &config, &jwks, &replay_store).await?;
 ```
 
+### Testing your own principal mapping
+
+`DeviceIdentity` is `#[non_exhaustive]`, so downstream crates cannot build one with a struct
+expression. `DeviceIdentity::new(subject, device, key_thumbprint, attributes)` exists so that the
+mapping from a verified identity onto your own principal/session type — where the
+security-relevant defaults live, such as what an absent `role` attribute grants — stays unit
+testable without minting a real attestation ([authkestra#282](https://github.com/marcjazz/authkestra/issues/282)):
+
+```rust,ignore
+let identity = DeviceIdentity::new(
+    "usr_1".to_owned(),
+    "vk_1".to_owned(),
+    "jkt-1".to_owned(),
+    serde_json::json!({}),
+);
+assert_eq!(my_mapping(&identity).role, "user");
+```
+
+`new` verifies nothing: a value built this way is test data, not an authentication result. Only
+`verify()` produces a `DeviceIdentity` that means a request passed the algorithm.
+
 ### Framework integration
 
 Framework wiring lives in the adapter crates, not here:

--- a/crates/authkestra-devsig/src/identity.rs
+++ b/crates/authkestra-devsig/src/identity.rs
@@ -22,3 +22,43 @@ pub struct DeviceIdentity {
     /// as-is to the application.
     pub attributes: Value,
 }
+
+impl DeviceIdentity {
+    /// Builds a `DeviceIdentity` from its parts, **verifying nothing**.
+    ///
+    /// A value built here carries no proof that any signature, attestation, or key binding was
+    /// ever checked; only [`verify()`](crate::verify()) returns a `DeviceIdentity` that means
+    /// "this request passed every step of the algorithm". Treat a hand-built value as test data,
+    /// never as an authentication result.
+    ///
+    /// It exists because `DeviceIdentity` is an *output* type: every consumer writes a mapping
+    /// from it onto their own principal/session representation, and that mapping is where the
+    /// security-relevant defaults live — what an absent `role` attribute grants, for one. With
+    /// `#[non_exhaustive]` and no constructor, that mapping could not be unit-tested from
+    /// outside this crate at all: a downstream test could not build the input without standing
+    /// up a full attestation mint plus a real signature (authkestra#282).
+    ///
+    /// `#[non_exhaustive]` is deliberately kept — it still stops downstream struct expressions
+    /// and exhaustive `match`es from breaking when a field is added — and this constructor is
+    /// the supported way through it.
+    ///
+    /// ```
+    /// use authkestra_devsig::DeviceIdentity;
+    ///
+    /// let identity = DeviceIdentity::new(
+    ///     "usr_1".to_owned(),
+    ///     "dev_1".to_owned(),
+    ///     "jkt-1".to_owned(),
+    ///     serde_json::json!({ "role": "user" }),
+    /// );
+    /// assert_eq!(identity.subject, "usr_1");
+    /// ```
+    pub fn new(subject: String, device: String, key_thumbprint: String, attributes: Value) -> Self {
+        Self {
+            subject,
+            device,
+            key_thumbprint,
+            attributes,
+        }
+    }
+}

--- a/crates/authkestra-devsig/src/verify.rs
+++ b/crates/authkestra-devsig/src/verify.rs
@@ -90,12 +90,12 @@ pub async fn verify(
         "device-signature request accepted"
     );
 
-    Ok(DeviceIdentity {
-        subject: att.sub,
-        device: att.did,
-        key_thumbprint: sig.jwk_thumbprint,
-        attributes: att.att,
-    })
+    Ok(DeviceIdentity::new(
+        att.sub,
+        att.did,
+        sig.jwk_thumbprint,
+        att.att,
+    ))
 }
 
 fn current_unix_time() -> i64 {

--- a/crates/authkestra-devsig/tests/identity_construction.rs
+++ b/crates/authkestra-devsig/tests/identity_construction.rs
@@ -1,0 +1,93 @@
+//! Downstream-consumer view of [`DeviceIdentity`]: these tests live outside the crate on
+//! purpose, because that is exactly what authkestra#282 reported as impossible — the type is
+//! `#[non_exhaustive]`, so no external crate could build one to unit-test its own principal
+//! mapping without minting a real attestation and a real signature first.
+//!
+//! Nothing here verifies anything cryptographically; `DeviceIdentity::new` performs no checks.
+//! The real algorithm is covered by `conformance.rs`.
+
+use authkestra_devsig::DeviceIdentity;
+use serde_json::{json, Value};
+
+#[test]
+fn new_exposes_every_field_to_an_external_crate() {
+    let identity = DeviceIdentity::new(
+        "usr_1".to_owned(),
+        "vk_1".to_owned(),
+        "jkt-1".to_owned(),
+        json!({ "role": "admin", "kycStatus": "verified" }),
+    );
+
+    assert_eq!(identity.subject, "usr_1");
+    assert_eq!(identity.device, "vk_1");
+    assert_eq!(identity.key_thumbprint, "jkt-1");
+    assert_eq!(identity.attributes["role"], "admin");
+    assert_eq!(identity.attributes["kycStatus"], "verified");
+}
+
+/// A consumer's principal, and the mapping from a verified identity onto it — the shape
+/// authkestra#282 described (`vaam-store`'s `ClaimsPrincipalResolver`), reduced to the one rule
+/// with real weight.
+#[derive(Debug, PartialEq, Eq)]
+struct Principal {
+    subject: String,
+    role: String,
+}
+
+fn principal_from(identity: &DeviceIdentity) -> Principal {
+    Principal {
+        subject: identity.subject.clone(),
+        // A missing `role` attribute must fall back to the least-privileged value. Inverting
+        // this default is a privilege escalation, which is why it is worth a test.
+        role: identity
+            .attributes
+            .get("role")
+            .and_then(Value::as_str)
+            .unwrap_or("user")
+            .to_owned(),
+    }
+}
+
+#[test]
+fn principal_mapping_defaults_a_missing_role_to_user() {
+    let identity = DeviceIdentity::new(
+        "usr_1".to_owned(),
+        "vk_1".to_owned(),
+        "jkt-1".to_owned(),
+        json!({}),
+    );
+
+    assert_eq!(
+        principal_from(&identity),
+        Principal {
+            subject: "usr_1".to_owned(),
+            role: "user".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn principal_mapping_reads_a_present_role() {
+    let identity = DeviceIdentity::new(
+        "usr_2".to_owned(),
+        "vk_2".to_owned(),
+        "jkt-2".to_owned(),
+        json!({ "role": "admin" }),
+    );
+
+    assert_eq!(principal_from(&identity).role, "admin");
+}
+
+/// A non-string `role` is not a string, so the fallback applies: still `"user"`, never anything
+/// more privileged.
+#[test]
+fn principal_mapping_defaults_a_non_string_role_to_user() {
+    let identity = DeviceIdentity::new(
+        "usr_3".to_owned(),
+        "vk_3".to_owned(),
+        "jkt-3".to_owned(),
+        json!({ "role": 7 }),
+    );
+
+    assert_eq!(principal_from(&identity).role, "user");
+}

--- a/website/src/content/docs/providers/device-signatures.mdx
+++ b/website/src/content/docs/providers/device-signatures.mdx
@@ -113,6 +113,24 @@ HttpServer::new(move || {
 
 By verifying the signature, you ensure that the request was genuinely initiated by the enrolled device, providing high-assurance authentication suitable for sensitive operations.
 
+## Testing your principal mapping
+
+The verified identity is an `authkestra_devsig::DeviceIdentity`, and it is `#[non_exhaustive]` — you cannot build one with a struct expression from your own crate. Use `DeviceIdentity::new(subject, device, key_thumbprint, attributes)` to unit-test the code that maps an identity onto your own principal or session type, which is where the security-relevant defaults live (for example, an absent `role` attribute must fall back to your least-privileged value):
+
+```rust
+use authkestra_devsig::DeviceIdentity;
+
+let identity = DeviceIdentity::new(
+    "usr_1".to_owned(),
+    "vk_1".to_owned(),
+    "jkt-1".to_owned(),
+    serde_json::json!({}),
+);
+assert_eq!(my_mapping(&identity).role, "user");
+```
+
+`DeviceIdentity::new` performs no verification at all: a value built this way is test data and carries no proof that any signature was checked. Only `verify()` (and therefore the layer/middleware above) produces a `DeviceIdentity` that means a request passed the algorithm.
+
 Complete, runnable versions of both wirings live in the repository:
 
 ```bash


### PR DESCRIPTION
## What

Adds `DeviceIdentity::new(subject, device, key_thumbprint, attributes)` to `authkestra-devsig`.

`DeviceIdentity` is the success type of `verify()`, so every consumer writes a mapping from it onto their own principal/session type — and that mapping is where the security-relevant defaults live (what an absent `role` attribute grants). Being `#[non_exhaustive]` with no constructor made that mapping impossible to unit-test from outside the crate: a downstream test could not build the input without minting a real attestation and a real signature first.

## Why option (2) from the issue

- `#[non_exhaustive]` is **kept** — adding a field stays non-breaking for downstream struct expressions and exhaustive matches.
- No `Default` impl: an all-empty identity is not a meaningful value for an authentication output, and `..Default::default()` would let a test silently miss a newly added field.
- The doc comment states plainly that `new` verifies nothing: a value built with it is test data and carries no proof that any signature was checked. Only `verify()` produces a `DeviceIdentity` that means a request passed the algorithm.

`verify()` now builds its result through `new`, so the constructor sits on the real path rather than being test-only scaffolding.

## Test

`crates/authkestra-devsig/tests/identity_construction.rs` — deliberately an integration test, i.e. from *outside* the crate, which is the vantage point the issue reported as impossible. It includes the issue's own example: a missing `role` attribute must map to `"user"`, never anything more privileged.

## Docs

Per `AGENTS.md` ("Docs Are Not Compiled"), the new API is noted in the two places `DeviceIdentity` is documented for consumers: `crates/authkestra-devsig/README.md` and `website/src/content/docs/providers/device-signatures.mdx`. Both repeat the "verifies nothing" caveat.

## Verification

| Command | Exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-features -- -D warnings` | 0 |
| `cargo test -p authkestra-devsig --all-features` | 0 (2 unit + 32 conformance + 4 new + 1 doctest) |
| `cargo test --workspace --all-features` | see note |

The full-workspace run did not go green in a single pass in this sandbox, and both failures are environmental, not from this change (which touches only `authkestra-devsig`):

- `authkestra-op` `sqlx_store::{postgres,mysql}` testcontainers failures — `RootlessKit PortManager.AddPort(): address already in use`. Re-run serially: **28 passed, 0 failed**.
- `authkestra` `examples_e2e::test_all_oauth_examples_sequentially` — the harness spawns a nested `cargo run --example`, which printed `Blocking waiting for file lock on build directory` and never acquired the lock inside its 180s budget (the build directory is shared with concurrent jobs here). It passed in an earlier pass of the same run at 157s.

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)
