### PR TITLE
feat(ssf): ingest and validate Security Event Tokens (RFC 8417) with typed CAEP events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "authkestra-op",
  "authkestra-providers",
  "authkestra-resource",
+ "authkestra-ssf",
  "authkestra-store-sqlx",
  "axum",
  "base64 0.22.1",
@@ -744,6 +745,20 @@ dependencies = [
  "tracing",
  "url",
  "wiremock",
+]
+
+[[package]]
+name = "authkestra-ssf"
+version = "0.8.0"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "jsonwebtoken",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/authkestra-store-sqlx",
     "crates/authkestra-example-seaorm",
     "crates/authkestra-example-diesel",
+    "crates/authkestra-ssf",
 ]
 
 [workspace.package]
@@ -58,6 +59,7 @@ authkestra-store-sqlx = { version = "0.8.0", path = "crates/authkestra-store-sql
 authkestra-store-testsuite = { version = "0.8.0", path = "crates/authkestra-store-testsuite" }
 authkestra-devsig = { version = "0.8.0", path = "crates/authkestra-devsig", default-features = false }
 authkestra-crypto-util = { version = "0.8.0", path = "crates/authkestra-crypto-util", default-features = false }
+authkestra-ssf = { version = "0.8.0", path = "crates/authkestra-ssf", default-features = false }
 rand = "0.9.2"
 url = "2.5"
 sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ check with `cargo tree -i aws-lc-rs -e features`.
 | [`authkestra-op`](https://github.com/marcjazz/authkestra/tree/main/crates/authkestra-op)               | OpenID Connect Provider (OP) implementation.                              |
 | [`authkestra-devsig`](https://github.com/marcjazz/authkestra/tree/main/crates/authkestra-devsig)       | Device-bound signature authentication (proof-of-possession + Issuer attestation). |
 | [`authkestra-crypto-util`](https://github.com/marcjazz/authkestra/tree/main/crates/authkestra-crypto-util) | Shared strict signature/key verification helpers used by the OP and devsig crates. |
+| [`authkestra-ssf`](https://github.com/marcjazz/authkestra/tree/main/crates/authkestra-ssf)             | Shared Signals Framework: Security Event Token (RFC 8417) ingestion and CAEP events. |
 | [`authkestra-macros`](https://github.com/marcjazz/authkestra/tree/main/crates/authkestra-macros)       | Procedural macros for simplifying Authkestra integration.                 |
 
 ## 🛠️ Usage

--- a/crates/authkestra-ssf/Cargo.toml
+++ b/crates/authkestra-ssf/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+exclude.workspace = true
+name = "authkestra-ssf"
+version.workspace = true
+edition.workspace = true
+description = "Shared Signals Framework for the authkestra framework: ingest and validate Security Event Tokens (RFC 8417), decode typed OpenID CAEP 1.0 events, and receive them over the RFC 8935 push delivery method"
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+readme = "README.md"
+
+[dependencies]
+async-trait = "0.1"
+# Raw base64 decoding of the JOSE header, *before* `jsonwebtoken`'s typed API sees it. See
+# `crate::verify` for why `alg: "none"` and a missing/wrong `typ` cannot be told apart from a
+# corrupt token any other way.
+base64 = "0.22.1"
+jsonwebtoken = { version = "11", features = ["rust_crypto"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "2.0.18"
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
+
+[features]
+default = []

--- a/crates/authkestra-ssf/README.md
+++ b/crates/authkestra-ssf/README.md
@@ -70,9 +70,23 @@ handful of lines today and a dedicated adapter feature in a follow-up PR.
   `application/secevent+jwt` are accepted, case-insensitively.
 - **`exp` is optional and honoured; `nbf` is parsed and ignored.** RFC 8417 §2.2 says `exp` is NOT
   RECOMMENDED in a SET and never profiles `nbf` at all.
+- **An empty or whitespace-only `jti` is refused** with `400 invalid_request`. RFC 8417 §2.2 makes
+  `jti` the SET's unique identifier; an empty one identifies nothing, and accepting it would
+  collapse the replay guard to a single slot per issuer so that the first such SET permanently
+  suppressed every later one.
+- **The request body is size-capped** at `DEFAULT_MAX_BODY_BYTES` (1 MiB), configurable with
+  `PushReceiver::with_max_body_bytes`. This is a *second* line of defence: by the time `receive`
+  is called the body is already in memory, so set your framework's own limit (axum's
+  `DefaultBodyLimit`, actix's `PayloadConfig`, or the proxy's `client_max_body_size`) too.
 - **Handlers run before the response.** This crate has no store of its own, so a handler *is* the
   persistence step RFC 8935 §2 asks for before acknowledging. Enqueue-and-return inside a handler
   if you want the RFC's asynchronous shape.
+- **The public models are `#[non_exhaustive]` but constructible.** `SecurityEventToken::new`,
+  `TokenClaimsChange::new`, `CredentialChange::new`, `AssuranceLevelChange::new`,
+  `DeviceComplianceChange::new`, `CaepMetadata::empty` and `SessionRevoked::default` exist so a
+  downstream crate can build fixtures for its own tests without minting and verifying a real SET
+  (the problem reported for `devsig`'s `DeviceIdentity` in authkestra#282). None of them validate
+  anything.
 
 ## License
 

--- a/crates/authkestra-ssf/README.md
+++ b/crates/authkestra-ssf/README.md
@@ -1,0 +1,79 @@
+# authkestra-ssf
+
+Shared Signals Framework ingestion for the `authkestra` framework: validate Security Event Tokens
+([RFC 8417](https://www.rfc-editor.org/rfc/rfc8417)), decode typed
+[OpenID CAEP 1.0](https://openid.net/specs/openid-caep-specification-1_0.html) events, and receive
+them over the [RFC 8935](https://www.rfc-editor.org/rfc/rfc8935) HTTP push delivery method.
+
+Part of [authkestra#25](https://github.com/marcjazz/authkestra/issues/25).
+
+## Status
+
+| Capability | Status |
+| --- | --- |
+| SET parsing and validation — `typ`, `alg` allow-listing, signature, issuer, audience, `iat` freshness, optional max age, `exp` when present, non-empty `events`, `jti` replay | done (`SetVerifier`) |
+| RFC 9493 subject identifiers (`iss_sub`, `email`, `opaque`, `phone_number`, everything else preserved) | done (`SubjectIdentifier`) |
+| Typed CAEP 1.0 events: session revoked, token claims change, credential change, assurance level change, device compliance change — unknown event types preserved, never dropped | done (`CaepEvent`) |
+| RFC 8935 push delivery semantics: 202, or 400 with a registered `err` code | done (`PushReceiver`) |
+| Revoking or attenuating a live session when an event arrives | **not implemented** |
+| Middleware that rejects tokens invalidated by a CAEP event | **not implemented** |
+| Axum / Actix route wiring | **not implemented** |
+
+The last three rows are follow-up work. Until they land, a `SetHandler` implementation is where a
+deployment plugs in its own reaction to an event; the events themselves are fully validated and
+decoded.
+
+## Usage
+
+```rust,ignore
+use std::sync::Arc;
+use std::time::Duration;
+
+use authkestra_ssf::{InMemorySetReplayGuard, LoggingHandler, PushReceiver, SetVerifier};
+use jsonwebtoken::{Algorithm, DecodingKey};
+
+let verifier = SetVerifier::builder("https://idp.example.com/")
+    .audience("https://sp.example.com/caep")
+    .algorithms([Algorithm::EdDSA])
+    .key(transmitter_key)
+    .max_age(Duration::from_secs(60 * 60))
+    .replay_guard(Arc::new(InMemorySetReplayGuard::new(Duration::from_secs(60 * 60))))
+    .build()?;
+
+let receiver = PushReceiver::new(Arc::new(verifier)).with_handler(Arc::new(LoggingHandler));
+
+// From your HTTP handler: pass the Content-Type header and the raw body through.
+let response = receiver.receive(content_type, body).await;
+// -> response.status(), response.content_type(), response.content_language(), response.body()
+```
+
+For a transmitter that rotates keys, implement `SetKeyResolver` over your JWKS cache and pass it
+to `.key_resolver(...)` instead of `.key(...)`.
+
+## Framework integration
+
+There is none in this crate, on purpose: per the workspace `AGENTS.md` "Framework Agnostic" rule,
+`PushReceiver::receive` takes a content type and a byte slice and returns a `PushResponse`
+describing the status, headers and body to send. Turning that into an axum or actix route is a
+handful of lines today and a dedicated adapter feature in a follow-up PR.
+
+## Notable behaviours worth knowing before you deploy
+
+- **A retransmitted SET is answered `202`, not `400`.** RFC 8935 §2 requires the recipient to
+  respond to a repeat transmission exactly as it would to a first one. The replay guard therefore
+  suppresses handler dispatch, not the acknowledgement.
+- **`alg: none` is rejected by name**, before any typed parsing, because RFC 8417 §2.4's own
+  worked example is an unsecured JWT.
+- **Explicit typing is required.** RFC 8417 §2.3 makes `typ: secevent+jwt` conditional; a
+  general-purpose receiver is exactly the "could be confused with other kinds of JWTs" context
+  that condition names, so this crate requires it. Both `secevent+jwt` and
+  `application/secevent+jwt` are accepted, case-insensitively.
+- **`exp` is optional and honoured; `nbf` is parsed and ignored.** RFC 8417 §2.2 says `exp` is NOT
+  RECOMMENDED in a SET and never profiles `nbf` at all.
+- **Handlers run before the response.** This crate has no store of its own, so a handler *is* the
+  persistence step RFC 8935 §2 asks for before acknowledging. Enqueue-and-return inside a handler
+  if you want the RFC's asynchronous shape.
+
+## License
+
+Licensed under either of MIT or Apache-2.0 at your option.

--- a/crates/authkestra-ssf/README.md
+++ b/crates/authkestra-ssf/README.md
@@ -62,6 +62,15 @@ handful of lines today and a dedicated adapter feature in a follow-up PR.
 - **A retransmitted SET is answered `202`, not `400`.** RFC 8935 §2 requires the recipient to
   respond to a repeat transmission exactly as it would to a first one. The replay guard therefore
   suppresses handler dispatch, not the acknowledgement.
+- **Event payloads are decoded during verification, not after it.** `SetVerifier::verify` returns
+  a `VerifiedSet { set, events }`, and a modelled event whose payload does not conform is refused
+  *before* the `(iss, jti)` replay slot is taken. Decoding afterwards would burn the `jti` on a
+  SET that is then rejected, so the transmitter's corrected retransmission under the same `jti`
+  would come back `202` from the replay path and never reach a handler.
+- **Failure descriptions never echo the configured issuer or audience.** The RFC 8935 §2.3
+  `description` goes to an unauthenticated caller — the push endpoint has no authentication of its
+  own — so `invalid_issuer` and `invalid_audience` responses say only that, and the expected
+  values are logged as structured tracing fields instead.
 - **`alg: none` is rejected by name**, before any typed parsing, because RFC 8417 §2.4's own
   worked example is an unsecured JWT.
 - **Explicit typing is required.** RFC 8417 §2.3 makes `typ: secevent+jwt` conditional; a

--- a/crates/authkestra-ssf/README.md
+++ b/crates/authkestra-ssf/README.md
@@ -90,6 +90,14 @@ handful of lines today and a dedicated adapter feature in a follow-up PR.
 - **Handlers run before the response.** This crate has no store of its own, so a handler *is* the
   persistence step RFC 8935 §2 asks for before acknowledging. Enqueue-and-return inside a handler
   if you want the RFC's asynchronous shape.
+- **Handlers must be idempotent.** A `HandlerError::Internal` answers 500 and releases the SET's
+  replay slot so the transmitter's retry is genuinely dispatched rather than acknowledged as a
+  duplicate — which means the retry re-runs *every* handler for *every* event in the SET,
+  including the handlers that already succeeded before the one that failed. A
+  `HandlerError::Rejected` (400) keeps the slot, because the transmitter is not going to retry.
+  One window stays open by design: a concurrent duplicate arriving between the record and the
+  release is answered 202 without dispatch, but the retry of the failed delivery still delivers
+  the event, so nothing is lost.
 - **The public models are `#[non_exhaustive]` but constructible.** `SecurityEventToken::new`,
   `TokenClaimsChange::new`, `CredentialChange::new`, `AssuranceLevelChange::new`,
   `DeviceComplianceChange::new`, `CaepMetadata::empty` and `SessionRevoked::default` exist so a

--- a/crates/authkestra-ssf/README.md
+++ b/crates/authkestra-ssf/README.md
@@ -67,10 +67,10 @@ handful of lines today and a dedicated adapter feature in a follow-up PR.
   *before* the `(iss, jti)` replay slot is taken. Decoding afterwards would burn the `jti` on a
   SET that is then rejected, so the transmitter's corrected retransmission under the same `jti`
   would come back `202` from the replay path and never reach a handler.
-- **Failure descriptions never echo the configured issuer or audience.** The RFC 8935 §2.3
-  `description` goes to an unauthenticated caller — the push endpoint has no authentication of its
-  own — so `invalid_issuer` and `invalid_audience` responses say only that, and the expected
-  values are logged as structured tracing fields instead.
+- **Failure descriptions never echo your configuration.** The RFC 8935 §2.3 `description` goes to
+  an unauthenticated caller — the push endpoint has no authentication of its own — so the
+  configured issuer, the accepted audiences, the clock leeway and the maximum accepted age stay
+  out of it. All of them are logged as structured tracing fields instead.
 - **`alg: none` is rejected by name**, before any typed parsing, because RFC 8417 §2.4's own
   worked example is an unsecured JWT.
 - **Explicit typing is required.** RFC 8417 §2.3 makes `typ: secevent+jwt` conditional; a

--- a/crates/authkestra-ssf/src/caep.rs
+++ b/crates/authkestra-ssf/src/caep.rs
@@ -227,6 +227,7 @@ pub type LocalizedMessage = BTreeMap<String, String>;
 /// The claims CAEP 1.0 §2 defines for every event type, all optional unless an event definition
 /// says otherwise.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CaepMetadata {
     /// When the event described by this SET occurred, as seconds since the Unix epoch.
     ///
@@ -267,6 +268,7 @@ pub struct CaepMetadata {
 /// Has no event-specific claims — the subject *is* the payload. When `event_timestamp` is
 /// present it is the time the revocation occurred.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct SessionRevoked {
     /// Claims common to every CAEP event.
     #[serde(flatten)]
@@ -275,6 +277,7 @@ pub struct SessionRevoked {
 
 /// Token Claims Change (CAEP 1.0 §3.2): a claim in a token identified by the subject changed.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct TokenClaimsChange {
     /// REQUIRED: one or more claims with their new value(s).
     pub claims: Map<String, Value>,
@@ -285,6 +288,7 @@ pub struct TokenClaimsChange {
 
 /// Credential Change (CAEP 1.0 §3.3): a credential was created, changed, revoked or deleted.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CredentialChange {
     /// REQUIRED: the kind of credential that changed.
     pub credential_type: CredentialType,
@@ -309,6 +313,7 @@ pub struct CredentialChange {
 
 /// Assurance Level Change (CAEP 1.0 §3.4): the authentication method changed since login.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct AssuranceLevelChange {
     /// REQUIRED: the current NIST AAL.
     pub current_level: AssuranceLevel,
@@ -323,6 +328,7 @@ pub struct AssuranceLevelChange {
 
 /// Device Compliance Change (CAEP 1.0 §3.5): a device's compliance status changed.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct DeviceComplianceChange {
     /// REQUIRED: the compliance status prior to the change.
     pub previous_status: ComplianceStatus,
@@ -331,6 +337,107 @@ pub struct DeviceComplianceChange {
     /// Claims common to every CAEP event.
     #[serde(flatten)]
     pub metadata: CaepMetadata,
+}
+
+impl CaepMetadata {
+    /// An empty set of common claims.
+    ///
+    /// **Exists so consumers can construct one in their own tests.** A `#[non_exhaustive]` claims
+    /// bag with no constructor cannot be built downstream at all, which is the problem reported
+    /// against `authkestra-devsig`'s `DeviceIdentity` in
+    /// [authkestra#282](https://github.com/marcjazz/authkestra/issues/282). It performs **no
+    /// validation**: these claims are all OPTIONAL per CAEP 1.0 §2, so an empty bag is
+    /// a legal, if uninformative, value.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+}
+
+impl TokenClaimsChange {
+    /// Builds a Token Claims Change event carrying `claims` (CAEP 1.0 §3.2.1: REQUIRED).
+    ///
+    /// **Exists so consumers can construct one in their own tests.** A `#[non_exhaustive]` event
+    /// type with no constructor cannot be built downstream at all, which is the problem reported
+    /// against `authkestra-devsig`'s `DeviceIdentity` in
+    /// [authkestra#282](https://github.com/marcjazz/authkestra/issues/282). It performs **no
+    /// validation**: an event a receiver should act on comes out of [`CaepEvent::decode`] behind
+    /// [`crate::SetVerifier`], never out of this constructor.
+    pub fn new(claims: Map<String, Value>) -> Self {
+        Self {
+            claims,
+            metadata: CaepMetadata::default(),
+        }
+    }
+}
+
+impl CredentialChange {
+    /// Builds a Credential Change event from the two claims CAEP 1.0 §3.3.1 makes REQUIRED.
+    ///
+    /// **Exists so consumers can construct one in their own tests.** A `#[non_exhaustive]` event
+    /// type with no constructor cannot be built downstream at all, which is the problem reported
+    /// against `authkestra-devsig`'s `DeviceIdentity` in
+    /// [authkestra#282](https://github.com/marcjazz/authkestra/issues/282). It performs **no
+    /// validation**: an event a receiver should act on comes out of [`CaepEvent::decode`] behind
+    /// [`crate::SetVerifier`], never out of this constructor.
+    pub fn new(credential_type: CredentialType, change_type: ChangeType) -> Self {
+        Self {
+            credential_type,
+            change_type,
+            friendly_name: None,
+            x509_issuer: None,
+            x509_serial: None,
+            fido2_aaguid: None,
+            metadata: CaepMetadata::default(),
+        }
+    }
+}
+
+impl AssuranceLevelChange {
+    /// Builds an Assurance Level Change event from the three claims CAEP 1.0 §3.4.1 makes
+    /// REQUIRED.
+    ///
+    /// **Exists so consumers can construct one in their own tests.** A `#[non_exhaustive]` event
+    /// type with no constructor cannot be built downstream at all, which is the problem reported
+    /// against `authkestra-devsig`'s `DeviceIdentity` in
+    /// [authkestra#282](https://github.com/marcjazz/authkestra/issues/282). It performs **no
+    /// validation**: an event a receiver should act on comes out of [`CaepEvent::decode`] behind
+    /// [`crate::SetVerifier`], never out of this constructor.
+    ///
+    /// Note in particular that nothing here checks that `change_direction` agrees with the two
+    /// levels: a transmitter that sends `increase` alongside a decrease is describing something
+    /// self-contradictory, and it is the receiver's policy, not this type, that decides what to
+    /// do about it.
+    pub fn new(
+        current_level: AssuranceLevel,
+        previous_level: AssuranceLevel,
+        change_direction: ChangeDirection,
+    ) -> Self {
+        Self {
+            current_level,
+            previous_level,
+            change_direction,
+            metadata: CaepMetadata::default(),
+        }
+    }
+}
+
+impl DeviceComplianceChange {
+    /// Builds a Device Compliance Change event from the two claims CAEP 1.0 §3.5.1 makes
+    /// REQUIRED.
+    ///
+    /// **Exists so consumers can construct one in their own tests.** A `#[non_exhaustive]` event
+    /// type with no constructor cannot be built downstream at all, which is the problem reported
+    /// against `authkestra-devsig`'s `DeviceIdentity` in
+    /// [authkestra#282](https://github.com/marcjazz/authkestra/issues/282). It performs **no
+    /// validation**: an event a receiver should act on comes out of [`CaepEvent::decode`] behind
+    /// [`crate::SetVerifier`], never out of this constructor.
+    pub fn new(previous_status: ComplianceStatus, current_status: ComplianceStatus) -> Self {
+        Self {
+            previous_status,
+            current_status,
+            metadata: CaepMetadata::default(),
+        }
+    }
 }
 
 /// One decoded entry of a SET's `events` claim.

--- a/crates/authkestra-ssf/src/caep.rs
+++ b/crates/authkestra-ssf/src/caep.rs
@@ -1,0 +1,744 @@
+//! Typed [OpenID Continuous Access Evaluation Profile (CAEP) 1.0](https://openid.net/specs/openid-caep-specification-1_0.html)
+//! events, decoded out of a SET's `events` claim.
+//!
+//! CAEP is the application of the Shared Signals Framework to access security: a transmitter
+//! signals that something about a subject changed — the session was revoked, a credential was
+//! rotated, the device fell out of compliance — and the receiver decides what to do about it.
+//! This module is the "what was signalled" half only; acting on it (session revocation,
+//! middleware enforcement) is deliberately out of scope here, see the crate-level docs.
+//!
+//! Field names and their required/optional status come from CAEP 1.0 §2 (claims common to every
+//! event) and §3.1–§3.5 (the event-specific claims).
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use thiserror::Error;
+
+use crate::subject::SubjectIdentifier;
+
+/// The base URI every CAEP 1.0 event type is built from (CAEP 1.0 §3).
+pub const CAEP_EVENT_TYPE_PREFIX: &str = "https://schemas.openid.net/secevent/caep/event-type/";
+
+/// Event Type URI for Session Revoked (CAEP 1.0 §3.1).
+pub const EVENT_TYPE_SESSION_REVOKED: &str =
+    "https://schemas.openid.net/secevent/caep/event-type/session-revoked";
+/// Event Type URI for Token Claims Change (CAEP 1.0 §3.2).
+pub const EVENT_TYPE_TOKEN_CLAIMS_CHANGE: &str =
+    "https://schemas.openid.net/secevent/caep/event-type/token-claims-change";
+/// Event Type URI for Credential Change (CAEP 1.0 §3.3).
+pub const EVENT_TYPE_CREDENTIAL_CHANGE: &str =
+    "https://schemas.openid.net/secevent/caep/event-type/credential-change";
+/// Event Type URI for Assurance Level Change (CAEP 1.0 §3.4).
+pub const EVENT_TYPE_ASSURANCE_LEVEL_CHANGE: &str =
+    "https://schemas.openid.net/secevent/caep/event-type/assurance-level-change";
+/// Event Type URI for Device Compliance Change (CAEP 1.0 §3.5).
+pub const EVENT_TYPE_DEVICE_COMPLIANCE_CHANGE: &str =
+    "https://schemas.openid.net/secevent/caep/event-type/device-compliance-change";
+
+/// An event payload named a CAEP event type but did not conform to that type's definition.
+///
+/// Kept distinct from "unknown event type": an unknown type is preserved as
+/// [`CaepEvent::Unknown`], whereas a *known* type with a malformed payload is exactly what
+/// RFC 8935 §2.4's `invalid_request` describes ("the Event Payload within the SET does not
+/// conform to the event's definition") and must be reported, not silently downgraded.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("event payload for {uri} does not conform to its CAEP 1.0 definition: {message}")]
+pub struct EventDecodeError {
+    uri: String,
+    message: String,
+}
+
+impl EventDecodeError {
+    /// Builds a decode error for `uri` with a human-readable `message`.
+    pub fn new(uri: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            uri: uri.into(),
+            message: message.into(),
+        }
+    }
+
+    /// The event type URI whose payload failed to decode.
+    pub fn uri(&self) -> &str {
+        &self.uri
+    }
+
+    /// The underlying reason, as reported by the JSON decoder.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+/// Generates a CAEP string-valued enum with an `Other(String)` escape hatch.
+///
+/// CAEP 1.0 spells most of these as "MUST be one of the following strings", but a receiver that
+/// hard-errors on an unrecognised value would reject a whole SET — including the events it *does*
+/// understand — because a transmitter added a value in a later profile revision. Preserving the
+/// raw string keeps the decision about what to do with it where it belongs: with the handler.
+macro_rules! caep_string_enum {
+    (
+        $(#[$meta:meta])*
+        $name:ident {
+            $( $(#[$vmeta:meta])* $variant:ident => $wire:literal ),+ $(,)?
+        }
+    ) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        #[non_exhaustive]
+        pub enum $name {
+            $( $(#[$vmeta])* $variant, )+
+            /// A value CAEP 1.0 does not define, preserved verbatim.
+            Other(String),
+        }
+
+        impl $name {
+            /// The on-the-wire string for this value.
+            pub fn as_str(&self) -> &str {
+                match self {
+                    $( $name::$variant => $wire, )+
+                    $name::Other(raw) => raw.as_str(),
+                }
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(raw: &str) -> Self {
+                match raw {
+                    $( $wire => $name::$variant, )+
+                    other => $name::Other(other.to_string()),
+                }
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                serializer.serialize_str(self.as_str())
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                let raw = String::deserialize(deserializer)?;
+                Ok($name::from(raw.as_str()))
+            }
+        }
+    };
+}
+
+caep_string_enum! {
+    /// The entity that invoked an event (CAEP 1.0 §2, `initiating_entity`).
+    InitiatingEntity {
+        /// An administrative action triggered the event.
+        Admin => "admin",
+        /// An end-user action triggered the event.
+        User => "user",
+        /// A policy evaluation triggered the event.
+        Policy => "policy",
+        /// A system or platform assertion triggered the event.
+        System => "system",
+    }
+}
+
+caep_string_enum! {
+    /// The kind of credential a Credential Change event is about (CAEP 1.0 §3.3.1,
+    /// `credential_type`). The spec explicitly allows "any other credential type supported
+    /// mutually by the Transmitter and the Receiver", so `Other` is not merely defensive here.
+    CredentialType {
+        /// A password.
+        Password => "password",
+        /// A PIN.
+        Pin => "pin",
+        /// An X.509 certificate.
+        X509 => "x509",
+        /// A platform FIDO2 authenticator.
+        Fido2Platform => "fido2-platform",
+        /// A roaming FIDO2 authenticator.
+        Fido2Roaming => "fido2-roaming",
+        /// A FIDO U2F authenticator.
+        FidoU2f => "fido-u2f",
+        /// A verifiable credential.
+        VerifiableCredential => "verifiable-credential",
+        /// Voice call to a phone number.
+        PhoneVoice => "phone-voice",
+        /// SMS to a phone number.
+        PhoneSms => "phone-sms",
+        /// An authenticator application.
+        App => "app",
+    }
+}
+
+caep_string_enum! {
+    /// What happened to the credential (CAEP 1.0 §3.3.1, `change_type`).
+    ChangeType {
+        /// The credential was created.
+        Create => "create",
+        /// The credential was revoked.
+        Revoke => "revoke",
+        /// The credential was updated.
+        Update => "update",
+        /// The credential was deleted.
+        Delete => "delete",
+    }
+}
+
+caep_string_enum! {
+    /// A NIST SP 800-63R3 Authenticator Assurance Level (CAEP 1.0 §3.4.1).
+    AssuranceLevel {
+        /// NIST AAL1.
+        Aal1 => "nist-aal1",
+        /// NIST AAL2.
+        Aal2 => "nist-aal2",
+        /// NIST AAL3.
+        Aal3 => "nist-aal3",
+    }
+}
+
+caep_string_enum! {
+    /// Whether an assurance level went up or down (CAEP 1.0 §3.4.1, `change_direction`).
+    ChangeDirection {
+        /// The assurance level increased.
+        Increase => "increase",
+        /// The assurance level decreased.
+        Decrease => "decrease",
+    }
+}
+
+caep_string_enum! {
+    /// A device compliance status (CAEP 1.0 §3.5.1).
+    ComplianceStatus {
+        /// The device is compliant with policy.
+        Compliant => "compliant",
+        /// The device is not compliant with policy.
+        NotCompliant => "not-compliant",
+    }
+}
+
+/// A localizable message: BCP 47 language tag to locale-specific text (CAEP 1.0 §2,
+/// `reason_admin` / `reason_user`).
+pub type LocalizedMessage = BTreeMap<String, String>;
+
+/// The claims CAEP 1.0 §2 defines for every event type, all optional unless an event definition
+/// says otherwise.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct CaepMetadata {
+    /// When the event described by this SET occurred, as seconds since the Unix epoch.
+    ///
+    /// Distinct from the SET's own `iat` (when the token was minted) and from `toe` (the SET's
+    /// own time-of-event claim): each event in a multi-event SET carries its own.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_timestamp: Option<i64>,
+
+    /// The entity that invoked the event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initiating_entity: Option<InitiatingEntity>,
+
+    /// A localizable administrative message intended for logging and auditing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason_admin: Option<LocalizedMessage>,
+
+    /// A localizable user-friendly message for display to an end user.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason_user: Option<LocalizedMessage>,
+
+    /// The event's own subject.
+    ///
+    /// Not in CAEP 1.0 §2's list, but every example in §3.1.2–§3.5.2 puts a `subject` member in
+    /// the event payload, and RFC 8417 §2.2 explicitly allows a profile to "convey event subject
+    /// information in the event payload". A receiver that only looked at the SET's `sub_id`
+    /// would miss the subject of every real-world CAEP event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<SubjectIdentifier>,
+
+    /// Any other member of the event payload, preserved so a handler can read members from a
+    /// profile this crate does not model.
+    #[serde(flatten)]
+    pub additional: Map<String, Value>,
+}
+
+/// Session Revoked (CAEP 1.0 §3.1): the session identified by the subject has been revoked.
+///
+/// Has no event-specific claims — the subject *is* the payload. When `event_timestamp` is
+/// present it is the time the revocation occurred.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SessionRevoked {
+    /// Claims common to every CAEP event.
+    #[serde(flatten)]
+    pub metadata: CaepMetadata,
+}
+
+/// Token Claims Change (CAEP 1.0 §3.2): a claim in a token identified by the subject changed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TokenClaimsChange {
+    /// REQUIRED: one or more claims with their new value(s).
+    pub claims: Map<String, Value>,
+    /// Claims common to every CAEP event.
+    #[serde(flatten)]
+    pub metadata: CaepMetadata,
+}
+
+/// Credential Change (CAEP 1.0 §3.3): a credential was created, changed, revoked or deleted.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CredentialChange {
+    /// REQUIRED: the kind of credential that changed.
+    pub credential_type: CredentialType,
+    /// REQUIRED: what happened to it.
+    pub change_type: ChangeType,
+    /// OPTIONAL: credential friendly name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub friendly_name: Option<String>,
+    /// OPTIONAL: issuer of the X.509 certificate (RFC 5280).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub x509_issuer: Option<String>,
+    /// OPTIONAL: serial number of the X.509 certificate (RFC 5280).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub x509_serial: Option<String>,
+    /// OPTIONAL: FIDO2 Authenticator Attestation GUID (WebAuthn).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fido2_aaguid: Option<String>,
+    /// Claims common to every CAEP event.
+    #[serde(flatten)]
+    pub metadata: CaepMetadata,
+}
+
+/// Assurance Level Change (CAEP 1.0 §3.4): the authentication method changed since login.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AssuranceLevelChange {
+    /// REQUIRED: the current NIST AAL.
+    pub current_level: AssuranceLevel,
+    /// REQUIRED: the previous NIST AAL.
+    pub previous_level: AssuranceLevel,
+    /// REQUIRED: whether the level increased or decreased.
+    pub change_direction: ChangeDirection,
+    /// Claims common to every CAEP event.
+    #[serde(flatten)]
+    pub metadata: CaepMetadata,
+}
+
+/// Device Compliance Change (CAEP 1.0 §3.5): a device's compliance status changed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DeviceComplianceChange {
+    /// REQUIRED: the compliance status prior to the change.
+    pub previous_status: ComplianceStatus,
+    /// REQUIRED: the status that triggered the event.
+    pub current_status: ComplianceStatus,
+    /// Claims common to every CAEP event.
+    #[serde(flatten)]
+    pub metadata: CaepMetadata,
+}
+
+/// One decoded entry of a SET's `events` claim.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum CaepEvent {
+    /// [`EVENT_TYPE_SESSION_REVOKED`].
+    SessionRevoked(SessionRevoked),
+    /// [`EVENT_TYPE_TOKEN_CLAIMS_CHANGE`].
+    TokenClaimsChange(TokenClaimsChange),
+    /// [`EVENT_TYPE_CREDENTIAL_CHANGE`].
+    CredentialChange(CredentialChange),
+    /// [`EVENT_TYPE_ASSURANCE_LEVEL_CHANGE`].
+    AssuranceLevelChange(AssuranceLevelChange),
+    /// [`EVENT_TYPE_DEVICE_COMPLIANCE_CHANGE`].
+    DeviceComplianceChange(DeviceComplianceChange),
+    /// An event type this crate does not model — another CAEP revision, a RISC event, a SCIM
+    /// event, or a vendor extension.
+    ///
+    /// Preserved rather than dropped: RFC 8417 §2.2 lets any URI name an event, receivers are
+    /// free to ignore events they do not care about (RFC 8935 §3), and a SET that mixes one
+    /// known event with one unknown one must still deliver the known one. A handler that
+    /// understands the URI can parse `payload` itself.
+    Unknown {
+        /// The event type URI, exactly as it appeared in the `events` claim.
+        uri: String,
+        /// The untouched event payload.
+        payload: Value,
+    },
+}
+
+impl CaepEvent {
+    /// Decodes one `events` entry.
+    ///
+    /// Returns `Err` only when `uri` names an event type this crate models *and* the payload
+    /// does not match its definition; an unrecognised `uri` yields [`CaepEvent::Unknown`].
+    pub fn decode(uri: &str, payload: &Value) -> Result<Self, EventDecodeError> {
+        fn parse<T: serde::de::DeserializeOwned>(
+            uri: &str,
+            payload: &Value,
+        ) -> Result<T, EventDecodeError> {
+            serde_json::from_value(payload.clone())
+                .map_err(|err| EventDecodeError::new(uri, err.to_string()))
+        }
+
+        let event = match uri {
+            EVENT_TYPE_SESSION_REVOKED => CaepEvent::SessionRevoked(parse(uri, payload)?),
+            EVENT_TYPE_TOKEN_CLAIMS_CHANGE => CaepEvent::TokenClaimsChange(parse(uri, payload)?),
+            EVENT_TYPE_CREDENTIAL_CHANGE => CaepEvent::CredentialChange(parse(uri, payload)?),
+            EVENT_TYPE_ASSURANCE_LEVEL_CHANGE => {
+                CaepEvent::AssuranceLevelChange(parse(uri, payload)?)
+            }
+            EVENT_TYPE_DEVICE_COMPLIANCE_CHANGE => {
+                CaepEvent::DeviceComplianceChange(parse(uri, payload)?)
+            }
+            other => {
+                tracing::debug!(
+                    target: "authkestra_ssf",
+                    event_type = %other,
+                    "event type is not modelled by authkestra-ssf; preserving payload verbatim"
+                );
+                CaepEvent::Unknown {
+                    uri: other.to_string(),
+                    payload: payload.clone(),
+                }
+            }
+        };
+        Ok(event)
+    }
+
+    /// The event type URI this event was decoded from.
+    pub fn event_type_uri(&self) -> &str {
+        match self {
+            CaepEvent::SessionRevoked(_) => EVENT_TYPE_SESSION_REVOKED,
+            CaepEvent::TokenClaimsChange(_) => EVENT_TYPE_TOKEN_CLAIMS_CHANGE,
+            CaepEvent::CredentialChange(_) => EVENT_TYPE_CREDENTIAL_CHANGE,
+            CaepEvent::AssuranceLevelChange(_) => EVENT_TYPE_ASSURANCE_LEVEL_CHANGE,
+            CaepEvent::DeviceComplianceChange(_) => EVENT_TYPE_DEVICE_COMPLIANCE_CHANGE,
+            CaepEvent::Unknown { uri, .. } => uri,
+        }
+    }
+
+    /// The CAEP 1.0 §2 common claims, or `None` for [`CaepEvent::Unknown`] — an unmodelled event
+    /// type is not guaranteed to be a CAEP event at all, so its payload is not interpreted.
+    pub fn metadata(&self) -> Option<&CaepMetadata> {
+        match self {
+            CaepEvent::SessionRevoked(event) => Some(&event.metadata),
+            CaepEvent::TokenClaimsChange(event) => Some(&event.metadata),
+            CaepEvent::CredentialChange(event) => Some(&event.metadata),
+            CaepEvent::AssuranceLevelChange(event) => Some(&event.metadata),
+            CaepEvent::DeviceComplianceChange(event) => Some(&event.metadata),
+            CaepEvent::Unknown { .. } => None,
+        }
+    }
+
+    /// The event's own subject, when it carries one (CAEP 1.0 §3 examples).
+    pub fn subject(&self) -> Option<&SubjectIdentifier> {
+        self.metadata().and_then(|m| m.subject.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn decodes_session_revoked_with_common_claims() {
+        let payload = json!({
+            "subject": { "format": "opaque", "id": "dMTlD|1600802906" },
+            "initiating_entity": "policy",
+            "event_timestamp": 1615304991,
+            "reason_admin": { "en": "Landspeed Policy Violation: C076E82F" },
+            "reason_user": { "en": "Access attempt from multiple regions." }
+        });
+        let event = CaepEvent::decode(EVENT_TYPE_SESSION_REVOKED, &payload).unwrap();
+        let CaepEvent::SessionRevoked(revoked) = &event else {
+            panic!("expected SessionRevoked, got {event:?}");
+        };
+        assert_eq!(revoked.metadata.event_timestamp, Some(1615304991));
+        assert_eq!(
+            revoked.metadata.initiating_entity,
+            Some(InitiatingEntity::Policy)
+        );
+        assert_eq!(
+            revoked.metadata.reason_admin.as_ref().unwrap()["en"],
+            "Landspeed Policy Violation: C076E82F"
+        );
+        assert_eq!(
+            revoked.metadata.reason_user.as_ref().unwrap()["en"],
+            "Access attempt from multiple regions."
+        );
+        assert_eq!(
+            event.subject(),
+            Some(&SubjectIdentifier::Opaque {
+                id: "dMTlD|1600802906".into()
+            })
+        );
+        assert_eq!(event.event_type_uri(), EVENT_TYPE_SESSION_REVOKED);
+    }
+
+    #[test]
+    fn decodes_session_revoked_with_empty_payload() {
+        let event = CaepEvent::decode(EVENT_TYPE_SESSION_REVOKED, &json!({})).unwrap();
+        assert_eq!(event, CaepEvent::SessionRevoked(SessionRevoked::default()));
+        assert_eq!(event.subject(), None);
+        assert_eq!(event.metadata(), Some(&CaepMetadata::default()));
+    }
+
+    #[test]
+    fn decodes_token_claims_change() {
+        let payload = json!({
+            "subject": { "format": "iss_sub", "iss": "https://idp.example.com/", "sub": "42" },
+            "claims": { "role": "ro-admin" },
+            "event_timestamp": 1615304991
+        });
+        let event = CaepEvent::decode(EVENT_TYPE_TOKEN_CLAIMS_CHANGE, &payload).unwrap();
+        let CaepEvent::TokenClaimsChange(change) = &event else {
+            panic!("expected TokenClaimsChange, got {event:?}");
+        };
+        assert_eq!(change.claims["role"], "ro-admin");
+        assert_eq!(change.metadata.event_timestamp, Some(1615304991));
+        assert_eq!(event.event_type_uri(), EVENT_TYPE_TOKEN_CLAIMS_CHANGE);
+        assert!(event.metadata().is_some());
+        assert!(event.subject().is_some());
+    }
+
+    #[test]
+    fn token_claims_change_requires_claims() {
+        let err = CaepEvent::decode(EVENT_TYPE_TOKEN_CLAIMS_CHANGE, &json!({})).unwrap_err();
+        assert_eq!(err.uri(), EVENT_TYPE_TOKEN_CLAIMS_CHANGE);
+        assert!(err.message().contains("claims"), "{err}");
+        assert!(err.to_string().contains("does not conform"), "{err}");
+    }
+
+    #[test]
+    fn decodes_credential_change() {
+        let payload = json!({
+            "credential_type": "fido2-roaming",
+            "change_type": "create",
+            "friendly_name": "Corp Issued YubiKey",
+            "fido2_aaguid": "accced6c-f6ec-45dd-9c9c-19e5b2b6d9c1",
+            "x509_issuer": "CN=Example CA",
+            "x509_serial": "123456",
+            "initiating_entity": "admin"
+        });
+        let event = CaepEvent::decode(EVENT_TYPE_CREDENTIAL_CHANGE, &payload).unwrap();
+        let CaepEvent::CredentialChange(change) = &event else {
+            panic!("expected CredentialChange, got {event:?}");
+        };
+        assert_eq!(change.credential_type, CredentialType::Fido2Roaming);
+        assert_eq!(change.change_type, ChangeType::Create);
+        assert_eq!(change.friendly_name.as_deref(), Some("Corp Issued YubiKey"));
+        assert_eq!(change.x509_issuer.as_deref(), Some("CN=Example CA"));
+        assert_eq!(change.x509_serial.as_deref(), Some("123456"));
+        assert_eq!(
+            change.fido2_aaguid.as_deref(),
+            Some("accced6c-f6ec-45dd-9c9c-19e5b2b6d9c1")
+        );
+        assert_eq!(
+            change.metadata.initiating_entity,
+            Some(InitiatingEntity::Admin)
+        );
+        assert_eq!(event.event_type_uri(), EVENT_TYPE_CREDENTIAL_CHANGE);
+        assert!(event.metadata().is_some());
+    }
+
+    #[test]
+    fn credential_change_requires_type_and_change() {
+        let err = CaepEvent::decode(
+            EVENT_TYPE_CREDENTIAL_CHANGE,
+            &json!({ "credential_type": "password" }),
+        )
+        .unwrap_err();
+        assert!(err.message().contains("change_type"), "{err}");
+    }
+
+    #[test]
+    fn decodes_assurance_level_change() {
+        let payload = json!({
+            "current_level": "nist-aal1",
+            "previous_level": "nist-aal2",
+            "change_direction": "decrease",
+            "initiating_entity": "system"
+        });
+        let event = CaepEvent::decode(EVENT_TYPE_ASSURANCE_LEVEL_CHANGE, &payload).unwrap();
+        let CaepEvent::AssuranceLevelChange(change) = &event else {
+            panic!("expected AssuranceLevelChange, got {event:?}");
+        };
+        assert_eq!(change.current_level, AssuranceLevel::Aal1);
+        assert_eq!(change.previous_level, AssuranceLevel::Aal2);
+        assert_eq!(change.change_direction, ChangeDirection::Decrease);
+        assert_eq!(event.event_type_uri(), EVENT_TYPE_ASSURANCE_LEVEL_CHANGE);
+        assert!(event.metadata().is_some());
+    }
+
+    #[test]
+    fn assurance_level_change_requires_all_three_claims() {
+        let err = CaepEvent::decode(
+            EVENT_TYPE_ASSURANCE_LEVEL_CHANGE,
+            &json!({ "current_level": "nist-aal1", "previous_level": "nist-aal2" }),
+        )
+        .unwrap_err();
+        assert!(err.message().contains("change_direction"), "{err}");
+    }
+
+    #[test]
+    fn decodes_device_compliance_change() {
+        let payload = json!({
+            "previous_status": "compliant",
+            "current_status": "not-compliant",
+            "reason_admin": { "en": "Location outside of the corporate network" }
+        });
+        let event = CaepEvent::decode(EVENT_TYPE_DEVICE_COMPLIANCE_CHANGE, &payload).unwrap();
+        let CaepEvent::DeviceComplianceChange(change) = &event else {
+            panic!("expected DeviceComplianceChange, got {event:?}");
+        };
+        assert_eq!(change.previous_status, ComplianceStatus::Compliant);
+        assert_eq!(change.current_status, ComplianceStatus::NotCompliant);
+        assert_eq!(event.event_type_uri(), EVENT_TYPE_DEVICE_COMPLIANCE_CHANGE);
+        assert!(event.metadata().is_some());
+    }
+
+    #[test]
+    fn device_compliance_change_requires_both_statuses() {
+        let err = CaepEvent::decode(
+            EVENT_TYPE_DEVICE_COMPLIANCE_CHANGE,
+            &json!({ "current_status": "compliant" }),
+        )
+        .unwrap_err();
+        assert!(err.message().contains("previous_status"), "{err}");
+    }
+
+    #[test]
+    fn preserves_unknown_event_type() {
+        let uri = "https://schemas.openid.net/secevent/risc/event-type/account-disabled";
+        let payload = json!({ "reason": "hijacking" });
+        let event = CaepEvent::decode(uri, &payload).unwrap();
+        assert_eq!(
+            event,
+            CaepEvent::Unknown {
+                uri: uri.to_string(),
+                payload: payload.clone(),
+            }
+        );
+        assert_eq!(event.event_type_uri(), uri);
+        assert_eq!(event.metadata(), None);
+        assert_eq!(event.subject(), None);
+    }
+
+    #[test]
+    fn preserves_unmodelled_members_of_a_known_event() {
+        let payload = json!({ "vendor_extension": { "tenant": "acme" } });
+        let event = CaepEvent::decode(EVENT_TYPE_SESSION_REVOKED, &payload).unwrap();
+        let metadata = event.metadata().expect("session-revoked has metadata");
+        assert_eq!(metadata.additional["vendor_extension"]["tenant"], "acme");
+    }
+
+    #[test]
+    fn all_event_type_uris_share_the_documented_prefix() {
+        for uri in [
+            EVENT_TYPE_SESSION_REVOKED,
+            EVENT_TYPE_TOKEN_CLAIMS_CHANGE,
+            EVENT_TYPE_CREDENTIAL_CHANGE,
+            EVENT_TYPE_ASSURANCE_LEVEL_CHANGE,
+            EVENT_TYPE_DEVICE_COMPLIANCE_CHANGE,
+        ] {
+            assert!(
+                uri.starts_with(CAEP_EVENT_TYPE_PREFIX),
+                "{uri} does not start with {CAEP_EVENT_TYPE_PREFIX}"
+            );
+        }
+    }
+
+    #[test]
+    fn string_enums_preserve_unknown_values() {
+        assert_eq!(
+            InitiatingEntity::from("robot"),
+            InitiatingEntity::Other("robot".into())
+        );
+        assert_eq!(InitiatingEntity::Other("robot".into()).as_str(), "robot");
+        assert_eq!(InitiatingEntity::User.to_string(), "user");
+
+        let credential: CredentialType =
+            serde_json::from_value(json!("smartcard-ng")).expect("unknown types are preserved");
+        assert_eq!(credential, CredentialType::Other("smartcard-ng".into()));
+        assert_eq!(
+            serde_json::to_value(&credential).unwrap(),
+            json!("smartcard-ng")
+        );
+    }
+
+    #[test]
+    fn string_enums_round_trip_every_defined_value() {
+        let cases: Vec<(Value, String)> = vec![
+            (json!("admin"), InitiatingEntity::Admin.as_str().into()),
+            (json!("user"), InitiatingEntity::User.as_str().into()),
+            (json!("policy"), InitiatingEntity::Policy.as_str().into()),
+            (json!("system"), InitiatingEntity::System.as_str().into()),
+        ];
+        for (wire, expected) in cases {
+            let parsed: InitiatingEntity = serde_json::from_value(wire.clone()).unwrap();
+            assert_eq!(parsed.as_str(), expected);
+            assert_eq!(serde_json::to_value(&parsed).unwrap(), wire);
+        }
+
+        for wire in [
+            "password",
+            "pin",
+            "x509",
+            "fido2-platform",
+            "fido2-roaming",
+            "fido-u2f",
+            "verifiable-credential",
+            "phone-voice",
+            "phone-sms",
+            "app",
+        ] {
+            let parsed = CredentialType::from(wire);
+            assert!(!matches!(parsed, CredentialType::Other(_)), "{wire}");
+            assert_eq!(parsed.as_str(), wire);
+        }
+
+        for wire in ["create", "revoke", "update", "delete"] {
+            assert_eq!(ChangeType::from(wire).as_str(), wire);
+            assert!(!matches!(ChangeType::from(wire), ChangeType::Other(_)));
+        }
+        for wire in ["nist-aal1", "nist-aal2", "nist-aal3"] {
+            assert!(!matches!(
+                AssuranceLevel::from(wire),
+                AssuranceLevel::Other(_)
+            ));
+            assert_eq!(AssuranceLevel::from(wire).as_str(), wire);
+        }
+        for wire in ["increase", "decrease"] {
+            assert!(!matches!(
+                ChangeDirection::from(wire),
+                ChangeDirection::Other(_)
+            ));
+            assert_eq!(ChangeDirection::from(wire).as_str(), wire);
+        }
+        for wire in ["compliant", "not-compliant"] {
+            assert!(!matches!(
+                ComplianceStatus::from(wire),
+                ComplianceStatus::Other(_)
+            ));
+            assert_eq!(ComplianceStatus::from(wire).as_str(), wire);
+        }
+    }
+
+    #[test]
+    fn known_events_serialize_back_to_their_wire_shape() {
+        let payload = json!({
+            "credential_type": "password",
+            "change_type": "update",
+            "event_timestamp": 1615304991
+        });
+        let event = CaepEvent::decode(EVENT_TYPE_CREDENTIAL_CHANGE, &payload).unwrap();
+        let CaepEvent::CredentialChange(change) = event else {
+            panic!("expected CredentialChange");
+        };
+        assert_eq!(serde_json::to_value(&change).unwrap(), payload);
+    }
+
+    #[test]
+    fn event_decode_error_accessors() {
+        let err = EventDecodeError::new("uri", "message");
+        assert_eq!(err.uri(), "uri");
+        assert_eq!(err.message(), "message");
+    }
+}

--- a/crates/authkestra-ssf/src/error.rs
+++ b/crates/authkestra-ssf/src/error.rs
@@ -102,7 +102,13 @@ pub enum SetError {
     InvalidClaims(String),
 
     /// `iss` does not equal the issuer this verifier was configured for.
-    #[error("invalid issuer: expected {expected:?}, got {found:?}")]
+    ///
+    /// The `Display` text deliberately names neither value. It reaches an unauthenticated caller
+    /// through the RFC 8935 §2.3 `description` member — the push endpoint has no authentication
+    /// of its own — so echoing the configured issuer back would let anyone POST a bogus SET and
+    /// enumerate the deployment's trust configuration. Both values are still carried in the
+    /// struct, and [`crate::SetVerifier`] logs them as structured fields on rejection.
+    #[error("invalid issuer")]
     IssuerMismatch {
         /// The issuer the verifier was configured with.
         expected: String,
@@ -111,14 +117,20 @@ pub enum SetError {
     },
 
     /// The verifier expects an audience but the SET has no `aud` claim.
-    #[error("missing aud claim: this receiver requires one of {expected:?}")]
+    ///
+    /// As with [`SetError::IssuerMismatch`], the expected values are kept out of the `Display`
+    /// text because it is returned to an unauthenticated caller.
+    #[error("missing aud claim")]
     MissingAudience {
         /// The audience values that would have been accepted.
         expected: Vec<String>,
     },
 
     /// The SET's `aud` does not include any audience this verifier accepts.
-    #[error("invalid audience: none of {expected:?} present in the SET's aud")]
+    ///
+    /// As with [`SetError::IssuerMismatch`], the expected values are kept out of the `Display`
+    /// text because it is returned to an unauthenticated caller.
+    #[error("audience mismatch")]
     AudienceMismatch {
         /// The audience values that would have been accepted.
         expected: Vec<String>,

--- a/crates/authkestra-ssf/src/error.rs
+++ b/crates/authkestra-ssf/src/error.rs
@@ -139,7 +139,12 @@ pub enum SetError {
     /// `iat` is further in the future than the configured leeway allows. A SET describes
     /// something that has *already happened* (RFC 8417 §2.2), so an `iat` in the future is
     /// either clock skew — hence the leeway — or a forgery attempt.
-    #[error("iat {iat} is {} seconds in the future, beyond the configured leeway of {leeway}s", iat - now)]
+    ///
+    /// As with [`SetError::IssuerMismatch`], the `Display` text names no numbers: it reaches an
+    /// unauthenticated caller through the RFC 8935 §2.3 `description`, and the configured leeway
+    /// is deployment policy rather than something a transmitter needs to be told. All three
+    /// values stay in the struct and are logged as structured fields on rejection.
+    #[error("iat is too far in the future")]
     IatInFuture {
         /// The `iat` the SET carried.
         iat: i64,
@@ -150,7 +155,10 @@ pub enum SetError {
     },
 
     /// `iat` is older than the configured maximum age.
-    #[error("SET is {} seconds old, exceeding the configured maximum age of {max_age}s", now - iat)]
+    ///
+    /// As with [`SetError::IatInFuture`], the configured maximum age is kept out of the `Display`
+    /// text because it is returned to an unauthenticated caller.
+    #[error("SET is too old")]
     TooOld {
         /// The `iat` the SET carried.
         iat: i64,
@@ -347,19 +355,40 @@ mod tests {
     }
 
     #[test]
-    fn arithmetic_in_display_messages_is_correct() {
+    fn freshness_errors_keep_their_values_but_never_display_them() {
+        // The numbers are exactly what an operator needs and what an unauthenticated caller must
+        // not be handed: `leeway` and `max_age` are deployment policy. They live in the variant
+        // (and in the verifier's structured tracing fields), never in `Display`.
         let err = SetError::IatInFuture {
             iat: 130,
             now: 100,
             leeway: 5,
         };
-        assert!(err.to_string().contains("30 seconds in the future"));
+        match &err {
+            SetError::IatInFuture { iat, now, leeway } => {
+                assert_eq!((*iat, *now, *leeway), (130, 100, 5));
+            }
+            other => panic!("unexpected variant {other:?}"),
+        }
+        let message = err.to_string();
+        for leaked in ["130", "100", "5"] {
+            assert!(!message.contains(leaked), "{message} leaked {leaked}");
+        }
 
         let err = SetError::TooOld {
             iat: 100,
             now: 400,
             max_age: 60,
         };
-        assert!(err.to_string().contains("300 seconds old"));
+        match &err {
+            SetError::TooOld { iat, now, max_age } => {
+                assert_eq!((*iat, *now, *max_age), (100, 400, 60));
+            }
+            other => panic!("unexpected variant {other:?}"),
+        }
+        let message = err.to_string();
+        for leaked in ["100", "400", "60"] {
+            assert!(!message.contains(leaked), "{message} leaked {leaked}");
+        }
     }
 }

--- a/crates/authkestra-ssf/src/error.rs
+++ b/crates/authkestra-ssf/src/error.rs
@@ -1,0 +1,342 @@
+//! Rejection reasons for SET ingestion, and their mapping onto the registered
+//! [RFC 8935 §2.4](https://www.rfc-editor.org/rfc/rfc8935#section-2.4) error codes.
+//!
+//! Every variant of [`SetError`] carries a *distinct* reason a SET was refused, so a caller — or
+//! a conformance test — can assert on which check failed rather than just "it failed". The
+//! coarse-grained [`SetErrorCode`] is what goes on the wire; the fine-grained variant is what
+//! goes in the logs.
+
+use thiserror::Error;
+
+use crate::caep::EventDecodeError;
+use crate::keys::KeyResolveError;
+
+/// The registered Security Event Token Error Codes from the IANA registry established by
+/// [RFC 8935 §7.1](https://www.rfc-editor.org/rfc/rfc8935#section-7.1), with the initial set
+/// defined in [§2.4](https://www.rfc-editor.org/rfc/rfc8935#section-2.4).
+///
+/// The registry is extensible, but this enum deliberately is not: emitting an unregistered code
+/// would leave a SET Transmitter with a value it has no way to interpret, which is strictly
+/// worse than reusing the closest registered one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SetErrorCode {
+    /// The request body cannot be parsed as a SET, or an Event Payload within the SET does not
+    /// conform to the event's definition.
+    InvalidRequest,
+    /// A key used to sign the SET is invalid or otherwise unacceptable to the recipient
+    /// (unknown `kid`, unusable key material, disallowed algorithm).
+    InvalidKey,
+    /// The SET Issuer is invalid for this recipient.
+    InvalidIssuer,
+    /// The SET Audience does not correspond to this recipient.
+    InvalidAudience,
+    /// The recipient could not authenticate the SET Transmitter — in practice, the signature
+    /// did not verify under the resolved key.
+    AuthenticationFailed,
+    /// The SET Transmitter is not authorized to transmit this SET to this recipient.
+    AccessDenied,
+}
+
+impl SetErrorCode {
+    /// The registered wire string (e.g. `"invalid_request"`), which is what goes in the `err`
+    /// member of an RFC 8935 §2.3 failure response body.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SetErrorCode::InvalidRequest => "invalid_request",
+            SetErrorCode::InvalidKey => "invalid_key",
+            SetErrorCode::InvalidIssuer => "invalid_issuer",
+            SetErrorCode::InvalidAudience => "invalid_audience",
+            SetErrorCode::AuthenticationFailed => "authentication_failed",
+            SetErrorCode::AccessDenied => "access_denied",
+        }
+    }
+}
+
+impl std::fmt::Display for SetErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Why a SET was refused by [`crate::SetVerifier`].
+///
+/// Never carries the token, the signature, or any key material — only enough to log, alert on,
+/// or return in an RFC 8935 §2.3 `description`.
+#[derive(Debug, Error, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum SetError {
+    /// The body is not a syntactically valid compact JWS, or its header is not JSON.
+    #[error("malformed SET: {0}")]
+    Malformed(String),
+
+    /// The JOSE header has no `typ`.
+    ///
+    /// RFC 8417 §2.3 only says `typ` "MUST be included if the SET could be used in an
+    /// application context in which it could be confused with other kinds of JWTs" — and
+    /// §4.1/§4.2 spend two sections on exactly how a SET gets confused with an ID Token or an
+    /// access token. A general-purpose receiver *is* such a context, so this crate requires it.
+    #[error("missing typ header: RFC 8417 §2.3 explicit typing is required by this receiver")]
+    MissingType,
+
+    /// The JOSE header's `typ` is present but is not `secevent+jwt`.
+    #[error("unexpected typ header {0:?}: expected \"secevent+jwt\" (RFC 8417 §2.3)")]
+    UnexpectedType(String),
+
+    /// `alg` is `none`, is not a JWS algorithm this build understands, or is not in the
+    /// verifier's configured allow-list.
+    #[error("disallowed alg: {0}")]
+    DisallowedAlgorithm(String),
+
+    /// No usable key could be resolved for the token's `kid`.
+    #[error("key resolution failed: {0}")]
+    KeyResolution(#[from] KeyResolveError),
+
+    /// The signature did not verify under the resolved key, or the key is unusable for the
+    /// header's algorithm.
+    #[error("signature verification failed: {0}")]
+    InvalidSignature(String),
+
+    /// The payload is not a JSON object with the claims RFC 8417 §2.2 requires (`iss`, `iat`,
+    /// `jti`, `events`), or one of them has the wrong JSON type.
+    #[error("invalid SET claims: {0}")]
+    InvalidClaims(String),
+
+    /// `iss` does not equal the issuer this verifier was configured for.
+    #[error("invalid issuer: expected {expected:?}, got {found:?}")]
+    IssuerMismatch {
+        /// The issuer the verifier was configured with.
+        expected: String,
+        /// The issuer the SET actually carried.
+        found: String,
+    },
+
+    /// The verifier expects an audience but the SET has no `aud` claim.
+    #[error("missing aud claim: this receiver requires one of {expected:?}")]
+    MissingAudience {
+        /// The audience values that would have been accepted.
+        expected: Vec<String>,
+    },
+
+    /// The SET's `aud` does not include any audience this verifier accepts.
+    #[error("invalid audience: none of {expected:?} present in the SET's aud")]
+    AudienceMismatch {
+        /// The audience values that would have been accepted.
+        expected: Vec<String>,
+    },
+
+    /// `iat` is further in the future than the configured leeway allows. A SET describes
+    /// something that has *already happened* (RFC 8417 §2.2), so an `iat` in the future is
+    /// either clock skew — hence the leeway — or a forgery attempt.
+    #[error("iat {iat} is {} seconds in the future, beyond the configured leeway of {leeway}s", iat - now)]
+    IatInFuture {
+        /// The `iat` the SET carried.
+        iat: i64,
+        /// The time verification was performed at.
+        now: i64,
+        /// The configured tolerance, in seconds.
+        leeway: i64,
+    },
+
+    /// `iat` is older than the configured maximum age.
+    #[error("SET is {} seconds old, exceeding the configured maximum age of {max_age}s", now - iat)]
+    TooOld {
+        /// The `iat` the SET carried.
+        iat: i64,
+        /// The time verification was performed at.
+        now: i64,
+        /// The configured maximum age, in seconds.
+        max_age: i64,
+    },
+
+    /// `exp` is in the past.
+    ///
+    /// RFC 8417 §2.2 says use of `exp` in a SET is NOT RECOMMENDED, so this is never *required*
+    /// to be present — but an issuer that went out of its way to say "do not accept this after
+    /// T" is not to be second-guessed, so it is honoured when it is there.
+    #[error("SET expired at {exp} (now {now})")]
+    Expired {
+        /// The `exp` the SET carried.
+        exp: i64,
+        /// The time verification was performed at.
+        now: i64,
+    },
+
+    /// The `events` claim is present but empty. RFC 8417 §2.2 defines `events` as "a set of
+    /// event statements"; a SET conveying none of them describes nothing and cannot be acted on.
+    #[error("empty events claim: a SET must convey at least one event (RFC 8417 §2.2)")]
+    EmptyEvents,
+
+    /// An event payload does not conform to its event type's definition.
+    #[error("{0}")]
+    EventPayload(#[from] EventDecodeError),
+
+    /// This `(iss, jti)` pair has already been ingested.
+    ///
+    /// Note that the RFC 8935 push receiver never turns this into a failure response — see
+    /// [`crate::PushReceiver::receive`] for why RFC 8935 §2 mandates a 202 on retransmission.
+    /// The variant exists so that a caller driving [`crate::SetVerifier`] directly can tell
+    /// "already seen" apart from "accepted", and so replays are visible in logs and metrics.
+    #[error("replayed SET: jti {jti:?} from issuer {iss:?} was already ingested")]
+    Replay {
+        /// The `jti` that had already been recorded.
+        jti: String,
+        /// The issuer the `jti` is scoped to.
+        iss: String,
+    },
+}
+
+impl SetError {
+    /// The RFC 8935 §2.4 error code this rejection maps onto.
+    ///
+    /// The mapping is many-to-one on purpose: the registry has six codes and this crate
+    /// distinguishes far more failure modes than that, because collapsing them at the point of
+    /// detection would make the logs useless. Only the wire response is coarse.
+    pub fn code(&self) -> SetErrorCode {
+        match self {
+            SetError::Malformed(_)
+            | SetError::MissingType
+            | SetError::UnexpectedType(_)
+            | SetError::InvalidClaims(_)
+            | SetError::IatInFuture { .. }
+            | SetError::TooOld { .. }
+            | SetError::Expired { .. }
+            | SetError::EmptyEvents
+            | SetError::EventPayload(_) => SetErrorCode::InvalidRequest,
+            SetError::DisallowedAlgorithm(_) | SetError::KeyResolution(_) => {
+                SetErrorCode::InvalidKey
+            }
+            SetError::InvalidSignature(_) => SetErrorCode::AuthenticationFailed,
+            SetError::IssuerMismatch { .. } => SetErrorCode::InvalidIssuer,
+            SetError::MissingAudience { .. } | SetError::AudienceMismatch { .. } => {
+                SetErrorCode::InvalidAudience
+            }
+            // Unreachable through `PushReceiver` (a replay answers 202), but a direct caller
+            // that chooses to surface it needs *some* registered code; "the transmitter may not
+            // send this SET to this recipient" is the closest fit.
+            SetError::Replay { .. } => SetErrorCode::AccessDenied,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_codes_have_registered_wire_strings() {
+        assert_eq!(SetErrorCode::InvalidRequest.as_str(), "invalid_request");
+        assert_eq!(SetErrorCode::InvalidKey.as_str(), "invalid_key");
+        assert_eq!(SetErrorCode::InvalidIssuer.as_str(), "invalid_issuer");
+        assert_eq!(SetErrorCode::InvalidAudience.as_str(), "invalid_audience");
+        assert_eq!(
+            SetErrorCode::AuthenticationFailed.as_str(),
+            "authentication_failed"
+        );
+        assert_eq!(SetErrorCode::AccessDenied.as_str(), "access_denied");
+        assert_eq!(SetErrorCode::AccessDenied.to_string(), "access_denied");
+    }
+
+    #[test]
+    fn every_variant_maps_to_a_code() {
+        let cases: Vec<(SetError, SetErrorCode)> = vec![
+            (
+                SetError::Malformed("x".into()),
+                SetErrorCode::InvalidRequest,
+            ),
+            (SetError::MissingType, SetErrorCode::InvalidRequest),
+            (
+                SetError::UnexpectedType("JWT".into()),
+                SetErrorCode::InvalidRequest,
+            ),
+            (
+                SetError::DisallowedAlgorithm("none".into()),
+                SetErrorCode::InvalidKey,
+            ),
+            (
+                SetError::KeyResolution(KeyResolveError::UnknownKid(Some("k".into()))),
+                SetErrorCode::InvalidKey,
+            ),
+            (
+                SetError::InvalidSignature("bad".into()),
+                SetErrorCode::AuthenticationFailed,
+            ),
+            (
+                SetError::InvalidClaims("no iss".into()),
+                SetErrorCode::InvalidRequest,
+            ),
+            (
+                SetError::IssuerMismatch {
+                    expected: "a".into(),
+                    found: "b".into(),
+                },
+                SetErrorCode::InvalidIssuer,
+            ),
+            (
+                SetError::MissingAudience {
+                    expected: vec!["a".into()],
+                },
+                SetErrorCode::InvalidAudience,
+            ),
+            (
+                SetError::AudienceMismatch {
+                    expected: vec!["a".into()],
+                },
+                SetErrorCode::InvalidAudience,
+            ),
+            (
+                SetError::IatInFuture {
+                    iat: 10,
+                    now: 0,
+                    leeway: 1,
+                },
+                SetErrorCode::InvalidRequest,
+            ),
+            (
+                SetError::TooOld {
+                    iat: 0,
+                    now: 10,
+                    max_age: 1,
+                },
+                SetErrorCode::InvalidRequest,
+            ),
+            (
+                SetError::Expired { exp: 0, now: 10 },
+                SetErrorCode::InvalidRequest,
+            ),
+            (SetError::EmptyEvents, SetErrorCode::InvalidRequest),
+            (
+                SetError::EventPayload(EventDecodeError::new("uri", "boom")),
+                SetErrorCode::InvalidRequest,
+            ),
+            (
+                SetError::Replay {
+                    jti: "j".into(),
+                    iss: "i".into(),
+                },
+                SetErrorCode::AccessDenied,
+            ),
+        ];
+
+        for (err, expected) in cases {
+            assert_eq!(err.code(), expected, "wrong code for {err:?}");
+            assert!(!err.to_string().is_empty(), "empty Display for {err:?}");
+        }
+    }
+
+    #[test]
+    fn arithmetic_in_display_messages_is_correct() {
+        let err = SetError::IatInFuture {
+            iat: 130,
+            now: 100,
+            leeway: 5,
+        };
+        assert!(err.to_string().contains("30 seconds in the future"));
+
+        let err = SetError::TooOld {
+            iat: 100,
+            now: 400,
+            max_age: 60,
+        };
+        assert!(err.to_string().contains("300 seconds old"));
+    }
+}

--- a/crates/authkestra-ssf/src/error.rs
+++ b/crates/authkestra-ssf/src/error.rs
@@ -161,6 +161,15 @@ pub enum SetError {
         now: i64,
     },
 
+    /// The `jti` claim is present but empty (or only whitespace).
+    ///
+    /// RFC 8417 §2.2 makes `jti` "a unique identifier for the SET" that a client "MAY use to
+    /// track whether a particular SET has already been received". An empty string identifies
+    /// nothing: accepting it would collapse the replay guard to a single slot per issuer, so
+    /// the first empty-`jti` SET from an issuer would permanently suppress every subsequent one.
+    #[error("empty jti claim: a SET's jti must uniquely identify it (RFC 8417 §2.2)")]
+    EmptyJti,
+
     /// The `events` claim is present but empty. RFC 8417 §2.2 defines `events` as "a set of
     /// event statements"; a SET conveying none of them describes nothing and cannot be acted on.
     #[error("empty events claim: a SET must convey at least one event (RFC 8417 §2.2)")]
@@ -200,6 +209,7 @@ impl SetError {
             | SetError::IatInFuture { .. }
             | SetError::TooOld { .. }
             | SetError::Expired { .. }
+            | SetError::EmptyJti
             | SetError::EmptyEvents
             | SetError::EventPayload(_) => SetErrorCode::InvalidRequest,
             SetError::DisallowedAlgorithm(_) | SetError::KeyResolution(_) => {
@@ -303,6 +313,7 @@ mod tests {
                 SetError::Expired { exp: 0, now: 10 },
                 SetErrorCode::InvalidRequest,
             ),
+            (SetError::EmptyJti, SetErrorCode::InvalidRequest),
             (SetError::EmptyEvents, SetErrorCode::InvalidRequest),
             (
                 SetError::EventPayload(EventDecodeError::new("uri", "boom")),

--- a/crates/authkestra-ssf/src/keys.rs
+++ b/crates/authkestra-ssf/src/keys.rs
@@ -1,0 +1,162 @@
+//! Where the verification key comes from.
+//!
+//! RFC 8935 §2 says the mechanism for validating a SET's authenticity "is deployment specific";
+//! this crate therefore takes no position on it beyond a trait. A deployment with one long-lived
+//! transmitter key configures a single [`jsonwebtoken::DecodingKey`]; a deployment that follows
+//! the transmitter's JWKS implements [`SetKeyResolver`] over its own cache.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use jsonwebtoken::DecodingKey;
+use thiserror::Error;
+
+/// Why a verification key could not be produced for a SET.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum KeyResolveError {
+    /// No key is known for the token's `kid` (or for a token with no `kid` at all).
+    #[error("no key for kid {0:?}")]
+    UnknownKid(Option<String>),
+
+    /// The key source itself failed — a JWKS fetch timed out, a cache was unreachable, etc.
+    ///
+    /// Deliberately distinct from [`KeyResolveError::UnknownKid`] so that an outage is
+    /// distinguishable in logs from a genuinely unknown key, even though both reject the SET.
+    #[error("key source unavailable: {0}")]
+    Unavailable(String),
+}
+
+/// Resolves the key a SET's signature should be verified against.
+///
+/// `async` because the realistic implementation consults a JWKS cache that may need to refresh
+/// over the network. Implementations must never fall back to "no key means accept": returning
+/// `Err` is the only way to signal that no key could be found, and [`crate::SetVerifier`] treats
+/// every `Err` as a rejection.
+#[async_trait]
+pub trait SetKeyResolver: Send + Sync + 'static {
+    /// Resolves a key for `issuer` and the token's `kid` header (absent for tokens that carry
+    /// none).
+    ///
+    /// `issuer` is passed as well as `kid` because `kid` is only unique within one issuer's key
+    /// set; a resolver serving several transmitters needs both to avoid one transmitter's key ID
+    /// selecting another transmitter's key.
+    async fn resolve(
+        &self,
+        issuer: &str,
+        kid: Option<&str>,
+    ) -> Result<DecodingKey, KeyResolveError>;
+}
+
+/// A [`SetKeyResolver`] that returns the same key for every `kid`.
+///
+/// This is what [`crate::SetVerifierBuilder::key`] installs. It ignores `kid` entirely, which is
+/// correct for a single-key deployment and wrong the moment the transmitter rotates keys — at
+/// which point the deployment wants a JWKS-backed resolver, not a second static key.
+pub struct SingleKeyResolver {
+    key: DecodingKey,
+}
+
+impl SingleKeyResolver {
+    /// Wraps `key` so that it is returned for every resolution request.
+    pub fn new(key: DecodingKey) -> Self {
+        Self { key }
+    }
+}
+
+#[async_trait]
+impl SetKeyResolver for SingleKeyResolver {
+    async fn resolve(
+        &self,
+        _issuer: &str,
+        _kid: Option<&str>,
+    ) -> Result<DecodingKey, KeyResolveError> {
+        Ok(self.key.clone())
+    }
+}
+
+/// A [`SetKeyResolver`] backed by a fixed `kid` to key map.
+///
+/// Useful for a deployment that pins a transmitter's published keys in configuration, and for
+/// tests. A token with no `kid` is rejected rather than matched against a sole entry: guessing
+/// which key an unlabelled token meant is how algorithm/key-confusion bugs start.
+#[derive(Default)]
+pub struct StaticKeyResolver {
+    keys: HashMap<String, DecodingKey>,
+}
+
+impl StaticKeyResolver {
+    /// Creates an empty resolver.
+    pub fn new() -> Self {
+        Self {
+            keys: HashMap::new(),
+        }
+    }
+
+    /// Adds `key` under `kid`, replacing any previous entry for that `kid`.
+    pub fn with_key(mut self, kid: impl Into<String>, key: DecodingKey) -> Self {
+        self.keys.insert(kid.into(), key);
+        self
+    }
+}
+
+#[async_trait]
+impl SetKeyResolver for StaticKeyResolver {
+    async fn resolve(
+        &self,
+        _issuer: &str,
+        kid: Option<&str>,
+    ) -> Result<DecodingKey, KeyResolveError> {
+        let kid = kid.ok_or(KeyResolveError::UnknownKid(None))?;
+        self.keys
+            .get(kid)
+            .cloned()
+            .ok_or_else(|| KeyResolveError::UnknownKid(Some(kid.to_string())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn single_key_resolver_ignores_kid() {
+        let resolver = SingleKeyResolver::new(DecodingKey::from_secret(b"secret"));
+        assert!(resolver.resolve("https://iss/", None).await.is_ok());
+        assert!(resolver.resolve("https://iss/", Some("any")).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn static_key_resolver_matches_on_kid() {
+        let resolver = StaticKeyResolver::new().with_key("k1", DecodingKey::from_secret(b"secret"));
+        assert!(resolver.resolve("https://iss/", Some("k1")).await.is_ok());
+        assert_eq!(
+            resolver
+                .resolve("https://iss/", Some("k2"))
+                .await
+                .unwrap_err(),
+            KeyResolveError::UnknownKid(Some("k2".into()))
+        );
+        assert_eq!(
+            resolver.resolve("https://iss/", None).await.unwrap_err(),
+            KeyResolveError::UnknownKid(None)
+        );
+    }
+
+    #[tokio::test]
+    async fn static_key_resolver_replaces_a_duplicate_kid() {
+        let resolver = StaticKeyResolver::default()
+            .with_key("k1", DecodingKey::from_secret(b"first"))
+            .with_key("k1", DecodingKey::from_secret(b"second"));
+        assert!(resolver.resolve("https://iss/", Some("k1")).await.is_ok());
+    }
+
+    #[test]
+    fn key_resolve_errors_describe_themselves() {
+        assert!(KeyResolveError::UnknownKid(Some("k".into()))
+            .to_string()
+            .contains("k"));
+        assert!(KeyResolveError::Unavailable("timeout".into())
+            .to_string()
+            .contains("timeout"));
+    }
+}

--- a/crates/authkestra-ssf/src/lib.rs
+++ b/crates/authkestra-ssf/src/lib.rs
@@ -83,8 +83,8 @@ pub use caep::{
 pub use error::{SetError, SetErrorCode};
 pub use keys::{KeyResolveError, SetKeyResolver, SingleKeyResolver, StaticKeyResolver};
 pub use receiver::{
-    HandlerError, LoggingHandler, PushReceiver, PushResponse, SetHandler, ERROR_CONTENT_LANGUAGE,
-    ERROR_CONTENT_TYPE,
+    HandlerError, LoggingHandler, PushReceiver, PushResponse, SetHandler, DEFAULT_MAX_BODY_BYTES,
+    ERROR_CONTENT_LANGUAGE, ERROR_CONTENT_TYPE,
 };
 pub use replay::{InMemorySetReplayGuard, SetReplayGuard};
 pub use set::{Audience, SecurityEventToken, SET_MEDIA_TYPE, SET_TYP};

--- a/crates/authkestra-ssf/src/lib.rs
+++ b/crates/authkestra-ssf/src/lib.rs
@@ -89,4 +89,4 @@ pub use receiver::{
 pub use replay::{InMemorySetReplayGuard, SetReplayGuard};
 pub use set::{Audience, SecurityEventToken, SET_MEDIA_TYPE, SET_TYP};
 pub use subject::SubjectIdentifier;
-pub use verify::{SetVerifier, SetVerifierBuilder, SetVerifierError};
+pub use verify::{SetVerifier, SetVerifierBuilder, SetVerifierError, VerifiedSet};

--- a/crates/authkestra-ssf/src/lib.rs
+++ b/crates/authkestra-ssf/src/lib.rs
@@ -1,0 +1,92 @@
+//! `authkestra-ssf` — Shared Signals Framework ingestion for authkestra.
+//!
+//! An identity provider, an EDR agent, or any other cooperating service can tell this process
+//! that something about a user changed *out of band*: their session was revoked, their password
+//! was reset, their laptop fell out of compliance. The wire format for that is a **Security
+//! Event Token** ([RFC 8417](https://www.rfc-editor.org/rfc/rfc8417)) — a signed JWT whose
+//! payload is a set of events — delivered over HTTP push
+//! ([RFC 8935](https://www.rfc-editor.org/rfc/rfc8935)), with the event vocabulary defined by
+//! [OpenID CAEP 1.0](https://openid.net/specs/openid-caep-specification-1_0.html).
+//!
+//! This crate covers the *receiving* half of that picture, end to end but no further:
+//!
+//! | Capability | Status |
+//! | --- | --- |
+//! | Parse and validate a SET (RFC 8417 claim profile, explicit `typ`, signature, issuer, audience, freshness, replay) | [`SetVerifier`] |
+//! | Structured subject identifiers ([RFC 9493](https://www.rfc-editor.org/rfc/rfc9493)) | [`SubjectIdentifier`] |
+//! | Typed CAEP 1.0 events, with unknown event types preserved | [`CaepEvent`] |
+//! | RFC 8935 push delivery semantics (202 / 400 with a registered error code) | [`PushReceiver`] |
+//! | **Revoking or attenuating a live session when an event arrives** | **not implemented** |
+//! | **Middleware that rejects tokens invalidated by a CAEP event** | **not implemented** |
+//!
+//! The last two rows are the second and third acceptance criteria of
+//! [authkestra#25](https://github.com/marcjazz/authkestra/issues/25) and are follow-up work.
+//! Until they land, a [`SetHandler`] is where a deployment puts its own reaction to an event —
+//! the events themselves are fully decoded and delivered.
+//!
+//! ## Framework wiring
+//!
+//! There is none here, on purpose. Per the workspace `AGENTS.md` "Framework Agnostic" rule,
+//! [`PushReceiver::receive`] takes a content type and a byte slice and returns a
+//! [`PushResponse`] describing the status, headers and body to send; the axum and actix
+//! adapters that turn that into a route are a follow-up.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use std::time::Duration;
+//!
+//! use authkestra_ssf::{
+//!     InMemorySetReplayGuard, LoggingHandler, PushReceiver, SetVerifier,
+//! };
+//! use jsonwebtoken::{Algorithm, DecodingKey};
+//!
+//! # async fn example(transmitter_key: DecodingKey, body: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+//! let verifier = SetVerifier::builder("https://idp.example.com/")
+//!     .audience("https://sp.example.com/caep")
+//!     .algorithms([Algorithm::EdDSA])
+//!     .key(transmitter_key)
+//!     .max_age(Duration::from_secs(60 * 60))
+//!     .replay_guard(Arc::new(InMemorySetReplayGuard::new(Duration::from_secs(
+//!         60 * 60,
+//!     ))))
+//!     .build()?;
+//!
+//! let receiver = PushReceiver::new(Arc::new(verifier)).with_handler(Arc::new(LoggingHandler));
+//!
+//! let response = receiver
+//!     .receive(Some("application/secevent+jwt"), body)
+//!     .await;
+//! assert_eq!(response.status(), 202);
+//! # Ok(())
+//! # }
+//! ```
+
+mod caep;
+mod error;
+mod keys;
+mod receiver;
+mod replay;
+mod set;
+mod subject;
+mod verify;
+
+pub use caep::{
+    AssuranceLevel, AssuranceLevelChange, CaepEvent, CaepMetadata, ChangeDirection, ChangeType,
+    ComplianceStatus, CredentialChange, CredentialType, DeviceComplianceChange, EventDecodeError,
+    InitiatingEntity, LocalizedMessage, SessionRevoked, TokenClaimsChange, CAEP_EVENT_TYPE_PREFIX,
+    EVENT_TYPE_ASSURANCE_LEVEL_CHANGE, EVENT_TYPE_CREDENTIAL_CHANGE,
+    EVENT_TYPE_DEVICE_COMPLIANCE_CHANGE, EVENT_TYPE_SESSION_REVOKED,
+    EVENT_TYPE_TOKEN_CLAIMS_CHANGE,
+};
+pub use error::{SetError, SetErrorCode};
+pub use keys::{KeyResolveError, SetKeyResolver, SingleKeyResolver, StaticKeyResolver};
+pub use receiver::{
+    HandlerError, LoggingHandler, PushReceiver, PushResponse, SetHandler, ERROR_CONTENT_LANGUAGE,
+    ERROR_CONTENT_TYPE,
+};
+pub use replay::{InMemorySetReplayGuard, SetReplayGuard};
+pub use set::{Audience, SecurityEventToken, SET_MEDIA_TYPE, SET_TYP};
+pub use subject::SubjectIdentifier;
+pub use verify::{SetVerifier, SetVerifierBuilder, SetVerifierError};

--- a/crates/authkestra-ssf/src/receiver.rs
+++ b/crates/authkestra-ssf/src/receiver.rs
@@ -45,11 +45,19 @@ pub enum HandlerError {
     /// downstream call timed out. Surfaced as a 5xx, because RFC 8935 §2.4's error codes all
     /// describe something *wrong with the SET*, and telling a transmitter its perfectly good SET
     /// was invalid would make it stop retrying the one thing that could still succeed.
+    ///
+    /// Returning this releases the SET's replay slot, so the retry is dispatched rather than
+    /// acknowledged as a duplicate — which means every handler runs again from the start. Return
+    /// it only when the event genuinely was not processed.
     #[error("handler failed: {0}")]
     Internal(String),
 
     /// The handler refuses this SET from this transmitter (an unrecognised subject, a tenant the
     /// transmitter may not signal for). Maps to `access_denied`.
+    ///
+    /// Unlike [`HandlerError::Internal`], this keeps the replay slot: a 400 tells the transmitter
+    /// not to retry, so nothing is waiting on the slot, and a re-send of an already-refused SET
+    /// should not run the handlers a second time.
     #[error("handler rejected the event: {0}")]
     Rejected(String),
 }
@@ -62,6 +70,10 @@ pub enum HandlerError {
 #[async_trait]
 pub trait SetHandler: Send + Sync + 'static {
     /// Handles one event from `set`.
+    ///
+    /// **Must be idempotent.** A [`HandlerError::Internal`] anywhere in the delivery causes the
+    /// whole SET to be re-dispatched when the transmitter retries, so this may be called more
+    /// than once for the same `(set, event)` pair — see [`PushReceiver::receive`].
     async fn handle(&self, set: &SecurityEventToken, event: &CaepEvent)
         -> Result<(), HandlerError>;
 }
@@ -240,6 +252,22 @@ impl PushReceiver {
     ///   own, so the handler *is* the persistence step; a 202 sent before it ran would promise
     ///   durability that nothing delivered. A deployment that wants the RFC's asynchronous shape
     ///   writes a handler that enqueues and returns immediately.
+    ///
+    /// # Handlers must be idempotent
+    ///
+    /// A [`HandlerError::Internal`] answers 500 and asks the transmitter to send the SET again,
+    /// and the replay slot is released so that the retry is actually dispatched rather than
+    /// acknowledged as a duplicate (see [`crate::SetReplayGuard::release`]). The retry replays the whole
+    /// delivery: every event in the SET, through every handler, **including the handlers that
+    /// already succeeded before the one that failed**. A handler that is not safe to run twice
+    /// will double-count.
+    ///
+    /// The release leaves one window open, deliberately. A *concurrent* duplicate that arrives
+    /// between the record and the release is answered 202 without dispatch, as a duplicate should
+    /// be; if the original then fails, that duplicate has already been answered, but the
+    /// transmitter's retry of the failed delivery still finds the slot free and delivers the
+    /// event. Holding the slot across dispatch instead would close the window at the cost of
+    /// losing events on every handler failure, which is the worse trade.
     pub async fn receive(&self, content_type: Option<&str>, body: &[u8]) -> PushResponse {
         // Before the content type, and long before any parsing: the cheapest possible rejection
         // for the cheapest possible attack.
@@ -313,6 +341,9 @@ impl PushReceiver {
                 match handler.handle(&set, event).await {
                     Ok(()) => {}
                     Err(HandlerError::Rejected(reason)) => {
+                        // The slot stays taken. A 400 tells the transmitter not to retry, so
+                        // nothing is waiting on it, and re-sending a SET this receiver has
+                        // already refused should not re-run the handlers.
                         tracing::warn!(
                             target: "authkestra_ssf",
                             jti = %set.jti,
@@ -323,12 +354,18 @@ impl PushReceiver {
                         return PushResponse::error(SetErrorCode::AccessDenied, reason);
                     }
                     Err(HandlerError::Internal(reason)) => {
+                        // The event was *not* processed and the transmitter is being asked to
+                        // send it again, so the replay slot has to go back before the 500 —
+                        // otherwise the retry looks like a duplicate, gets a 202, and the event
+                        // is lost until the entry expires.
+                        self.verifier.release_replay_slot(&set.jti, &set.iss).await;
                         tracing::error!(
                             target: "authkestra_ssf",
                             jti = %set.jti,
                             event_type = %event.event_type_uri(),
                             reason = %reason,
-                            "handler failed; answering 500 so the transmitter retries"
+                            "handler failed; released the replay slot and answering 500 so the \
+                             transmitter retries"
                         );
                         return PushResponse::internal_error();
                     }

--- a/crates/authkestra-ssf/src/receiver.rs
+++ b/crates/authkestra-ssf/src/receiver.rs
@@ -1,0 +1,433 @@
+//! The RFC 8935 push delivery receiver.
+//!
+//! [RFC 8935](https://www.rfc-editor.org/rfc/rfc8935) ("Push-Based Security Event Token (SET)
+//! Delivery Using HTTP") defines exactly one interaction: the transmitter POSTs a SET with
+//! `Content-Type: application/secevent+jwt`, and the receiver answers `202 Accepted` with an
+//! empty body, or `400 Bad Request` with a JSON `{"err": ..., "description": ...}` body.
+//!
+//! [`PushReceiver`] implements that interaction *without* an HTTP framework, per the workspace
+//! `AGENTS.md` "Framework Agnostic" rule: it takes the content type and the raw body and returns
+//! a [`PushResponse`] that an axum or actix handler can translate in a few lines. Wiring those
+//! adapters is deliberately left to a follow-up.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+use crate::caep::CaepEvent;
+use crate::error::{SetError, SetErrorCode};
+use crate::set::{SecurityEventToken, SET_MEDIA_TYPE};
+use crate::verify::SetVerifier;
+
+/// The `Content-Language` RFC 8935 §2.3 requires on a failure response.
+///
+/// RFC 8935 §2.3 says the receiver SHOULD honour `Accept-Language` and MUST otherwise answer in
+/// something an English speaker understands (RFC 2277 §4.5). This crate's `description` strings
+/// are English only, so the value is fixed; a deployment that localizes them should override it.
+pub const ERROR_CONTENT_LANGUAGE: &str = "en";
+
+/// The `Content-Type` RFC 8935 §2.3 requires on a failure response body.
+pub const ERROR_CONTENT_TYPE: &str = "application/json";
+
+/// Why a [`SetHandler`] could not process an event.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum HandlerError {
+    /// The handler failed for a reason the transmitter cannot fix — a database was down, a
+    /// downstream call timed out. Surfaced as a 5xx, because RFC 8935 §2.4's error codes all
+    /// describe something *wrong with the SET*, and telling a transmitter its perfectly good SET
+    /// was invalid would make it stop retrying the one thing that could still succeed.
+    #[error("handler failed: {0}")]
+    Internal(String),
+
+    /// The handler refuses this SET from this transmitter (an unrecognised subject, a tenant the
+    /// transmitter may not signal for). Maps to `access_denied`.
+    #[error("handler rejected the event: {0}")]
+    Rejected(String),
+}
+
+/// Does something with a validated SET.
+///
+/// Handlers see events one at a time, together with the SET they arrived in, because RFC 8417
+/// §2.2 allows several event types per SET while forbidding several *independent logical* events
+/// — so the SET-level claims (`iss`, `jti`, `sub_id`, `toe`) apply to each of them.
+#[async_trait]
+pub trait SetHandler: Send + Sync + 'static {
+    /// Handles one event from `set`.
+    async fn handle(&self, set: &SecurityEventToken, event: &CaepEvent)
+        -> Result<(), HandlerError>;
+}
+
+/// A [`SetHandler`] that only traces what it received.
+///
+/// Useful as a first deployment step — turn on delivery, watch the events arrive, and confirm
+/// the transmitter's configuration before anything acts on them.
+pub struct LoggingHandler;
+
+#[async_trait]
+impl SetHandler for LoggingHandler {
+    async fn handle(
+        &self,
+        set: &SecurityEventToken,
+        event: &CaepEvent,
+    ) -> Result<(), HandlerError> {
+        tracing::info!(
+            target: "authkestra_ssf",
+            iss = %set.iss,
+            jti = %set.jti,
+            event_type = %event.event_type_uri(),
+            subject_format = event.subject().map(|s| s.format()).unwrap_or("none"),
+            "received SET event"
+        );
+        Ok(())
+    }
+}
+
+/// What the caller's HTTP layer should send back.
+///
+/// Modelled as data rather than as a framework response type so that the same receiver serves
+/// axum, actix, a queue consumer, or a test.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PushResponse {
+    status: u16,
+    content_type: Option<&'static str>,
+    content_language: Option<&'static str>,
+    body: Vec<u8>,
+    error_code: Option<SetErrorCode>,
+}
+
+impl PushResponse {
+    /// The RFC 8935 §2.2 success response: `202 Accepted`, empty body.
+    pub fn accepted() -> Self {
+        Self {
+            status: 202,
+            content_type: None,
+            content_language: None,
+            body: Vec::new(),
+            error_code: None,
+        }
+    }
+
+    /// An RFC 8935 §2.3 failure response: `400 Bad Request` with a JSON body carrying `err` and
+    /// `description`.
+    pub fn error(code: SetErrorCode, description: impl Into<String>) -> Self {
+        let description = description.into();
+        let body = serde_json::json!({ "err": code.as_str(), "description": description });
+        Self {
+            status: 400,
+            content_type: Some(ERROR_CONTENT_TYPE),
+            content_language: Some(ERROR_CONTENT_LANGUAGE),
+            // `serde_json::to_vec` on an object of two strings cannot fail; the fallback keeps
+            // the receiver infallible rather than importing a panic into a request path.
+            body: serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec()),
+            error_code: Some(code),
+        }
+    }
+
+    /// A `500 Internal Server Error` with an empty body, for a handler failure that is not the
+    /// transmitter's fault. See [`HandlerError::Internal`].
+    pub fn internal_error() -> Self {
+        Self {
+            status: 500,
+            content_type: None,
+            content_language: None,
+            body: Vec::new(),
+            error_code: None,
+        }
+    }
+
+    /// The HTTP status code to send.
+    pub fn status(&self) -> u16 {
+        self.status
+    }
+
+    /// The `Content-Type` header value, if the response has a body.
+    pub fn content_type(&self) -> Option<&'static str> {
+        self.content_type
+    }
+
+    /// The `Content-Language` header value, which RFC 8935 §2.3 requires on failure responses.
+    pub fn content_language(&self) -> Option<&'static str> {
+        self.content_language
+    }
+
+    /// The response body, empty for success.
+    pub fn body(&self) -> &[u8] {
+        &self.body
+    }
+
+    /// The RFC 8935 §2.4 error code carried in the body, if this is a failure response.
+    pub fn error_code(&self) -> Option<SetErrorCode> {
+        self.error_code
+    }
+
+    /// Whether this is the RFC 8935 §2.2 success response.
+    pub fn is_accepted(&self) -> bool {
+        self.status == 202
+    }
+}
+
+/// Receives pushed SETs, validates them, and dispatches their events to handlers.
+pub struct PushReceiver {
+    verifier: Arc<SetVerifier>,
+    handlers: Vec<Arc<dyn SetHandler>>,
+}
+
+impl PushReceiver {
+    /// Creates a receiver that validates with `verifier` and, until handlers are added, only
+    /// validates.
+    pub fn new(verifier: Arc<SetVerifier>) -> Self {
+        Self {
+            verifier,
+            handlers: Vec::new(),
+        }
+    }
+
+    /// Adds a handler. Handlers run in the order they were added, and every handler sees every
+    /// event; a handler that only cares about one event type filters on
+    /// [`CaepEvent::event_type_uri`].
+    pub fn with_handler(mut self, handler: Arc<dyn SetHandler>) -> Self {
+        self.handlers.push(handler);
+        self
+    }
+
+    /// Handles one SET Transmission Request (RFC 8935 §2.1).
+    ///
+    /// `content_type` is the request's `Content-Type` header, if any, and `body` its raw bytes.
+    ///
+    /// Two deliberate decisions:
+    ///
+    /// - **A replayed SET answers `202`, not an error.** RFC 8935 §2 is explicit: "The SET
+    ///   Transmitter MAY transmit the same SET to the SET Recipient multiple times... The SET
+    ///   Recipient MUST respond as it would if the SET had not been previously received." So the
+    ///   replay guard suppresses *handler dispatch*, not the acknowledgement. Answering 400
+    ///   would make a conformant transmitter retry forever.
+    /// - **Handlers run before the response, not after.** RFC 8935 §2 recommends persisting the
+    ///   SET and then doing further processing asynchronously. This crate has no store of its
+    ///   own, so the handler *is* the persistence step; a 202 sent before it ran would promise
+    ///   durability that nothing delivered. A deployment that wants the RFC's asynchronous shape
+    ///   writes a handler that enqueues and returns immediately.
+    pub async fn receive(&self, content_type: Option<&str>, body: &[u8]) -> PushResponse {
+        if let Err(response) = check_content_type(content_type) {
+            return response;
+        }
+
+        let token = match std::str::from_utf8(body) {
+            Ok(token) => token.trim(),
+            Err(err) => {
+                tracing::warn!(
+                    target: "authkestra_ssf",
+                    error = %err,
+                    "rejecting SET delivery: body is not UTF-8"
+                );
+                return PushResponse::error(
+                    SetErrorCode::InvalidRequest,
+                    "request body is not valid UTF-8",
+                );
+            }
+        };
+
+        let set = match self.verifier.verify(token).await {
+            Ok(set) => set,
+            Err(SetError::Replay { jti, iss }) => {
+                tracing::info!(
+                    target: "authkestra_ssf",
+                    jti = %jti,
+                    iss = %iss,
+                    "SET already ingested; acknowledging without re-dispatching (RFC 8935 §2)"
+                );
+                return PushResponse::accepted();
+            }
+            Err(err) => {
+                let code = err.code();
+                tracing::warn!(
+                    target: "authkestra_ssf",
+                    code = %code,
+                    error = %err,
+                    "rejecting SET delivery"
+                );
+                return PushResponse::error(code, err.to_string());
+            }
+        };
+
+        let events = match set.caep_events() {
+            Ok(events) => events,
+            Err(err) => {
+                tracing::warn!(
+                    target: "authkestra_ssf",
+                    jti = %set.jti,
+                    error = %err,
+                    "rejecting SET delivery: event payload does not conform"
+                );
+                return PushResponse::error(SetErrorCode::InvalidRequest, err.to_string());
+            }
+        };
+
+        for event in &events {
+            for handler in &self.handlers {
+                match handler.handle(&set, event).await {
+                    Ok(()) => {}
+                    Err(HandlerError::Rejected(reason)) => {
+                        tracing::warn!(
+                            target: "authkestra_ssf",
+                            jti = %set.jti,
+                            event_type = %event.event_type_uri(),
+                            reason = %reason,
+                            "handler rejected the event"
+                        );
+                        return PushResponse::error(SetErrorCode::AccessDenied, reason);
+                    }
+                    Err(HandlerError::Internal(reason)) => {
+                        tracing::error!(
+                            target: "authkestra_ssf",
+                            jti = %set.jti,
+                            event_type = %event.event_type_uri(),
+                            reason = %reason,
+                            "handler failed; answering 500 so the transmitter retries"
+                        );
+                        return PushResponse::internal_error();
+                    }
+                }
+            }
+        }
+
+        tracing::debug!(
+            target: "authkestra_ssf",
+            jti = %set.jti,
+            events = events.len(),
+            handlers = self.handlers.len(),
+            "SET delivery accepted"
+        );
+        PushResponse::accepted()
+    }
+}
+
+/// RFC 8935 §2.1: the request's `Content-Type` MUST be `application/secevent+jwt`.
+///
+/// Parameters (`; charset=utf-8`) are ignored and the comparison is case-insensitive, per
+/// RFC 9110 §8.3 / RFC 2045 §5.1 — a transmitter that spells the type in a legal but unusual way
+/// is conformant, and rejecting it would be this receiver's bug, not theirs.
+fn check_content_type(content_type: Option<&str>) -> Result<(), PushResponse> {
+    let Some(content_type) = content_type else {
+        tracing::warn!(
+            target: "authkestra_ssf",
+            "rejecting SET delivery: no Content-Type (RFC 8935 §2.1 requires one)"
+        );
+        return Err(PushResponse::error(
+            SetErrorCode::InvalidRequest,
+            format!("missing Content-Type: RFC 8935 §2.1 requires {SET_MEDIA_TYPE}"),
+        ));
+    };
+
+    let essence = content_type.split(';').next().unwrap_or("").trim();
+    if essence.eq_ignore_ascii_case(SET_MEDIA_TYPE) {
+        return Ok(());
+    }
+
+    tracing::warn!(
+        target: "authkestra_ssf",
+        content_type = %content_type,
+        "rejecting SET delivery: wrong Content-Type"
+    );
+    Err(PushResponse::error(
+        SetErrorCode::InvalidRequest,
+        format!(
+            "unsupported Content-Type {content_type:?}: RFC 8935 §2.1 requires {SET_MEDIA_TYPE}"
+        ),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_the_required_content_type_with_parameters() {
+        assert!(check_content_type(Some(SET_MEDIA_TYPE)).is_ok());
+        assert!(check_content_type(Some("application/secevent+jwt; charset=UTF-8")).is_ok());
+        assert!(check_content_type(Some("  Application/SecEvent+JWT  ")).is_ok());
+    }
+
+    #[test]
+    fn rejects_a_missing_or_wrong_content_type() {
+        let response = check_content_type(None).unwrap_err();
+        assert_eq!(response.status(), 400);
+        assert_eq!(response.error_code(), Some(SetErrorCode::InvalidRequest));
+        assert!(String::from_utf8_lossy(response.body()).contains("missing Content-Type"));
+
+        let response = check_content_type(Some("application/json")).unwrap_err();
+        assert_eq!(response.error_code(), Some(SetErrorCode::InvalidRequest));
+        assert!(String::from_utf8_lossy(response.body()).contains("unsupported Content-Type"));
+
+        let response = check_content_type(Some("")).unwrap_err();
+        assert_eq!(response.status(), 400);
+    }
+
+    #[test]
+    fn success_response_matches_rfc_8935_section_2_2() {
+        let response = PushResponse::accepted();
+        assert_eq!(response.status(), 202);
+        assert!(response.is_accepted());
+        assert!(response.body().is_empty());
+        assert_eq!(response.content_type(), None);
+        assert_eq!(response.content_language(), None);
+        assert_eq!(response.error_code(), None);
+    }
+
+    #[test]
+    fn failure_response_matches_rfc_8935_section_2_3() {
+        let response =
+            PushResponse::error(SetErrorCode::InvalidKey, "Key ID 12345 has been revoked.");
+        assert_eq!(response.status(), 400);
+        assert!(!response.is_accepted());
+        assert_eq!(response.content_type(), Some("application/json"));
+        assert_eq!(response.content_language(), Some("en"));
+        assert_eq!(response.error_code(), Some(SetErrorCode::InvalidKey));
+
+        let body: serde_json::Value = serde_json::from_slice(response.body()).unwrap();
+        assert_eq!(body["err"], "invalid_key");
+        assert_eq!(body["description"], "Key ID 12345 has been revoked.");
+    }
+
+    #[test]
+    fn internal_error_response_has_no_set_error_code() {
+        let response = PushResponse::internal_error();
+        assert_eq!(response.status(), 500);
+        assert!(response.body().is_empty());
+        assert_eq!(response.error_code(), None);
+        assert!(!response.is_accepted());
+    }
+
+    #[tokio::test]
+    async fn logging_handler_accepts_everything() {
+        let set = SecurityEventToken {
+            iss: "https://idp/".into(),
+            jti: "jti".into(),
+            iat: 0,
+            aud: None,
+            sub: None,
+            sub_id: None,
+            txn: None,
+            toe: None,
+            exp: None,
+            nbf: None,
+            events: Default::default(),
+            additional: Default::default(),
+        };
+        let event = CaepEvent::Unknown {
+            uri: "https://example.com/e".into(),
+            payload: serde_json::json!({}),
+        };
+        assert!(LoggingHandler.handle(&set, &event).await.is_ok());
+    }
+
+    #[test]
+    fn handler_errors_describe_themselves() {
+        assert!(HandlerError::Internal("db down".into())
+            .to_string()
+            .contains("db down"));
+        assert!(HandlerError::Rejected("unknown tenant".into())
+            .to_string()
+            .contains("unknown tenant"));
+    }
+}

--- a/crates/authkestra-ssf/src/receiver.rs
+++ b/crates/authkestra-ssf/src/receiver.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 use crate::caep::CaepEvent;
 use crate::error::{SetError, SetErrorCode};
 use crate::set::{SecurityEventToken, SET_MEDIA_TYPE};
-use crate::verify::SetVerifier;
+use crate::verify::{SetVerifier, VerifiedSet};
 
 /// The `Content-Language` RFC 8935 §2.3 requires on a failure response.
 ///
@@ -279,8 +279,8 @@ impl PushReceiver {
             }
         };
 
-        let set = match self.verifier.verify(token).await {
-            Ok(set) => set,
+        let verified = match self.verifier.verify(token).await {
+            Ok(verified) => verified,
             Err(SetError::Replay { jti, iss }) => {
                 tracing::info!(
                     target: "authkestra_ssf",
@@ -302,18 +302,11 @@ impl PushReceiver {
             }
         };
 
-        let events = match set.caep_events() {
-            Ok(events) => events,
-            Err(err) => {
-                tracing::warn!(
-                    target: "authkestra_ssf",
-                    jti = %set.jti,
-                    error = %err,
-                    "rejecting SET delivery: event payload does not conform"
-                );
-                return PushResponse::error(SetErrorCode::InvalidRequest, err.to_string());
-            }
-        };
+        // Already decoded by the verifier, and deliberately so: decoding here instead would mean
+        // rejecting a SET whose `jti` the replay guard had already recorded, so the transmitter's
+        // corrected retransmission (RFC 8935 §2) would come back as a replay and never reach a
+        // handler. See `SetVerifier::verify_at` step 4.
+        let VerifiedSet { set, events } = verified;
 
         for event in &events {
             for handler in &self.handlers {

--- a/crates/authkestra-ssf/src/receiver.rs
+++ b/crates/authkestra-ssf/src/receiver.rs
@@ -30,6 +30,14 @@ pub const ERROR_CONTENT_LANGUAGE: &str = "en";
 /// The `Content-Type` RFC 8935 §2.3 requires on a failure response body.
 pub const ERROR_CONTENT_TYPE: &str = "application/json";
 
+/// The default ceiling on a SET Transmission Request body, in bytes.
+///
+/// RFC 8935 sets no limit — it says only that the body "MUST consist of the SET itself" (§2.1) —
+/// so one has to be chosen. 1 MiB is roughly two orders of magnitude above any realistic signed
+/// SET (RFC 8935 §2.1's own example is a few hundred bytes) while still being small enough that
+/// a flood of oversized bodies cannot exhaust memory through this path.
+pub const DEFAULT_MAX_BODY_BYTES: usize = 1024 * 1024;
+
 /// Why a [`SetHandler`] could not process an event.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum HandlerError {
@@ -171,6 +179,7 @@ impl PushResponse {
 pub struct PushReceiver {
     verifier: Arc<SetVerifier>,
     handlers: Vec<Arc<dyn SetHandler>>,
+    max_body_bytes: usize,
 }
 
 impl PushReceiver {
@@ -180,7 +189,27 @@ impl PushReceiver {
         Self {
             verifier,
             handlers: Vec::new(),
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
         }
+    }
+
+    /// Caps the request body at `max_body_bytes`; anything larger is refused with
+    /// `400 invalid_request` before it is parsed. Defaults to [`DEFAULT_MAX_BODY_BYTES`].
+    ///
+    /// **This is a second line of defence, not the first one.** By the time `receive` is called
+    /// the body has already been read into memory by the HTTP layer, so this check cannot
+    /// prevent that allocation — it only stops an oversized body from reaching the parser and
+    /// the signature verifier. The framework's own limit (axum's `DefaultBodyLimit`, actix's
+    /// `PayloadConfig`, or the reverse proxy's `client_max_body_size`) is what actually bounds
+    /// what gets buffered, and it should be set too.
+    pub fn with_max_body_bytes(mut self, max_body_bytes: usize) -> Self {
+        self.max_body_bytes = max_body_bytes;
+        self
+    }
+
+    /// The configured body ceiling, in bytes.
+    pub fn max_body_bytes(&self) -> usize {
+        self.max_body_bytes
     }
 
     /// Adds a handler. Handlers run in the order they were added, and every handler sees every
@@ -195,7 +224,11 @@ impl PushReceiver {
     ///
     /// `content_type` is the request's `Content-Type` header, if any, and `body` its raw bytes.
     ///
-    /// Two deliberate decisions:
+    /// Three deliberate decisions:
+    ///
+    /// - **The body is size-capped before anything else happens** — see
+    ///   [`PushReceiver::with_max_body_bytes`] for why that is a second line of defence rather
+    ///   than the primary one.
     ///
     /// - **A replayed SET answers `202`, not an error.** RFC 8935 §2 is explicit: "The SET
     ///   Transmitter MAY transmit the same SET to the SET Recipient multiple times... The SET
@@ -208,6 +241,25 @@ impl PushReceiver {
     ///   durability that nothing delivered. A deployment that wants the RFC's asynchronous shape
     ///   writes a handler that enqueues and returns immediately.
     pub async fn receive(&self, content_type: Option<&str>, body: &[u8]) -> PushResponse {
+        // Before the content type, and long before any parsing: the cheapest possible rejection
+        // for the cheapest possible attack.
+        if body.len() > self.max_body_bytes {
+            tracing::warn!(
+                target: "authkestra_ssf",
+                body_len = body.len(),
+                max_body_bytes = self.max_body_bytes,
+                "rejecting SET delivery: body exceeds the configured maximum"
+            );
+            return PushResponse::error(
+                SetErrorCode::InvalidRequest,
+                format!(
+                    "request body of {} bytes exceeds the maximum of {} bytes",
+                    body.len(),
+                    self.max_body_bytes
+                ),
+            );
+        }
+
         if let Err(response) = check_content_type(content_type) {
             return response;
         }
@@ -419,6 +471,43 @@ mod tests {
             payload: serde_json::json!({}),
         };
         assert!(LoggingHandler.handle(&set, &event).await.is_ok());
+    }
+
+    #[test]
+    fn body_cap_defaults_to_one_mebibyte_and_is_configurable() {
+        let verifier = Arc::new(
+            SetVerifier::builder("https://idp/")
+                .algorithms([jsonwebtoken::Algorithm::HS256])
+                .key(jsonwebtoken::DecodingKey::from_secret(b"s"))
+                .build()
+                .unwrap(),
+        );
+        let receiver = PushReceiver::new(verifier.clone());
+        assert_eq!(receiver.max_body_bytes(), DEFAULT_MAX_BODY_BYTES);
+        assert_eq!(DEFAULT_MAX_BODY_BYTES, 1024 * 1024);
+
+        let receiver = PushReceiver::new(verifier).with_max_body_bytes(16);
+        assert_eq!(receiver.max_body_bytes(), 16);
+    }
+
+    #[tokio::test]
+    async fn an_oversized_body_is_refused_before_the_content_type_is_looked_at() {
+        let verifier = Arc::new(
+            SetVerifier::builder("https://idp/")
+                .algorithms([jsonwebtoken::Algorithm::HS256])
+                .key(jsonwebtoken::DecodingKey::from_secret(b"s"))
+                .build()
+                .unwrap(),
+        );
+        let receiver = PushReceiver::new(verifier).with_max_body_bytes(4);
+
+        // Oversized *and* wrong content type: the size check must be the one that fires, which
+        // is what proves it runs first.
+        let response = receiver.receive(Some("application/json"), b"12345").await;
+        assert_eq!(response.status(), 400);
+        assert_eq!(response.error_code(), Some(SetErrorCode::InvalidRequest));
+        let body = String::from_utf8_lossy(response.body()).to_string();
+        assert!(body.contains("exceeds the maximum"), "{body}");
     }
 
     #[test]

--- a/crates/authkestra-ssf/src/replay.rs
+++ b/crates/authkestra-ssf/src/replay.rs
@@ -1,0 +1,133 @@
+//! Replay protection for SETs, keyed by `(iss, jti)`.
+//!
+//! RFC 8417 §2.2 says `jti` "MUST be unique within a particular event feed and MAY be used by
+//! clients to track whether a particular SET has already been received" — hence the composite
+//! key: two transmitters may legitimately mint the same `jti`, and treating them as one would
+//! drop a real event.
+//!
+//! Note what this is *not* for. RFC 8935 §2 requires a receiver to answer a retransmitted SET
+//! exactly as it would answer a first transmission, so detecting a replay must not turn into an
+//! error response — see [`crate::PushReceiver::receive`]. The guard exists so the *handlers* run
+//! once, not so the transmitter gets told off.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+
+/// Records which SETs have already been ingested.
+///
+/// Returns `true` when the SET is new and processing should continue, `false` when it has
+/// already been seen. There is no error case on purpose: an implementation whose backing store
+/// is unreachable must decide locally between failing closed (`false`, at the cost of dropping
+/// events during an outage) and failing open (`true`, at the cost of duplicate handler
+/// invocations) — and that trade-off depends on whether the deployment's handlers are
+/// idempotent, which this crate cannot know. Whichever it picks, it should log the outage.
+#[async_trait]
+pub trait SetReplayGuard: Send + Sync + 'static {
+    /// Atomically records `(iss, jti)` if absent, and reports whether it was newly recorded.
+    async fn check_and_record(&self, jti: &str, iss: &str) -> bool;
+}
+
+/// A `HashMap`-backed [`SetReplayGuard`] with a fixed entry TTL.
+///
+/// Single-process only: two receiver instances each keep their own map, so a SET replayed to a
+/// *different* instance is seen as new. Deployments running more than one receiver want a shared
+/// store (e.g. Redis `SET key val NX PX ttl`) behind the same trait.
+///
+/// Entries are swept lazily on each call rather than by a background task, so an idle receiver
+/// holds its last window's worth of `jti`s until the next SET arrives. That is a deliberate
+/// trade: a timer task would need a runtime handle and a shutdown story for what is, at most, a
+/// few kilobytes of strings.
+pub struct InMemorySetReplayGuard {
+    ttl: Duration,
+    seen: Mutex<HashMap<(String, String), Instant>>,
+}
+
+impl InMemorySetReplayGuard {
+    /// Creates a guard that remembers each `(iss, jti)` for `ttl`.
+    ///
+    /// `ttl` should comfortably exceed the transmitter's retransmission window (RFC 8935 §4
+    /// leaves retry timing to the transmitter): once an entry expires, a retransmission is
+    /// indistinguishable from a new event and handlers run again.
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            ttl,
+            seen: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// How many entries are currently retained, after sweeping expired ones.
+    pub fn len(&self) -> usize {
+        let mut seen = self.seen.lock().expect("replay guard mutex poisoned");
+        let now = Instant::now();
+        seen.retain(|_, recorded_at| now.duration_since(*recorded_at) < self.ttl);
+        seen.len()
+    }
+
+    /// Whether nothing is currently retained.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[async_trait]
+impl SetReplayGuard for InMemorySetReplayGuard {
+    async fn check_and_record(&self, jti: &str, iss: &str) -> bool {
+        let now = Instant::now();
+        let mut seen = self.seen.lock().expect("replay guard mutex poisoned");
+
+        seen.retain(|_, recorded_at| now.duration_since(*recorded_at) < self.ttl);
+
+        let key = (iss.to_string(), jti.to_string());
+        if seen.contains_key(&key) {
+            tracing::warn!(
+                target: "authkestra_ssf",
+                jti = %jti,
+                iss = %iss,
+                "SET jti already recorded; treating as a replay"
+            );
+            return false;
+        }
+        seen.insert(key, now);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn records_then_detects_a_replay() {
+        let guard = InMemorySetReplayGuard::new(Duration::from_secs(60));
+        assert!(guard.check_and_record("jti-1", "https://idp/").await);
+        assert!(!guard.check_and_record("jti-1", "https://idp/").await);
+        assert_eq!(guard.len(), 1);
+        assert!(!guard.is_empty());
+    }
+
+    #[tokio::test]
+    async fn scopes_jti_to_the_issuer() {
+        let guard = InMemorySetReplayGuard::new(Duration::from_secs(60));
+        assert!(guard.check_and_record("jti-1", "https://a/").await);
+        assert!(
+            guard.check_and_record("jti-1", "https://b/").await,
+            "the same jti from a different feed is a different SET (RFC 8417 §2.2)"
+        );
+        assert_eq!(guard.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn expires_entries_after_the_ttl() {
+        let guard = InMemorySetReplayGuard::new(Duration::from_millis(20));
+        assert!(guard.check_and_record("jti-1", "https://idp/").await);
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        assert!(guard.is_empty(), "the entry should have been swept");
+        assert!(
+            guard.check_and_record("jti-1", "https://idp/").await,
+            "after the TTL, the same jti is accepted again"
+        );
+    }
+}

--- a/crates/authkestra-ssf/src/replay.rs
+++ b/crates/authkestra-ssf/src/replay.rs
@@ -27,7 +27,39 @@ use async_trait::async_trait;
 #[async_trait]
 pub trait SetReplayGuard: Send + Sync + 'static {
     /// Atomically records `(iss, jti)` if absent, and reports whether it was newly recorded.
+    ///
+    /// The check and the record must be a single atomic operation (Redis `SET key val NX PX ttl`,
+    /// an `INSERT` against a unique index, a `HashMap` under one lock). Reading first and writing
+    /// second lets two concurrent deliveries of the same SET both observe "absent" and both
+    /// dispatch.
     async fn check_and_record(&self, jti: &str, iss: &str) -> bool;
+
+    /// Forgets `(iss, jti)`, so that a subsequent [`SetReplayGuard::check_and_record`] for the
+    /// same pair reports it as new again.
+    ///
+    /// Releasing an entry that is absent — never recorded, or already expired — is a no-op, not
+    /// an error.
+    ///
+    /// **Why this exists.** The slot is taken during verification, before any handler runs,
+    /// because that is what makes two concurrent deliveries of the same SET dispatch exactly
+    /// once. But some rejections only become knowable *after* dispatch has started: a handler
+    /// that cannot reach its database has not processed the event, and [`crate::PushReceiver`]
+    /// answers 500 so the transmitter retries. Without a way to give the slot back, that retry
+    /// would hit the recorded entry, be acknowledged with 202 as a duplicate, and the event would
+    /// be lost until the entry expired. The receiver therefore releases the slot on that path
+    /// before answering 500.
+    ///
+    /// **Handlers must therefore be idempotent.** A released SET is re-verified and
+    /// re-dispatched from the beginning, which re-runs *every* handler — including the ones that
+    /// already succeeded before the failing one — for *every* event in the SET.
+    ///
+    /// **There is a window.** Between the record and the release, a concurrent duplicate delivery
+    /// is answered 202 without dispatch, exactly as a duplicate should be. If the original then
+    /// fails and releases, that particular duplicate has already been answered — but the
+    /// transmitter's retry of the *failed* delivery still arrives, finds the slot free, and
+    /// delivers the event, so it is not lost. Closing the window entirely would mean holding the
+    /// slot across dispatch, which is the bug this method exists to avoid.
+    async fn release(&self, jti: &str, iss: &str);
 }
 
 /// A `HashMap`-backed [`SetReplayGuard`] with a fixed entry TTL.
@@ -93,6 +125,18 @@ impl SetReplayGuard for InMemorySetReplayGuard {
         seen.insert(key, now);
         true
     }
+
+    async fn release(&self, jti: &str, iss: &str) {
+        let mut seen = self.seen.lock().expect("replay guard mutex poisoned");
+        if seen.remove(&(iss.to_string(), jti.to_string())).is_some() {
+            tracing::debug!(
+                target: "authkestra_ssf",
+                jti = %jti,
+                iss = %iss,
+                "released the SET replay slot; a retransmission will be dispatched again"
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -117,6 +161,39 @@ mod tests {
             "the same jti from a different feed is a different SET (RFC 8417 §2.2)"
         );
         assert_eq!(guard.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn release_makes_a_recorded_jti_acceptable_again() {
+        let guard = InMemorySetReplayGuard::new(Duration::from_secs(60));
+        assert!(guard.check_and_record("jti-1", "https://idp/").await);
+        assert!(!guard.check_and_record("jti-1", "https://idp/").await);
+
+        guard.release("jti-1", "https://idp/").await;
+        assert!(guard.is_empty());
+        assert!(
+            guard.check_and_record("jti-1", "https://idp/").await,
+            "after a release the same SET must be dispatchable again"
+        );
+    }
+
+    #[tokio::test]
+    async fn releasing_an_unknown_entry_is_a_no_op() {
+        let guard = InMemorySetReplayGuard::new(Duration::from_secs(60));
+
+        // Never recorded at all.
+        guard.release("never-seen", "https://idp/").await;
+        assert!(guard.is_empty());
+
+        // And it must not disturb an unrelated entry, including one that differs only by issuer.
+        assert!(guard.check_and_record("jti-1", "https://a/").await);
+        guard.release("jti-1", "https://b/").await;
+        guard.release("other-jti", "https://a/").await;
+        assert_eq!(guard.len(), 1);
+        assert!(
+            !guard.check_and_record("jti-1", "https://a/").await,
+            "the surviving entry must still be recorded"
+        );
     }
 
     #[tokio::test]

--- a/crates/authkestra-ssf/src/set.rs
+++ b/crates/authkestra-ssf/src/set.rs
@@ -81,6 +81,7 @@ impl Audience {
 /// - **Freshness comes from `iat`, not `exp`** — see [`crate::SetVerifier`] for the leeway and
 ///   maximum-age checks that replace expiry.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct SecurityEventToken {
     /// REQUIRED (§2.2). The service provider publishing the SET.
     ///
@@ -144,6 +145,38 @@ pub struct SecurityEventToken {
 }
 
 impl SecurityEventToken {
+    /// Builds a SET from the four claims RFC 8417 §2.2 makes REQUIRED, leaving every optional
+    /// claim empty.
+    ///
+    /// **This exists so consumers can construct one in their own tests** — a `#[non_exhaustive]`
+    /// output type with no constructor is unusable downstream, which is exactly the problem
+    /// reported for `authkestra-devsig`'s `DeviceIdentity` in
+    /// [authkestra#282](https://github.com/marcjazz/authkestra/issues/282). It performs **no
+    /// validation whatsoever**: nothing here checks that `iss` is a URI, that `jti` is non-empty,
+    /// or that `events` conforms to anything. A SET that a receiver should trust comes out of
+    /// [`crate::SetVerifier`], never out of this constructor.
+    pub fn new(
+        iss: impl Into<String>,
+        jti: impl Into<String>,
+        iat: i64,
+        events: BTreeMap<String, Value>,
+    ) -> Self {
+        Self {
+            iss: iss.into(),
+            jti: jti.into(),
+            iat,
+            aud: None,
+            sub: None,
+            sub_id: None,
+            txn: None,
+            toe: None,
+            exp: None,
+            nbf: None,
+            events,
+            additional: Map::new(),
+        }
+    }
+
     /// Decodes every entry of [`SecurityEventToken::events`] into a typed [`CaepEvent`].
     ///
     /// Fails on the first event whose type is modelled but whose payload does not conform;

--- a/crates/authkestra-ssf/src/set.rs
+++ b/crates/authkestra-ssf/src/set.rs
@@ -1,0 +1,373 @@
+//! The Security Event Token model, per [RFC 8417](https://www.rfc-editor.org/rfc/rfc8417).
+//!
+//! A SET is a JWT whose payload describes something that *already happened* to a security
+//! subject. That tense is what makes its claim profile unusual, and the unusual parts are
+//! modelled explicitly here rather than left to a generic JWT struct — see [`SecurityEventToken`].
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::caep::{CaepEvent, EventDecodeError};
+use crate::subject::SubjectIdentifier;
+
+/// The media type registered for a SET by
+/// [RFC 8417 §2.3](https://www.rfc-editor.org/rfc/rfc8417#section-2.3), and the value RFC 8935
+/// §2.1 requires in the `Content-Type` of a push delivery request.
+pub const SET_MEDIA_TYPE: &str = "application/secevent+jwt";
+
+/// The value RFC 8417 §2.3 says SHOULD appear in the JWT's `typ` header: the media type with the
+/// `application/` prefix omitted, as RFC 7515 §4.1.9 recommends.
+pub const SET_TYP: &str = "secevent+jwt";
+
+/// The `aud` claim, which RFC 7519 §4.1.3 allows to be either a single string or an array of
+/// strings.
+///
+/// Both shapes are kept distinct rather than normalised to a `Vec` on parse, so that a SET can
+/// be re-serialized in the shape it arrived in — a receiver that forwards or archives SETs must
+/// not silently rewrite the transmitter's tokens.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Audience {
+    /// A single audience value.
+    Single(String),
+    /// One or more audience values.
+    Multiple(Vec<String>),
+}
+
+impl Audience {
+    /// Whether `value` is one of the audiences.
+    pub fn contains(&self, value: &str) -> bool {
+        match self {
+            Audience::Single(single) => single == value,
+            Audience::Multiple(values) => values.iter().any(|v| v == value),
+        }
+    }
+
+    /// Iterates over the audience values.
+    pub fn iter(&self) -> impl Iterator<Item = &str> {
+        // `Either` would need another dependency for two cases; a boxed iterator keeps the
+        // signature simple and this is never on a hot path (one call per SET).
+        let iter: Box<dyn Iterator<Item = &str>> = match self {
+            Audience::Single(single) => Box::new(std::iter::once(single.as_str())),
+            Audience::Multiple(values) => Box::new(values.iter().map(String::as_str)),
+        };
+        iter
+    }
+
+    /// Whether the claim carries no audience value at all (an empty JSON array).
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Audience::Single(_) => false,
+            Audience::Multiple(values) => values.is_empty(),
+        }
+    }
+}
+
+/// A Security Event Token's claims (RFC 8417 §2.2).
+///
+/// Three things about this profile are not what a JWT reader expects, and each is modelled
+/// deliberately:
+///
+/// - **`exp` is NOT RECOMMENDED** (§2.2), because a SET is historical — it does not stop being
+///   true. So [`SecurityEventToken::exp`] is optional and its absence is never an error;
+///   [`crate::SetVerifier`] still honours it when a transmitter chose to send one. §4.1 goes
+///   further: a SET profile that could be confused with an ID Token MUST NOT carry `exp` at all.
+/// - **`nbf` is not profiled by RFC 8417 at all** — the word does not appear in the document.
+///   It is therefore parsed into [`SecurityEventToken::nbf`] and *deliberately not validated*:
+///   rejecting on a claim the specification never gave meaning to would refuse valid SETs, while
+///   dropping it would hide it from handlers that a profiling specification does give meaning to.
+/// - **Freshness comes from `iat`, not `exp`** — see [`crate::SetVerifier`] for the leeway and
+///   maximum-age checks that replace expiry.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SecurityEventToken {
+    /// REQUIRED (§2.2). The service provider publishing the SET.
+    ///
+    /// Not necessarily the issuer associated with the security subject: §2.2 warns that
+    /// implementers cannot assume the two are the same unless a profiling specification says so.
+    pub iss: String,
+
+    /// REQUIRED (§2.2). Unique identifier for this SET, unique within a particular event feed —
+    /// which is why replay state is keyed by `(iss, jti)` and not by `jti` alone.
+    pub jti: String,
+
+    /// REQUIRED (§2.2). When the SET was issued, as a NumericDate.
+    pub iat: i64,
+
+    /// RECOMMENDED (§2.2). One or more audience identifiers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aud: Option<Audience>,
+
+    /// OPTIONAL (§2.2). A `StringOrURI` naming the principal the SET is about.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sub: Option<String>,
+
+    /// OPTIONAL. The RFC 9493 §4.1 `sub_id` claim: the subject as a structured Subject
+    /// Identifier rather than a bare string.
+    ///
+    /// RFC 9493 §4.1 requires that `sub` and `sub_id`, when both present, identify the same
+    /// subject, and that an implementation MUST NOT rely on both to determine it. This crate
+    /// therefore only parses them; picking which one to resolve against is the consumer's call,
+    /// because only the consumer knows which identifier formats its user store speaks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sub_id: Option<SubjectIdentifier>,
+
+    /// OPTIONAL (§2.2). Correlates several related JWTs issued as one transaction.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub txn: Option<String>,
+
+    /// OPTIONAL (§2.2). Time of event: when the event occurred, as opposed to when the SET was
+    /// issued. Its absence means the issuer chose not to share an event time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub toe: Option<i64>,
+
+    /// NOT RECOMMENDED (§2.2), honoured when present. See the type-level docs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exp: Option<i64>,
+
+    /// Not profiled by RFC 8417; parsed, preserved, and deliberately not validated. See the
+    /// type-level docs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nbf: Option<i64>,
+
+    /// REQUIRED (§2.2). Event type URI to event payload.
+    ///
+    /// A `BTreeMap` rather than a `HashMap` so that iteration order — and therefore the order
+    /// handlers are invoked in, and the order log lines appear in — is deterministic across
+    /// runs. §2.2 forbids repeating an event identifier, so a map loses nothing.
+    pub events: BTreeMap<String, Value>,
+
+    /// Any other claim, preserved for profiling specifications this crate does not model.
+    #[serde(flatten)]
+    pub additional: Map<String, Value>,
+}
+
+impl SecurityEventToken {
+    /// Decodes every entry of [`SecurityEventToken::events`] into a typed [`CaepEvent`].
+    ///
+    /// Fails on the first event whose type is modelled but whose payload does not conform;
+    /// unmodelled event types become [`CaepEvent::Unknown`] rather than an error, so a SET
+    /// carrying one CAEP event and one RISC event still yields both.
+    pub fn caep_events(&self) -> Result<Vec<CaepEvent>, EventDecodeError> {
+        self.events
+            .iter()
+            .map(|(uri, payload)| CaepEvent::decode(uri, payload))
+            .collect()
+    }
+
+    /// The event type URIs this SET carries, in deterministic order.
+    pub fn event_type_uris(&self) -> impl Iterator<Item = &str> {
+        self.events.keys().map(String::as_str)
+    }
+
+    /// Whether this SET carries an event of type `uri`.
+    pub fn contains_event(&self, uri: &str) -> bool {
+        self.events.contains_key(uri)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::caep::EVENT_TYPE_SESSION_REVOKED;
+    use serde_json::json;
+
+    fn parse(value: Value) -> Result<SecurityEventToken, serde_json::Error> {
+        serde_json::from_value(value)
+    }
+
+    fn minimal() -> Value {
+        json!({
+            "iss": "https://idp.example.com/",
+            "jti": "756E69717565206964656E746966696572",
+            "iat": 1_508_184_845_i64,
+            "events": { EVENT_TYPE_SESSION_REVOKED: {} }
+        })
+    }
+
+    #[test]
+    fn parses_the_rfc_8935_example_claims() {
+        let set = parse(json!({
+            "iss": "https://idp.example.com/",
+            "jti": "756E69717565206964656E746966696572",
+            "iat": 1_508_184_845_i64,
+            "aud": "636C69656E745F6964",
+            "events": {
+                "https://schemas.openid.net/secevent/risc/event-type/account-disabled": {
+                    "subject": {
+                        "subject_type": "iss-sub",
+                        "iss": "https://idp.example.com/",
+                        "sub": "7375626A656374"
+                    },
+                    "reason": "hijacking"
+                }
+            }
+        }))
+        .expect("the RFC 8935 §2.1 example must parse");
+        assert_eq!(set.iss, "https://idp.example.com/");
+        assert_eq!(set.iat, 1_508_184_845);
+        assert!(set.aud.as_ref().unwrap().contains("636C69656E745F6964"));
+        assert_eq!(set.events.len(), 1);
+        assert!(set.exp.is_none());
+    }
+
+    #[test]
+    fn required_claims_are_required() {
+        for missing in ["iss", "jti", "iat", "events"] {
+            let mut value = minimal();
+            value.as_object_mut().unwrap().remove(missing);
+            let err = parse(value).unwrap_err();
+            assert!(
+                err.to_string().contains(missing),
+                "removing {missing} should be reported: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_and_ignores_nbf() {
+        let mut value = minimal();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("nbf".into(), json!(4));
+        let set = parse(value).unwrap();
+        assert_eq!(set.nbf, Some(4));
+    }
+
+    #[test]
+    fn preserves_unmodelled_top_level_claims() {
+        let mut value = minimal();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("tenant".into(), json!("acme"));
+        let set = parse(value).unwrap();
+        assert_eq!(set.additional["tenant"], "acme");
+    }
+
+    #[test]
+    fn audience_accepts_a_single_string_or_an_array() {
+        let mut single = minimal();
+        single
+            .as_object_mut()
+            .unwrap()
+            .insert("aud".into(), json!("https://sp.example.com/caep"));
+        let set = parse(single).unwrap();
+        assert_eq!(
+            set.aud,
+            Some(Audience::Single("https://sp.example.com/caep".into()))
+        );
+        assert!(set
+            .aud
+            .as_ref()
+            .unwrap()
+            .contains("https://sp.example.com/caep"));
+        assert!(!set.aud.as_ref().unwrap().contains("https://other/"));
+        assert!(!set.aud.as_ref().unwrap().is_empty());
+        assert_eq!(
+            set.aud.as_ref().unwrap().iter().collect::<Vec<_>>(),
+            vec!["https://sp.example.com/caep"]
+        );
+
+        let mut multiple = minimal();
+        multiple
+            .as_object_mut()
+            .unwrap()
+            .insert("aud".into(), json!(["a", "b"]));
+        let set = parse(multiple).unwrap();
+        assert_eq!(
+            set.aud,
+            Some(Audience::Multiple(vec!["a".into(), "b".into()]))
+        );
+        assert!(set.aud.as_ref().unwrap().contains("b"));
+        assert!(!set.aud.as_ref().unwrap().contains("c"));
+        assert_eq!(
+            set.aud.as_ref().unwrap().iter().collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
+
+        let empty = Audience::Multiple(Vec::new());
+        assert!(empty.is_empty());
+        assert!(!empty.contains(""));
+    }
+
+    #[test]
+    fn round_trips_the_audience_shape_it_arrived_in() {
+        let mut value = minimal();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("aud".into(), json!("one"));
+        let set = parse(value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&set).unwrap(), value);
+
+        let mut value = minimal();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("aud".into(), json!(["one"]));
+        let set = parse(value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&set).unwrap(), value);
+    }
+
+    #[test]
+    fn parses_optional_rfc_8417_claims() {
+        let mut value = minimal();
+        let obj = value.as_object_mut().unwrap();
+        obj.insert("sub".into(), json!("user@example.com"));
+        obj.insert(
+            "sub_id".into(),
+            json!({ "format": "email", "email": "user@example.com" }),
+        );
+        obj.insert("txn".into(), json!("txn-1"));
+        obj.insert("toe".into(), json!(1_508_184_000_i64));
+        obj.insert("exp".into(), json!(1_508_185_000_i64));
+
+        let set = parse(value).unwrap();
+        assert_eq!(set.sub.as_deref(), Some("user@example.com"));
+        assert_eq!(
+            set.sub_id,
+            Some(SubjectIdentifier::Email {
+                email: "user@example.com".into()
+            })
+        );
+        assert_eq!(set.txn.as_deref(), Some("txn-1"));
+        assert_eq!(set.toe, Some(1_508_184_000));
+        assert_eq!(set.exp, Some(1_508_185_000));
+    }
+
+    #[test]
+    fn event_helpers_expose_the_events_claim() {
+        let set = parse(minimal()).unwrap();
+        assert!(set.contains_event(EVENT_TYPE_SESSION_REVOKED));
+        assert!(!set.contains_event("https://example.com/other"));
+        assert_eq!(
+            set.event_type_uris().collect::<Vec<_>>(),
+            vec![EVENT_TYPE_SESSION_REVOKED]
+        );
+        let events = set.caep_events().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type_uri(), EVENT_TYPE_SESSION_REVOKED);
+    }
+
+    #[test]
+    fn caep_events_reports_a_malformed_known_payload() {
+        let mut value = minimal();
+        value.as_object_mut().unwrap().insert(
+            "events".into(),
+            json!({ crate::caep::EVENT_TYPE_CREDENTIAL_CHANGE: {} }),
+        );
+        let set = parse(value).unwrap();
+        let err = set.caep_events().unwrap_err();
+        assert_eq!(err.uri(), crate::caep::EVENT_TYPE_CREDENTIAL_CHANGE);
+    }
+
+    #[test]
+    fn media_type_constants_match_rfc_8417_section_2_3() {
+        assert_eq!(SET_MEDIA_TYPE, "application/secevent+jwt");
+        assert_eq!(SET_TYP, "secevent+jwt");
+        assert_eq!(SET_MEDIA_TYPE, format!("application/{SET_TYP}"));
+    }
+}

--- a/crates/authkestra-ssf/src/subject.rs
+++ b/crates/authkestra-ssf/src/subject.rs
@@ -1,0 +1,275 @@
+//! Subject Identifiers for Security Events, per
+//! [RFC 9493](https://www.rfc-editor.org/rfc/rfc9493).
+//!
+//! A Subject Identifier is a JSON object with a `format` member naming its Identifier Format,
+//! plus whatever members that format requires (RFC 9493 §3). It appears in a SET as the
+//! `sub_id` JWT claim (§4.1) and, for CAEP, also inside individual event payloads.
+
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::{Map, Value};
+
+/// A Subject Identifier (RFC 9493 §3).
+///
+/// The formats modelled explicitly are the ones a CAEP receiver realistically has to act on.
+/// Every other registered format — `account`, `did`, `uri`, `aliases`, `jwt_id`, plus any
+/// Collision-Resistant Name a transmitter invents — lands in [`SubjectIdentifier::Other`] with
+/// its JSON intact, because RFC 9493 §4.1 explicitly contemplates a receiver that "does not
+/// understand the format" of an identifier, and silently dropping such a subject would turn an
+/// event about *someone* into an event about nobody.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SubjectIdentifier {
+    /// Issuer and Subject Identifier Format (RFC 9493 §3.2.3), `format: "iss_sub"`.
+    IssSub {
+        /// The issuer of the subject, following the JWT `iss` format.
+        iss: String,
+        /// The subject at that issuer, following the JWT `sub` format.
+        sub: String,
+    },
+    /// Email Identifier Format (RFC 9493 §3.2.2), `format: "email"`.
+    ///
+    /// The value is *not* canonicalized here. RFC 9493 §3.2.2.1 is explicit that email
+    /// canonicalization is not standardized and that the recipient should apply its own
+    /// algorithm, so guessing one in a protocol crate would silently merge or split identities
+    /// according to a rule the deployment never chose.
+    Email {
+        /// The subject's email address, as an RFC 5322 `addr-spec`.
+        email: String,
+    },
+    /// Opaque Identifier Format (RFC 9493 §3.2.4), `format: "opaque"`.
+    Opaque {
+        /// An identifier string with no asserted semantics beyond identifying the subject.
+        id: String,
+    },
+    /// Phone Number Identifier Format (RFC 9493 §3.2.5), `format: "phone_number"`.
+    PhoneNumber {
+        /// The subject's full telephone number in E.164 form, including the dialing prefix.
+        phone_number: String,
+    },
+    /// Any other Identifier Format, preserved verbatim.
+    Other {
+        /// The value of the `format` member.
+        format: String,
+        /// The complete original JSON object, `format` member included, so that a receiver that
+        /// *does* understand the format can still parse it.
+        raw: Map<String, Value>,
+    },
+}
+
+impl SubjectIdentifier {
+    /// The value of the `format` member for this identifier.
+    pub fn format(&self) -> &str {
+        match self {
+            SubjectIdentifier::IssSub { .. } => "iss_sub",
+            SubjectIdentifier::Email { .. } => "email",
+            SubjectIdentifier::Opaque { .. } => "opaque",
+            SubjectIdentifier::PhoneNumber { .. } => "phone_number",
+            SubjectIdentifier::Other { format, .. } => format.as_str(),
+        }
+    }
+}
+
+/// The known formats, parsed strictly: an identifier that *claims* a registered format but omits
+/// the member that format requires is a spec violation (RFC 9493 §3: "MUST contain all members
+/// required by its Identifier Format"), not an unknown format, and must not be quietly demoted
+/// to [`SubjectIdentifier::Other`].
+#[derive(Deserialize)]
+#[serde(tag = "format", rename_all = "snake_case")]
+enum KnownSubject {
+    IssSub { iss: String, sub: String },
+    Email { email: String },
+    Opaque { id: String },
+    PhoneNumber { phone_number: String },
+}
+
+impl<'de> Deserialize<'de> for SubjectIdentifier {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = Value::deserialize(deserializer)?;
+        let Value::Object(obj) = value else {
+            return Err(D::Error::custom(
+                "a Subject Identifier must be a JSON object (RFC 9493 §3)",
+            ));
+        };
+
+        let format = obj
+            .get("format")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                D::Error::custom(
+                    "a Subject Identifier must contain a string \"format\" member (RFC 9493 §3)",
+                )
+            })?
+            .to_string();
+
+        match format.as_str() {
+            "iss_sub" | "email" | "opaque" | "phone_number" => {
+                let known: KnownSubject =
+                    serde_json::from_value(Value::Object(obj)).map_err(D::Error::custom)?;
+                Ok(match known {
+                    KnownSubject::IssSub { iss, sub } => SubjectIdentifier::IssSub { iss, sub },
+                    KnownSubject::Email { email } => SubjectIdentifier::Email { email },
+                    KnownSubject::Opaque { id } => SubjectIdentifier::Opaque { id },
+                    KnownSubject::PhoneNumber { phone_number } => {
+                        SubjectIdentifier::PhoneNumber { phone_number }
+                    }
+                })
+            }
+            _ => Ok(SubjectIdentifier::Other { format, raw: obj }),
+        }
+    }
+}
+
+impl Serialize for SubjectIdentifier {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let value = match self {
+            SubjectIdentifier::IssSub { iss, sub } => {
+                serde_json::json!({ "format": "iss_sub", "iss": iss, "sub": sub })
+            }
+            SubjectIdentifier::Email { email } => {
+                serde_json::json!({ "format": "email", "email": email })
+            }
+            SubjectIdentifier::Opaque { id } => serde_json::json!({ "format": "opaque", "id": id }),
+            SubjectIdentifier::PhoneNumber { phone_number } => {
+                serde_json::json!({ "format": "phone_number", "phone_number": phone_number })
+            }
+            // Round-trips byte-for-byte modulo JSON object ordering: `raw` still holds the
+            // `format` member, so nothing has to be re-inserted here.
+            SubjectIdentifier::Other { raw, .. } => Value::Object(raw.clone()),
+        };
+        value.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: serde_json::Value) -> Result<SubjectIdentifier, serde_json::Error> {
+        serde_json::from_value(json)
+    }
+
+    #[test]
+    fn parses_iss_sub_format() {
+        let subject = parse(serde_json::json!({
+            "format": "iss_sub",
+            "iss": "https://issuer.example.com/",
+            "sub": "145234573"
+        }))
+        .expect("iss_sub should parse");
+        assert_eq!(
+            subject,
+            SubjectIdentifier::IssSub {
+                iss: "https://issuer.example.com/".into(),
+                sub: "145234573".into(),
+            }
+        );
+        assert_eq!(subject.format(), "iss_sub");
+    }
+
+    #[test]
+    fn parses_email_format() {
+        let subject =
+            parse(serde_json::json!({ "format": "email", "email": "user@example.com" })).unwrap();
+        assert_eq!(
+            subject,
+            SubjectIdentifier::Email {
+                email: "user@example.com".into()
+            }
+        );
+        assert_eq!(subject.format(), "email");
+    }
+
+    #[test]
+    fn parses_opaque_format() {
+        let subject =
+            parse(serde_json::json!({ "format": "opaque", "id": "11112222333344445555" })).unwrap();
+        assert_eq!(
+            subject,
+            SubjectIdentifier::Opaque {
+                id: "11112222333344445555".into()
+            }
+        );
+        assert_eq!(subject.format(), "opaque");
+    }
+
+    #[test]
+    fn parses_phone_number_format() {
+        let subject =
+            parse(serde_json::json!({ "format": "phone_number", "phone_number": "+12065550100" }))
+                .unwrap();
+        assert_eq!(
+            subject,
+            SubjectIdentifier::PhoneNumber {
+                phone_number: "+12065550100".into()
+            }
+        );
+        assert_eq!(subject.format(), "phone_number");
+    }
+
+    #[test]
+    fn preserves_unknown_format_verbatim() {
+        let json = serde_json::json!({
+            "format": "did",
+            "url": "did:example:123456/did/url/path?versionId=1"
+        });
+        let subject = parse(json.clone()).unwrap();
+        match &subject {
+            SubjectIdentifier::Other { format, raw } => {
+                assert_eq!(format, "did");
+                assert_eq!(
+                    raw.get("url").unwrap(),
+                    "did:example:123456/did/url/path?versionId=1"
+                );
+            }
+            other => panic!("expected Other, got {other:?}"),
+        }
+        assert_eq!(subject.format(), "did");
+        assert_eq!(serde_json::to_value(&subject).unwrap(), json);
+    }
+
+    #[test]
+    fn preserves_nested_aliases_format() {
+        let json = serde_json::json!({
+            "format": "aliases",
+            "identifiers": [
+                { "format": "email", "email": "user@example.com" },
+                { "format": "phone_number", "phone_number": "+12065550100" }
+            ]
+        });
+        let subject = parse(json.clone()).unwrap();
+        assert_eq!(subject.format(), "aliases");
+        assert_eq!(serde_json::to_value(&subject).unwrap(), json);
+    }
+
+    #[test]
+    fn rejects_known_format_missing_its_required_member() {
+        let err = parse(serde_json::json!({ "format": "email" })).unwrap_err();
+        assert!(err.to_string().contains("email"), "{err}");
+    }
+
+    #[test]
+    fn rejects_missing_format_member() {
+        let err = parse(serde_json::json!({ "email": "user@example.com" })).unwrap_err();
+        assert!(err.to_string().contains("format"), "{err}");
+    }
+
+    #[test]
+    fn rejects_non_object() {
+        let err = parse(serde_json::json!("user@example.com")).unwrap_err();
+        assert!(err.to_string().contains("JSON object"), "{err}");
+    }
+
+    #[test]
+    fn known_formats_round_trip() {
+        for json in [
+            serde_json::json!({ "format": "iss_sub", "iss": "https://i/", "sub": "s" }),
+            serde_json::json!({ "format": "email", "email": "user@example.com" }),
+            serde_json::json!({ "format": "opaque", "id": "abc" }),
+            serde_json::json!({ "format": "phone_number", "phone_number": "+12065550100" }),
+        ] {
+            let subject = parse(json.clone()).unwrap();
+            assert_eq!(serde_json::to_value(&subject).unwrap(), json);
+        }
+    }
+}

--- a/crates/authkestra-ssf/src/verify.rs
+++ b/crates/authkestra-ssf/src/verify.rs
@@ -141,6 +141,29 @@ impl SetVerifier {
         &self.issuer
     }
 
+    /// Gives back the replay slot that [`SetVerifier::verify_at`] took for this SET, so a
+    /// retransmission is verified and dispatched again instead of being acknowledged as a
+    /// duplicate. A no-op when no replay guard is configured.
+    ///
+    /// Call this — and only this — when the SET was verified successfully but could *not* be
+    /// processed for a reason the transmitter should retry: a handler whose datastore was
+    /// unreachable, a queue that refused the write. [`crate::PushReceiver`] does it on the
+    /// [`crate::HandlerError::Internal`] path, immediately before answering 500.
+    ///
+    /// Do **not** call it after a rejection the transmitter will not retry (a refused event, a
+    /// policy denial answered with 400): releasing there would let a re-send of the same rejected
+    /// SET run the handlers again for no benefit.
+    ///
+    /// Public because [`SetVerifier::verify_at`] is: anything that drives verification itself and
+    /// dispatches on its own has exactly the same obligation, and without this it would have no
+    /// way to meet it. See [`SetReplayGuard::release`] for the idempotency requirement this puts
+    /// on handlers and for the window it does not close.
+    pub async fn release_replay_slot(&self, jti: &str, iss: &str) {
+        if let Some(guard) = &self.replay_guard {
+            guard.release(jti, iss).await;
+        }
+    }
+
     /// Verifies `token` against the current system clock.
     pub async fn verify(&self, token: &str) -> Result<VerifiedSet, SetError> {
         self.verify_at(token, current_unix_time()).await

--- a/crates/authkestra-ssf/src/verify.rs
+++ b/crates/authkestra-ssf/src/verify.rs
@@ -1,0 +1,760 @@
+//! Ingestion and validation of Security Event Tokens.
+//!
+//! [`SetVerifier`] implements the recipient-side checks RFC 8935 §2 requires ("the SET Recipient
+//! can parse the SET", "the SET is authentic", "the SET Recipient is identified as an intended
+//! audience", "the SET Issuer is recognized") on top of the RFC 8417 claim profile, plus the two
+//! freshness controls that a specification which discourages `exp` leaves to the receiver.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use jsonwebtoken::errors::ErrorKind;
+use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+use serde_json::Value;
+use thiserror::Error;
+
+use crate::error::SetError;
+use crate::keys::{SetKeyResolver, SingleKeyResolver};
+use crate::replay::SetReplayGuard;
+use crate::set::{SecurityEventToken, SET_TYP};
+
+/// The default tolerance for an `iat` in the future, absorbing ordinary clock skew between
+/// transmitter and receiver.
+const DEFAULT_IAT_LEEWAY: Duration = Duration::from_secs(60);
+
+/// Why a [`SetVerifier`] could not be built. Every variant is a configuration mistake that would
+/// otherwise become a runtime security hole, so it is refused up front rather than defaulted.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum SetVerifierError {
+    /// No issuer was given, or it was empty. Without one, the RFC 8935 §2 "SET Issuer is
+    /// recognized" check has nothing to compare against.
+    #[error("a SET verifier needs a non-empty expected issuer")]
+    MissingIssuer,
+
+    /// No accepted algorithms were configured. An empty allow-list would accept whatever
+    /// algorithm the token names.
+    #[error("a SET verifier needs at least one accepted algorithm")]
+    NoAlgorithms,
+
+    /// Neither [`SetVerifierBuilder::key`] nor [`SetVerifierBuilder::key_resolver`] was called.
+    #[error("a SET verifier needs either a decoding key or a key resolver")]
+    MissingKeySource,
+}
+
+/// Validates Security Event Tokens against one transmitter's configuration.
+///
+/// Build one with [`SetVerifier::builder`]. A verifier is cheap to share (`Arc`) and holds no
+/// mutable state of its own — any state lives behind the [`SetReplayGuard`].
+pub struct SetVerifier {
+    issuer: String,
+    audiences: Vec<String>,
+    algorithms: Vec<Algorithm>,
+    keys: Arc<dyn SetKeyResolver>,
+    iat_leeway: Duration,
+    max_age: Option<Duration>,
+    replay_guard: Option<Arc<dyn SetReplayGuard>>,
+}
+
+/// Hand-written rather than derived: the key source is a trait object, and more importantly a
+/// derived `Debug` on a future field holding key material would leak it into logs. Only the
+/// policy is printed; whether a key or a resolver is installed is a boolean.
+impl std::fmt::Debug for SetVerifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SetVerifier")
+            .field("issuer", &self.issuer)
+            .field("audiences", &self.audiences)
+            .field("algorithms", &self.algorithms)
+            .field("iat_leeway", &self.iat_leeway)
+            .field("max_age", &self.max_age)
+            .field("replay_guard", &self.replay_guard.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Builder for [`SetVerifier`].
+pub struct SetVerifierBuilder {
+    issuer: String,
+    audiences: Vec<String>,
+    algorithms: Vec<Algorithm>,
+    keys: Option<Arc<dyn SetKeyResolver>>,
+    iat_leeway: Duration,
+    max_age: Option<Duration>,
+    replay_guard: Option<Arc<dyn SetReplayGuard>>,
+}
+
+impl SetVerifier {
+    /// Starts building a verifier for SETs issued by `issuer`.
+    pub fn builder(issuer: impl Into<String>) -> SetVerifierBuilder {
+        SetVerifierBuilder {
+            issuer: issuer.into(),
+            audiences: Vec::new(),
+            algorithms: Vec::new(),
+            keys: None,
+            iat_leeway: DEFAULT_IAT_LEEWAY,
+            max_age: None,
+            replay_guard: None,
+        }
+    }
+
+    /// The issuer this verifier accepts SETs from.
+    pub fn issuer(&self) -> &str {
+        &self.issuer
+    }
+
+    /// Verifies `token` against the current system clock.
+    pub async fn verify(&self, token: &str) -> Result<SecurityEventToken, SetError> {
+        self.verify_at(token, current_unix_time()).await
+    }
+
+    /// Verifies `token` as if the current time were `now` (seconds since the Unix epoch).
+    ///
+    /// Public, not test-only: a receiver that buffers SETs and validates them out of band needs
+    /// to be able to say *when* it is validating, and a caller with a trusted time source should
+    /// not be forced through `SystemTime::now`.
+    ///
+    /// The order below is load-bearing:
+    ///
+    /// 1. **Header, `typ`, `alg`** — cheap, and done against the raw JSON before `jsonwebtoken`'s
+    ///    typed API sees it. `jsonwebtoken::Algorithm` has no variant for `none` and its
+    ///    `Deserialize` hard-fails on unknown names, so a typed header parse cannot tell
+    ///    `alg: "none"` from a corrupt token; this crate must, because they are a
+    ///    `disallowed alg` and a `malformed` SET respectively.
+    /// 2. **Key resolution and signature** — before *any* claim is trusted. Claims from an
+    ///    unverified token are attacker-controlled strings, so no rejection above this line may
+    ///    depend on them, and the key is resolved for the *configured* issuer rather than the
+    ///    token's self-asserted `iss`.
+    /// 3. **Claims** — issuer, audience, freshness, non-empty `events`.
+    /// 4. **Replay** — last, so a SET rejected for any other reason does not consume its `jti`
+    ///    and thereby stop a corrected retransmission from being processed.
+    pub async fn verify_at(&self, token: &str, now: i64) -> Result<SecurityEventToken, SetError> {
+        tracing::debug!(target: "authkestra_ssf", issuer = %self.issuer, "verifying SET");
+
+        // --- Step 1: header, typ, alg (raw JSON, pre-`jsonwebtoken`) ---
+        let header = decode_header_json(token).map_err(reject)?;
+
+        let typ = header
+            .get("typ")
+            .and_then(Value::as_str)
+            .ok_or(SetError::MissingType)
+            .map_err(reject)?;
+        if !is_set_typ(typ) {
+            return Err(reject(SetError::UnexpectedType(typ.to_string())));
+        }
+
+        let alg = self.check_algorithm(&header).map_err(reject)?;
+        let kid = header.get("kid").and_then(Value::as_str);
+
+        // --- Step 2: key resolution and signature ---
+        let key = self
+            .keys
+            .resolve(&self.issuer, kid)
+            .await
+            .map_err(SetError::from)
+            .map_err(reject)?;
+        let claims = decode_claims(token, &key, alg).map_err(reject)?;
+        let set: SecurityEventToken = serde_json::from_value(claims)
+            .map_err(|err| SetError::InvalidClaims(err.to_string()))
+            .map_err(reject)?;
+
+        // --- Step 3: claims ---
+        self.check_issuer(&set).map_err(reject)?;
+        self.check_audience(&set).map_err(reject)?;
+        self.check_freshness(&set, now).map_err(reject)?;
+        if set.events.is_empty() {
+            return Err(reject(SetError::EmptyEvents));
+        }
+
+        // --- Step 4: replay ---
+        if let Some(guard) = &self.replay_guard {
+            if !guard.check_and_record(&set.jti, &set.iss).await {
+                return Err(reject(SetError::Replay {
+                    jti: set.jti.clone(),
+                    iss: set.iss.clone(),
+                }));
+            }
+        }
+
+        tracing::info!(
+            target: "authkestra_ssf",
+            iss = %set.iss,
+            jti = %set.jti,
+            events = set.events.len(),
+            "accepted SET"
+        );
+        Ok(set)
+    }
+
+    fn check_algorithm(&self, header: &Value) -> Result<Algorithm, SetError> {
+        let raw = header
+            .get("alg")
+            .and_then(Value::as_str)
+            .ok_or_else(|| SetError::Malformed("JOSE header has no alg".to_string()))?;
+
+        // Checked by name, before parsing: an unsecured JWT is exactly what RFC 8417 §2.4's own
+        // example uses, so a receiver will see one, and accepting it would make every other
+        // check in this function decorative.
+        if raw.eq_ignore_ascii_case("none") {
+            return Err(SetError::DisallowedAlgorithm(
+                "alg \"none\" is never accepted: an unsecured SET authenticates nothing"
+                    .to_string(),
+            ));
+        }
+
+        let alg: Algorithm = raw
+            .parse()
+            .map_err(|_| SetError::DisallowedAlgorithm(format!("unsupported alg {raw:?}")))?;
+
+        if !self.algorithms.contains(&alg) {
+            return Err(SetError::DisallowedAlgorithm(format!(
+                "{alg:?} is not in this verifier's allow-list"
+            )));
+        }
+        Ok(alg)
+    }
+
+    fn check_issuer(&self, set: &SecurityEventToken) -> Result<(), SetError> {
+        if set.iss == self.issuer {
+            Ok(())
+        } else {
+            Err(SetError::IssuerMismatch {
+                expected: self.issuer.clone(),
+                found: set.iss.clone(),
+            })
+        }
+    }
+
+    fn check_audience(&self, set: &SecurityEventToken) -> Result<(), SetError> {
+        // An unconfigured audience list means "this receiver has no audience identifier of its
+        // own"; RFC 8417 §2.2 only RECOMMENDs `aud`, so requiring it unconditionally would
+        // reject conformant SETs. Configuring one makes the check mandatory.
+        if self.audiences.is_empty() {
+            return Ok(());
+        }
+        match &set.aud {
+            None => Err(SetError::MissingAudience {
+                expected: self.audiences.clone(),
+            }),
+            Some(aud) => {
+                if self.audiences.iter().any(|expected| aud.contains(expected)) {
+                    Ok(())
+                } else {
+                    Err(SetError::AudienceMismatch {
+                        expected: self.audiences.clone(),
+                    })
+                }
+            }
+        }
+    }
+
+    fn check_freshness(&self, set: &SecurityEventToken, now: i64) -> Result<(), SetError> {
+        let leeway = self.iat_leeway.as_secs() as i64;
+        if set.iat > now.saturating_add(leeway) {
+            return Err(SetError::IatInFuture {
+                iat: set.iat,
+                now,
+                leeway,
+            });
+        }
+
+        if let Some(max_age) = self.max_age {
+            let max_age = max_age.as_secs() as i64;
+            // The same leeway applies on this side too: a receiver whose clock runs fast must
+            // not start calling fresh SETs stale.
+            if now.saturating_sub(set.iat) > max_age.saturating_add(leeway) {
+                return Err(SetError::TooOld {
+                    iat: set.iat,
+                    now,
+                    max_age,
+                });
+            }
+        }
+
+        if let Some(exp) = set.exp {
+            if now.saturating_sub(leeway) >= exp {
+                return Err(SetError::Expired { exp, now });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl SetVerifierBuilder {
+    /// Adds an audience identifier this receiver answers to.
+    ///
+    /// Calling this at least once makes the `aud` check mandatory; leaving it unset skips the
+    /// check entirely (see [`SetVerifier::verify_at`]).
+    pub fn audience(mut self, audience: impl Into<String>) -> Self {
+        self.audiences.push(audience.into());
+        self
+    }
+
+    /// Adds several audience identifiers at once.
+    pub fn audiences<I, S>(mut self, audiences: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.audiences.extend(audiences.into_iter().map(Into::into));
+        self
+    }
+
+    /// Sets the accepted JWS algorithms, replacing any previously configured.
+    ///
+    /// There is no way to allow `none` here: `jsonwebtoken::Algorithm` has no such variant, so
+    /// the unsecured-JWT case cannot be configured in — only detected on the wire.
+    pub fn algorithms(mut self, algorithms: impl IntoIterator<Item = Algorithm>) -> Self {
+        self.algorithms = algorithms.into_iter().collect();
+        self
+    }
+
+    /// Uses a single decoding key for every SET, regardless of `kid`.
+    ///
+    /// Mutually exclusive with [`SetVerifierBuilder::key_resolver`]; the last call wins.
+    pub fn key(mut self, key: DecodingKey) -> Self {
+        self.keys = Some(Arc::new(SingleKeyResolver::new(key)));
+        self
+    }
+
+    /// Resolves the decoding key per token, by `kid` — the JWKS-backed case.
+    ///
+    /// Mutually exclusive with [`SetVerifierBuilder::key`]; the last call wins.
+    pub fn key_resolver(mut self, resolver: Arc<dyn SetKeyResolver>) -> Self {
+        self.keys = Some(resolver);
+        self
+    }
+
+    /// How far into the future an `iat` may be before the SET is rejected. Defaults to 60
+    /// seconds.
+    pub fn iat_leeway(mut self, leeway: Duration) -> Self {
+        self.iat_leeway = leeway;
+        self
+    }
+
+    /// Rejects SETs whose `iat` is older than `max_age`.
+    ///
+    /// Off by default, because a SET is historical (RFC 8417 §2.2) and a legitimate transmitter
+    /// may be replaying a backlog after an outage. Deployments that would rather drop a stale
+    /// backlog than act on it opt in here.
+    pub fn max_age(mut self, max_age: Duration) -> Self {
+        self.max_age = Some(max_age);
+        self
+    }
+
+    /// Installs replay protection.
+    ///
+    /// Off by default: RFC 8417 §2.2 says a client MAY use `jti` to track SETs it has already
+    /// received, and a deployment whose handlers are idempotent may legitimately not want the
+    /// state.
+    pub fn replay_guard(mut self, guard: Arc<dyn SetReplayGuard>) -> Self {
+        self.replay_guard = Some(guard);
+        self
+    }
+
+    /// Validates the configuration and builds the verifier.
+    pub fn build(self) -> Result<SetVerifier, SetVerifierError> {
+        if self.issuer.trim().is_empty() {
+            return Err(SetVerifierError::MissingIssuer);
+        }
+        if self.algorithms.is_empty() {
+            return Err(SetVerifierError::NoAlgorithms);
+        }
+        let keys = self.keys.ok_or(SetVerifierError::MissingKeySource)?;
+
+        Ok(SetVerifier {
+            issuer: self.issuer,
+            audiences: self.audiences,
+            algorithms: self.algorithms,
+            keys,
+            iat_leeway: self.iat_leeway,
+            max_age: self.max_age,
+            replay_guard: self.replay_guard,
+        })
+    }
+}
+
+/// Logs every rejection uniformly, so no branch of the algorithm can go unobserved in production
+/// (the workspace `AGENTS.md` tracing Definition of Done).
+fn reject(err: SetError) -> SetError {
+    tracing::warn!(
+        target: "authkestra_ssf",
+        code = %err.code(),
+        error = %err,
+        "rejecting SET"
+    );
+    err
+}
+
+/// Whether `typ` is the SET explicit type from RFC 8417 §2.3.
+///
+/// Both `secevent+jwt` (what §2.3 says SHOULD be used) and the full `application/secevent+jwt`
+/// media type are accepted, and both case-insensitively: RFC 7515 §4.1.9 defines `typ` as a
+/// media type whose `application/` prefix may be omitted, and media types are case-insensitive
+/// per RFC 2045 §5.1. Rejecting `Secevent+JWT` would refuse a conformant transmitter.
+fn is_set_typ(typ: &str) -> bool {
+    let typ = typ.trim();
+    let bare = match typ.get(..12) {
+        Some(prefix) if prefix.eq_ignore_ascii_case("application/") => &typ[12..],
+        _ => typ,
+    };
+    bare.eq_ignore_ascii_case(SET_TYP)
+}
+
+/// Base64url-decodes and JSON-parses a compact JWS's protected header.
+///
+/// An *empty* signature segment is accepted at this stage even though no such token can ever be
+/// valid, because that is exactly the shape of the unsecured JWT in RFC 8417 §2.4's own example.
+/// Rejecting it here as "malformed" would hide the far more useful `disallowed alg` diagnostic
+/// that [`SetVerifier::check_algorithm`] produces two steps later.
+fn decode_header_json(token: &str) -> Result<Value, SetError> {
+    let mut parts = token.split('.');
+    let header_b64 = match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some(header), Some(_), Some(_), None) if !header.is_empty() => header,
+        _ => {
+            return Err(SetError::Malformed(
+                "expected a compact JWS with three non-empty dot-separated segments".to_string(),
+            ))
+        }
+    };
+
+    let bytes = URL_SAFE_NO_PAD
+        .decode(header_b64)
+        .map_err(|err| SetError::Malformed(format!("JOSE header is not base64url: {err}")))?;
+    let header: Value = serde_json::from_slice(&bytes)
+        .map_err(|err| SetError::Malformed(format!("JOSE header is not JSON: {err}")))?;
+    if !header.is_object() {
+        return Err(SetError::Malformed(
+            "JOSE header is not a JSON object".to_string(),
+        ));
+    }
+    Ok(header)
+}
+
+/// Verifies the signature and returns the raw claims.
+///
+/// Every time-based check `jsonwebtoken` offers is switched off here and re-done in
+/// [`SetVerifier::check_freshness`]: its `exp` handling is mandatory-by-default, which is the
+/// opposite of RFC 8417 §2.2, and its errors are not granular enough to map onto the RFC 8935
+/// §2.4 error codes.
+fn decode_claims(token: &str, key: &DecodingKey, alg: Algorithm) -> Result<Value, SetError> {
+    let mut validation = Validation::new(alg);
+    validation.required_spec_claims.clear();
+    validation.validate_exp = false;
+    validation.validate_nbf = false;
+    validation.validate_aud = false;
+    // Exactly the one algorithm the header named — and which was already checked against the
+    // verifier's allow-list — so the key can never be used with a different family.
+    validation.algorithms = vec![alg];
+
+    decode::<Value>(token, key, &validation)
+        .map(|data| data.claims)
+        .map_err(map_jwt_error)
+}
+
+fn map_jwt_error(err: jsonwebtoken::errors::Error) -> SetError {
+    match err.kind() {
+        ErrorKind::InvalidToken | ErrorKind::Base64(_) | ErrorKind::Utf8(_) => {
+            SetError::Malformed(err.to_string())
+        }
+        ErrorKind::Json(_) => SetError::InvalidClaims(err.to_string()),
+        ErrorKind::InvalidAlgorithm
+        | ErrorKind::InvalidKeyFormat
+        | ErrorKind::InvalidEcdsaKey
+        | ErrorKind::InvalidEddsaKey
+        | ErrorKind::InvalidRsaKey(_)
+        | ErrorKind::UnsupportedAlgorithm
+        | ErrorKind::MissingAlgorithm => SetError::DisallowedAlgorithm(err.to_string()),
+        // Everything else means "we could not authenticate this token", which is what
+        // RFC 8935's `authentication_failed` is for. Notably `InvalidSignature`.
+        _ => SetError::InvalidSignature(err.to_string()),
+    }
+}
+
+fn current_unix_time() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_both_spellings_of_the_set_type() {
+        assert!(is_set_typ("secevent+jwt"));
+        assert!(is_set_typ("application/secevent+jwt"));
+        assert!(is_set_typ("Application/SecEvent+JWT"));
+        assert!(is_set_typ("  secevent+jwt  "));
+    }
+
+    #[test]
+    fn rejects_other_types() {
+        assert!(!is_set_typ("JWT"));
+        assert!(!is_set_typ("at+jwt"));
+        assert!(!is_set_typ(""));
+        assert!(!is_set_typ("application/jwt"));
+        // A multi-byte prefix must not panic the byte-slicing shortcut.
+        assert!(!is_set_typ("æææææææææææ/secevent+jwt"));
+    }
+
+    #[test]
+    fn header_decoding_rejects_non_compact_input() {
+        for token in ["", "a.b", "a.b.c.d", ".b.c"] {
+            let err = decode_header_json(token).unwrap_err();
+            assert!(matches!(err, SetError::Malformed(_)), "{token:?}: {err:?}");
+        }
+    }
+
+    #[test]
+    fn header_decoding_tolerates_an_empty_signature_segment() {
+        let header = URL_SAFE_NO_PAD.encode(br#"{"typ":"secevent+jwt","alg":"none"}"#);
+        let header = decode_header_json(&format!("{header}.payload.")).unwrap();
+        assert_eq!(header["alg"], "none");
+    }
+
+    #[test]
+    fn header_decoding_rejects_bad_base64_and_bad_json() {
+        let err = decode_header_json("!!!.payload.sig").unwrap_err();
+        assert!(err.to_string().contains("base64url"), "{err}");
+
+        let not_json = URL_SAFE_NO_PAD.encode(b"not json");
+        let err = decode_header_json(&format!("{not_json}.payload.sig")).unwrap_err();
+        assert!(err.to_string().contains("not JSON"), "{err}");
+
+        let not_object = URL_SAFE_NO_PAD.encode(b"\"a string\"");
+        let err = decode_header_json(&format!("{not_object}.payload.sig")).unwrap_err();
+        assert!(err.to_string().contains("not a JSON object"), "{err}");
+    }
+
+    #[test]
+    fn header_decoding_accepts_a_well_formed_header() {
+        let header = URL_SAFE_NO_PAD.encode(br#"{"typ":"secevent+jwt","alg":"HS256"}"#);
+        let header = decode_header_json(&format!("{header}.payload.sig")).unwrap();
+        assert_eq!(header["alg"], "HS256");
+    }
+
+    fn verifier() -> SetVerifier {
+        SetVerifier::builder("https://idp.example.com/")
+            .algorithms([Algorithm::HS256])
+            .key(DecodingKey::from_secret(b"secret"))
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn builder_rejects_incomplete_configuration() {
+        assert_eq!(
+            SetVerifier::builder("   ")
+                .algorithms([Algorithm::HS256])
+                .key(DecodingKey::from_secret(b"s"))
+                .build()
+                .unwrap_err(),
+            SetVerifierError::MissingIssuer
+        );
+        assert_eq!(
+            SetVerifier::builder("https://idp/")
+                .key(DecodingKey::from_secret(b"s"))
+                .build()
+                .unwrap_err(),
+            SetVerifierError::NoAlgorithms
+        );
+        assert_eq!(
+            SetVerifier::builder("https://idp/")
+                .algorithms([Algorithm::HS256])
+                .build()
+                .unwrap_err(),
+            SetVerifierError::MissingKeySource
+        );
+        for err in [
+            SetVerifierError::MissingIssuer,
+            SetVerifierError::NoAlgorithms,
+            SetVerifierError::MissingKeySource,
+        ] {
+            assert!(!err.to_string().is_empty());
+        }
+    }
+
+    #[test]
+    fn builder_exposes_the_configured_issuer() {
+        assert_eq!(verifier().issuer(), "https://idp.example.com/");
+    }
+
+    #[test]
+    fn audiences_accumulate_across_both_setters() {
+        let verifier = SetVerifier::builder("https://idp/")
+            .audience("one")
+            .audiences(["two", "three"])
+            .algorithms([Algorithm::HS256])
+            .key(DecodingKey::from_secret(b"s"))
+            .build()
+            .unwrap();
+
+        let mut set = set_with(0, None);
+        set.iss = "https://idp/".into();
+        for accepted in ["one", "two", "three"] {
+            set.aud = Some(crate::set::Audience::Single(accepted.to_string()));
+            assert!(verifier.check_audience(&set).is_ok(), "{accepted}");
+        }
+        set.aud = Some(crate::set::Audience::Single("four".to_string()));
+        assert!(matches!(
+            verifier.check_audience(&set),
+            Err(SetError::AudienceMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn algorithm_check_rejects_none_unknown_and_unlisted() {
+        let verifier = verifier();
+
+        let err = verifier
+            .check_algorithm(&serde_json::json!({ "alg": "none" }))
+            .unwrap_err();
+        assert!(err.to_string().contains("none"), "{err}");
+
+        let err = verifier
+            .check_algorithm(&serde_json::json!({ "alg": "NoNe" }))
+            .unwrap_err();
+        assert!(err.to_string().contains("none"), "{err}");
+
+        let err = verifier
+            .check_algorithm(&serde_json::json!({ "alg": "XS999" }))
+            .unwrap_err();
+        assert!(err.to_string().contains("unsupported"), "{err}");
+
+        let err = verifier
+            .check_algorithm(&serde_json::json!({ "alg": "RS256" }))
+            .unwrap_err();
+        assert!(err.to_string().contains("allow-list"), "{err}");
+
+        let err = verifier
+            .check_algorithm(&serde_json::json!({}))
+            .unwrap_err();
+        assert!(matches!(err, SetError::Malformed(_)), "{err:?}");
+
+        assert_eq!(
+            verifier
+                .check_algorithm(&serde_json::json!({ "alg": "HS256" }))
+                .unwrap(),
+            Algorithm::HS256
+        );
+    }
+
+    fn set_with(iat: i64, exp: Option<i64>) -> SecurityEventToken {
+        SecurityEventToken {
+            iss: "https://idp.example.com/".into(),
+            jti: "jti".into(),
+            iat,
+            aud: None,
+            sub: None,
+            sub_id: None,
+            txn: None,
+            toe: None,
+            exp,
+            nbf: None,
+            events: Default::default(),
+            additional: Default::default(),
+        }
+    }
+
+    #[test]
+    fn freshness_honours_leeway_max_age_and_exp() {
+        let verifier = SetVerifier::builder("https://idp.example.com/")
+            .algorithms([Algorithm::HS256])
+            .key(DecodingKey::from_secret(b"secret"))
+            .iat_leeway(Duration::from_secs(10))
+            .max_age(Duration::from_secs(100))
+            .build()
+            .unwrap();
+
+        // Inside the leeway window.
+        assert!(verifier
+            .check_freshness(&set_with(1_010, None), 1_000)
+            .is_ok());
+        // Beyond it.
+        assert!(matches!(
+            verifier.check_freshness(&set_with(1_011, None), 1_000),
+            Err(SetError::IatInFuture { .. })
+        ));
+        // Within max_age + leeway.
+        assert!(verifier
+            .check_freshness(&set_with(890, None), 1_000)
+            .is_ok());
+        assert!(matches!(
+            verifier.check_freshness(&set_with(889, None), 1_000),
+            Err(SetError::TooOld { .. })
+        ));
+        // exp is honoured when present, with the same leeway.
+        assert!(verifier
+            .check_freshness(&set_with(1_000, Some(991)), 1_000)
+            .is_ok());
+        assert!(matches!(
+            verifier.check_freshness(&set_with(1_000, Some(990)), 1_000),
+            Err(SetError::Expired { .. })
+        ));
+    }
+
+    #[test]
+    fn freshness_without_max_age_accepts_arbitrarily_old_sets() {
+        let verifier = verifier();
+        assert!(verifier
+            .check_freshness(&set_with(0, None), 2_000_000_000)
+            .is_ok());
+    }
+
+    #[test]
+    fn issuer_check_compares_exactly() {
+        let verifier = verifier();
+        assert!(verifier.check_issuer(&set_with(0, None)).is_ok());
+
+        let mut other = set_with(0, None);
+        other.iss = "https://evil.example.com/".into();
+        assert!(matches!(
+            verifier.check_issuer(&other),
+            Err(SetError::IssuerMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn audience_check_is_skipped_when_unconfigured() {
+        assert!(verifier().check_audience(&set_with(0, None)).is_ok());
+    }
+
+    #[test]
+    fn map_jwt_error_classifies_by_kind() {
+        use jsonwebtoken::errors::Error;
+        assert!(matches!(
+            map_jwt_error(Error::from(ErrorKind::InvalidToken)),
+            SetError::Malformed(_)
+        ));
+        assert!(matches!(
+            map_jwt_error(Error::from(ErrorKind::InvalidSignature)),
+            SetError::InvalidSignature(_)
+        ));
+        assert!(matches!(
+            map_jwt_error(Error::from(ErrorKind::InvalidAlgorithm)),
+            SetError::DisallowedAlgorithm(_)
+        ));
+        assert!(matches!(
+            map_jwt_error(Error::from(ErrorKind::InvalidKeyFormat)),
+            SetError::DisallowedAlgorithm(_)
+        ));
+        let json_error = serde_json::from_str::<i32>("not a number").unwrap_err();
+        assert!(matches!(
+            map_jwt_error(Error::from(ErrorKind::Json(std::sync::Arc::new(json_error)))),
+            SetError::InvalidClaims(_)
+        ));
+        assert!(matches!(
+            map_jwt_error(Error::from(ErrorKind::MissingRequiredClaim("iss".into()))),
+            SetError::InvalidSignature(_)
+        ));
+    }
+
+    #[test]
+    fn current_unix_time_is_after_2020() {
+        assert!(current_unix_time() > 1_577_836_800);
+    }
+}

--- a/crates/authkestra-ssf/src/verify.rs
+++ b/crates/authkestra-ssf/src/verify.rs
@@ -744,7 +744,9 @@ mod tests {
         ));
         let json_error = serde_json::from_str::<i32>("not a number").unwrap_err();
         assert!(matches!(
-            map_jwt_error(Error::from(ErrorKind::Json(std::sync::Arc::new(json_error)))),
+            map_jwt_error(Error::from(ErrorKind::Json(std::sync::Arc::new(
+                json_error
+            )))),
             SetError::InvalidClaims(_)
         ));
         assert!(matches!(

--- a/crates/authkestra-ssf/src/verify.rs
+++ b/crates/authkestra-ssf/src/verify.rs
@@ -15,6 +15,7 @@ use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde_json::Value;
 use thiserror::Error;
 
+use crate::caep::CaepEvent;
 use crate::error::SetError;
 use crate::keys::{SetKeyResolver, SingleKeyResolver};
 use crate::replay::SetReplayGuard;
@@ -41,6 +42,43 @@ pub enum SetVerifierError {
     /// Neither [`SetVerifierBuilder::key`] nor [`SetVerifierBuilder::key_resolver`] was called.
     #[error("a SET verifier needs either a decoding key or a key resolver")]
     MissingKeySource,
+}
+
+/// A SET that passed every check in [`SetVerifier::verify_at`], together with its decoded events.
+///
+/// The events travel with the token rather than being decoded by the caller afterwards, and that
+/// is the whole point of the type: event-payload decoding is one of the checks that decides
+/// whether a SET is acceptable, so it has to happen *before* the replay slot for `(iss, jti)` is
+/// taken. A caller that received a bare `SecurityEventToken` and then called
+/// [`SecurityEventToken::caep_events`] itself would be rejecting the SET after the verifier had
+/// already recorded it — and RFC 8935 §2 lets the transmitter fix the payload and retransmit
+/// under the same `jti`, which would then be silently swallowed as a replay.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct VerifiedSet {
+    /// The validated token and its claims.
+    pub set: SecurityEventToken,
+    /// Every entry of the token's `events` claim, decoded. Never empty: an empty `events` claim
+    /// is refused as [`SetError::EmptyEvents`] before this is built.
+    pub events: Vec<CaepEvent>,
+}
+
+impl VerifiedSet {
+    /// Pairs a token with its decoded events.
+    ///
+    /// **Exists so consumers can construct one in their own tests** — sealing an output type with
+    /// no way to build it is the problem reported against `authkestra-devsig`'s `DeviceIdentity`
+    /// in [authkestra#282](https://github.com/marcjazz/authkestra/issues/282). It performs **no
+    /// validation and no decoding**: the name is not a promise, and a `VerifiedSet` built here
+    /// has been verified by nobody. Only [`SetVerifier::verify_at`] produces a trustworthy one.
+    pub fn new(set: SecurityEventToken, events: Vec<CaepEvent>) -> Self {
+        Self { set, events }
+    }
+
+    /// Consumes the wrapper, yielding the token and its events.
+    pub fn into_parts(self) -> (SecurityEventToken, Vec<CaepEvent>) {
+        (self.set, self.events)
+    }
 }
 
 /// Validates Security Event Tokens against one transmitter's configuration.
@@ -104,7 +142,7 @@ impl SetVerifier {
     }
 
     /// Verifies `token` against the current system clock.
-    pub async fn verify(&self, token: &str) -> Result<SecurityEventToken, SetError> {
+    pub async fn verify(&self, token: &str) -> Result<VerifiedSet, SetError> {
         self.verify_at(token, current_unix_time()).await
     }
 
@@ -126,9 +164,15 @@ impl SetVerifier {
     ///    depend on them, and the key is resolved for the *configured* issuer rather than the
     ///    token's self-asserted `iss`.
     /// 3. **Claims** — issuer, audience, freshness, non-empty `jti`, non-empty `events`.
-    /// 4. **Replay** — last, so a SET rejected for any other reason does not consume its `jti`
+    /// 4. **Event payloads** — every entry of `events` is decoded here, not by the caller
+    ///    afterwards. A modelled event type whose payload does not conform is an
+    ///    `invalid_request` rejection just like a bad claim, so it has to be discovered before
+    ///    the `jti` is spent; decoding it after this function returned would burn the slot on a
+    ///    SET that is then refused, and RFC 8935 §2 retransmission of the corrected SET under
+    ///    the same `jti` would be swallowed as a replay.
+    /// 5. **Replay** — last, so a SET rejected for any other reason does not consume its `jti`
     ///    and thereby stop a corrected retransmission from being processed.
-    pub async fn verify_at(&self, token: &str, now: i64) -> Result<SecurityEventToken, SetError> {
+    pub async fn verify_at(&self, token: &str, now: i64) -> Result<VerifiedSet, SetError> {
         tracing::debug!(target: "authkestra_ssf", issuer = %self.issuer, "verifying SET");
 
         // --- Step 1: header, typ, alg (raw JSON, pre-`jsonwebtoken`) ---
@@ -172,7 +216,10 @@ impl SetVerifier {
             return Err(reject(SetError::EmptyEvents));
         }
 
-        // --- Step 4: replay ---
+        // --- Step 4: event payloads, before the replay slot is spent ---
+        let events = set.caep_events().map_err(SetError::from).map_err(reject)?;
+
+        // --- Step 5: replay ---
         if let Some(guard) = &self.replay_guard {
             if !guard.check_and_record(&set.jti, &set.iss).await {
                 return Err(reject(SetError::Replay {
@@ -186,10 +233,10 @@ impl SetVerifier {
             target: "authkestra_ssf",
             iss = %set.iss,
             jti = %set.jti,
-            events = set.events.len(),
+            events = events.len(),
             "accepted SET"
         );
-        Ok(set)
+        Ok(VerifiedSet { set, events })
     }
 
     fn check_algorithm(&self, header: &Value) -> Result<Algorithm, SetError> {
@@ -384,12 +431,35 @@ impl SetVerifierBuilder {
 /// Logs every rejection uniformly, so no branch of the algorithm can go unobserved in production
 /// (the workspace `AGENTS.md` tracing Definition of Done).
 fn reject(err: SetError) -> SetError {
-    tracing::warn!(
-        target: "authkestra_ssf",
-        code = %err.code(),
-        error = %err,
-        "rejecting SET"
-    );
+    // The issuer/audience variants are logged with their values as structured fields rather than
+    // through `Display`, because `Display` is what the RFC 8935 §2.3 failure body returns to an
+    // unauthenticated caller and must not disclose the deployment's configuration. Operators
+    // still get the full picture here, where the log is trusted.
+    match &err {
+        SetError::IssuerMismatch { expected, found } => tracing::warn!(
+            target: "authkestra_ssf",
+            code = %err.code(),
+            error = %err,
+            expected_issuer = %expected,
+            found_issuer = %found,
+            "rejecting SET"
+        ),
+        SetError::MissingAudience { expected } | SetError::AudienceMismatch { expected } => {
+            tracing::warn!(
+                target: "authkestra_ssf",
+                code = %err.code(),
+                error = %err,
+                expected_audiences = ?expected,
+                "rejecting SET"
+            )
+        }
+        _ => tracing::warn!(
+            target: "authkestra_ssf",
+            code = %err.code(),
+            error = %err,
+            "rejecting SET"
+        ),
+    }
     err
 }
 

--- a/crates/authkestra-ssf/src/verify.rs
+++ b/crates/authkestra-ssf/src/verify.rs
@@ -125,7 +125,7 @@ impl SetVerifier {
     ///    unverified token are attacker-controlled strings, so no rejection above this line may
     ///    depend on them, and the key is resolved for the *configured* issuer rather than the
     ///    token's self-asserted `iss`.
-    /// 3. **Claims** — issuer, audience, freshness, non-empty `events`.
+    /// 3. **Claims** — issuer, audience, freshness, non-empty `jti`, non-empty `events`.
     /// 4. **Replay** — last, so a SET rejected for any other reason does not consume its `jti`
     ///    and thereby stop a corrected retransmission from being processed.
     pub async fn verify_at(&self, token: &str, now: i64) -> Result<SecurityEventToken, SetError> {
@@ -162,6 +162,12 @@ impl SetVerifier {
         self.check_issuer(&set).map_err(reject)?;
         self.check_audience(&set).map_err(reject)?;
         self.check_freshness(&set, now).map_err(reject)?;
+        // Checked here rather than in the claim model, which only knows `jti` is a string: a
+        // present-but-empty `jti` parses fine and would then silently defeat the replay guard
+        // below, since every such SET from an issuer hashes to the same key.
+        if set.jti.trim().is_empty() {
+            return Err(reject(SetError::EmptyJti));
+        }
         if set.events.is_empty() {
             return Err(reject(SetError::EmptyEvents));
         }

--- a/crates/authkestra-ssf/src/verify.rs
+++ b/crates/authkestra-ssf/src/verify.rs
@@ -431,10 +431,11 @@ impl SetVerifierBuilder {
 /// Logs every rejection uniformly, so no branch of the algorithm can go unobserved in production
 /// (the workspace `AGENTS.md` tracing Definition of Done).
 fn reject(err: SetError) -> SetError {
-    // The issuer/audience variants are logged with their values as structured fields rather than
-    // through `Display`, because `Display` is what the RFC 8935 §2.3 failure body returns to an
-    // unauthenticated caller and must not disclose the deployment's configuration. Operators
-    // still get the full picture here, where the log is trusted.
+    // The issuer, audience and freshness variants are logged with their values as structured
+    // fields rather than through `Display`, because `Display` is what the RFC 8935 §2.3 failure
+    // body returns to an unauthenticated caller and must not disclose the deployment's
+    // configuration — its trusted issuer, its audience identifiers, its clock leeway or its
+    // maximum accepted age. Operators still get the full picture here, where the log is trusted.
     match &err {
         SetError::IssuerMismatch { expected, found } => tracing::warn!(
             target: "authkestra_ssf",
@@ -453,6 +454,24 @@ fn reject(err: SetError) -> SetError {
                 "rejecting SET"
             )
         }
+        SetError::IatInFuture { iat, now, leeway } => tracing::warn!(
+            target: "authkestra_ssf",
+            code = %err.code(),
+            error = %err,
+            iat = iat,
+            now = now,
+            leeway_secs = leeway,
+            "rejecting SET"
+        ),
+        SetError::TooOld { iat, now, max_age } => tracing::warn!(
+            target: "authkestra_ssf",
+            code = %err.code(),
+            error = %err,
+            iat = iat,
+            now = now,
+            max_age_secs = max_age,
+            "rejecting SET"
+        ),
         _ => tracing::warn!(
             target: "authkestra_ssf",
             code = %err.code(),

--- a/crates/authkestra-ssf/tests/conformance.rs
+++ b/crates/authkestra-ssf/tests/conformance.rs
@@ -1245,6 +1245,81 @@ async fn failure_bodies_do_not_disclose_the_configured_issuer_or_audience() {
     }
 }
 
+#[tokio::test]
+async fn failure_bodies_do_not_disclose_the_configured_freshness_policy() {
+    // The sibling of `failure_bodies_do_not_disclose_the_configured_issuer_or_audience`, for the
+    // other two settings that used to reach the unauthenticated RFC 8935 §2.3 `description`: how
+    // much clock skew this receiver tolerates, and how old a SET it will still accept. Both are
+    // deployment policy, and knowing them tells a prober exactly which `iat` values slip through.
+    const LEEWAY_SECS: u64 = 37;
+    const MAX_AGE_SECS: u64 = 91;
+
+    let verifier = SetVerifier::builder(ISSUER)
+        .audience(AUDIENCE)
+        .algorithms([Algorithm::HS256])
+        .key(decoding_key())
+        .iat_leeway(Duration::from_secs(LEEWAY_SECS))
+        .max_age(Duration::from_secs(MAX_AGE_SECS))
+        .build()
+        .unwrap();
+    let receiver = PushReceiver::new(Arc::new(verifier));
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    let cases: Vec<(&str, String)> = vec![
+        (
+            "iat beyond the leeway",
+            sign(&with_claim(
+                session_revoked_claims(),
+                "iat",
+                json!(now + LEEWAY_SECS as i64 + 60),
+            )),
+        ),
+        (
+            "iat older than the maximum age",
+            sign(&with_claim(
+                session_revoked_claims(),
+                "iat",
+                json!(now - (MAX_AGE_SECS + LEEWAY_SECS) as i64 - 60),
+            )),
+        ),
+    ];
+
+    for (label, token) in cases {
+        let response = receiver
+            .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+            .await;
+        assert_eq!(response.status(), 400, "{label}");
+        assert_eq!(
+            response.error_code(),
+            Some(SetErrorCode::InvalidRequest),
+            "{label}"
+        );
+
+        let body = String::from_utf8(response.body().to_vec()).expect("the body is UTF-8 JSON");
+        for (what, secret) in [
+            ("leeway", LEEWAY_SECS.to_string()),
+            ("maximum age", MAX_AGE_SECS.to_string()),
+        ] {
+            assert!(
+                !body.contains(&secret),
+                "{label}: the failure body leaked the configured {what} ({secret}): {body}"
+            );
+        }
+
+        // Still a usable failure response: the registered code and a non-empty description.
+        let parsed = error_body(&response);
+        assert_eq!(parsed["err"], "invalid_request", "{label}");
+        assert!(
+            !parsed["description"].as_str().unwrap().is_empty(),
+            "{label}"
+        );
+    }
+}
+
 #[test]
 fn the_redacted_errors_still_carry_their_values_for_the_caller() {
     // Redaction is on `Display` only. A caller driving `SetVerifier` directly — and the crate's
@@ -1275,6 +1350,28 @@ fn the_redacted_errors_still_carry_their_values_for_the_caller() {
         expected: vec![AUDIENCE.to_string()],
     };
     assert!(!err.to_string().contains(AUDIENCE));
+
+    let err = SetError::IatInFuture {
+        iat: NOW + 900,
+        now: NOW,
+        leeway: 37,
+    };
+    match &err {
+        SetError::IatInFuture { leeway, .. } => assert_eq!(*leeway, 37),
+        other => panic!("unexpected variant {other:?}"),
+    }
+    assert!(!err.to_string().contains("37"));
+
+    let err = SetError::TooOld {
+        iat: NOW - 900,
+        now: NOW,
+        max_age: 91,
+    };
+    match &err {
+        SetError::TooOld { max_age, .. } => assert_eq!(*max_age, 91),
+        other => panic!("unexpected variant {other:?}"),
+    }
+    assert!(!err.to_string().contains("91"));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/authkestra-ssf/tests/conformance.rs
+++ b/crates/authkestra-ssf/tests/conformance.rs
@@ -17,11 +17,13 @@ use jsonwebtoken::{Algorithm, DecodingKey};
 use serde_json::json;
 
 use authkestra_ssf::{
-    AssuranceLevel, CaepEvent, ChangeDirection, ChangeType, ComplianceStatus, CredentialType,
-    HandlerError, InMemorySetReplayGuard, InitiatingEntity, LoggingHandler, PushReceiver,
-    PushResponse, SecurityEventToken, SetError, SetErrorCode, SetHandler, SetVerifier,
-    StaticKeyResolver, SubjectIdentifier, EVENT_TYPE_ASSURANCE_LEVEL_CHANGE,
-    EVENT_TYPE_CREDENTIAL_CHANGE, EVENT_TYPE_DEVICE_COMPLIANCE_CHANGE, EVENT_TYPE_SESSION_REVOKED,
+    AssuranceLevel, AssuranceLevelChange, CaepEvent, CaepMetadata, ChangeDirection, ChangeType,
+    ComplianceStatus, CredentialChange, CredentialType, DeviceComplianceChange, HandlerError,
+    InMemorySetReplayGuard, InitiatingEntity, LoggingHandler, PushReceiver, PushResponse,
+    SecurityEventToken, SessionRevoked, SetError, SetErrorCode, SetHandler, SetVerifier,
+    StaticKeyResolver, SubjectIdentifier, TokenClaimsChange, DEFAULT_MAX_BODY_BYTES,
+    EVENT_TYPE_ASSURANCE_LEVEL_CHANGE, EVENT_TYPE_CREDENTIAL_CHANGE,
+    EVENT_TYPE_DEVICE_COMPLIANCE_CHANGE, EVENT_TYPE_SESSION_REVOKED,
     EVENT_TYPE_TOKEN_CLAIMS_CHANGE, SET_MEDIA_TYPE,
 };
 
@@ -885,4 +887,172 @@ async fn the_verifier_is_debug_printable_without_leaking_keys() {
 fn decoding_key_helper_is_usable_standalone() {
     // Guards against the fixture drifting from `DecodingKey::from_secret`.
     let _: DecodingKey = decoding_key();
+}
+
+// ---------------------------------------------------------------------------
+// Consumer ergonomics: every `#[non_exhaustive]` model must still be buildable
+// from *outside* this crate, or a downstream service cannot unit-test the code
+// that maps these types onto its own domain (authkestra#282).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_consumer_can_construct_every_public_model() {
+    let mut events = std::collections::BTreeMap::new();
+    events.insert(EVENT_TYPE_SESSION_REVOKED.to_string(), json!({}));
+    let mut set = SecurityEventToken::new(ISSUER, "jti-1", NOW, events);
+    set.sub_id = Some(SubjectIdentifier::Email {
+        email: "user@example.com".to_string(),
+    });
+    assert_eq!(set.iss, ISSUER);
+    assert_eq!(set.jti, "jti-1");
+    assert_eq!(set.iat, NOW);
+    assert!(set.contains_event(EVENT_TYPE_SESSION_REVOKED));
+    assert!(set.aud.is_none());
+
+    let mut metadata = CaepMetadata::empty();
+    metadata.event_timestamp = Some(NOW);
+    metadata.initiating_entity = Some(InitiatingEntity::Policy);
+    assert_eq!(metadata.event_timestamp, Some(NOW));
+
+    let mut revoked = SessionRevoked::default();
+    revoked.metadata = metadata.clone();
+    assert_eq!(
+        revoked.metadata.initiating_entity,
+        Some(InitiatingEntity::Policy)
+    );
+
+    let mut claims = serde_json::Map::new();
+    claims.insert("role".to_string(), json!("ro-admin"));
+    let mut token_claims_change = TokenClaimsChange::new(claims);
+    token_claims_change.metadata = metadata.clone();
+    assert_eq!(token_claims_change.claims["role"], "ro-admin");
+
+    let mut credential_change = CredentialChange::new(CredentialType::Password, ChangeType::Update);
+    credential_change.friendly_name = Some("Work laptop".to_string());
+    assert_eq!(credential_change.change_type, ChangeType::Update);
+    assert!(credential_change.x509_issuer.is_none());
+
+    let assurance_change = AssuranceLevelChange::new(
+        AssuranceLevel::Aal1,
+        AssuranceLevel::Aal2,
+        ChangeDirection::Decrease,
+    );
+    assert_eq!(assurance_change.current_level, AssuranceLevel::Aal1);
+
+    let compliance_change =
+        DeviceComplianceChange::new(ComplianceStatus::Compliant, ComplianceStatus::NotCompliant);
+    assert_eq!(
+        compliance_change.current_status,
+        ComplianceStatus::NotCompliant
+    );
+
+    // The constructed values still round-trip through serde, so a consumer can use them as
+    // fixtures for its own wire-level tests.
+    for value in [
+        serde_json::to_value(&revoked).unwrap(),
+        serde_json::to_value(&token_claims_change).unwrap(),
+        serde_json::to_value(&credential_change).unwrap(),
+        serde_json::to_value(&assurance_change).unwrap(),
+        serde_json::to_value(&compliance_change).unwrap(),
+        serde_json::to_value(&set).unwrap(),
+    ] {
+        assert!(value.is_object());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// jti must actually identify something (RFC 8417 section 2.2)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn rejects_an_empty_or_whitespace_only_jti() {
+    for jti in ["", " ", "\t\n  "] {
+        let token = sign(&with_claim(session_revoked_claims(), "jti", json!(jti)));
+        let err = verifier().verify_at(&token, NOW).await.unwrap_err();
+        assert_eq!(err, SetError::EmptyJti, "jti {jti:?} must be refused");
+        assert_eq!(err.code(), SetErrorCode::InvalidRequest);
+    }
+}
+
+#[tokio::test]
+async fn an_empty_jti_cannot_poison_the_replay_guard() {
+    // The point of the check: without it, the first empty-jti SET would occupy the issuer's
+    // only "" slot and every later one would look like a replay.
+    let verifier = SetVerifier::builder(ISSUER)
+        .audience(AUDIENCE)
+        .algorithms([Algorithm::HS256])
+        .key(decoding_key())
+        .replay_guard(Arc::new(InMemorySetReplayGuard::new(Duration::from_secs(
+            3600,
+        ))))
+        .build()
+        .unwrap();
+
+    let empty = sign(&with_claim(session_revoked_claims(), "jti", json!("")));
+    assert_eq!(
+        verifier.verify_at(&empty, NOW).await.unwrap_err(),
+        SetError::EmptyJti
+    );
+
+    let good = sign(&session_revoked_claims());
+    assert!(verifier.verify_at(&good, NOW).await.is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// Body size cap
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn the_body_cap_accepts_exactly_the_limit_and_refuses_one_byte_more() {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let token = sign(&with_claim(session_revoked_claims(), "iat", json!(now)));
+    let len = token.len();
+
+    let at_limit = PushReceiver::new(Arc::new(verifier())).with_max_body_bytes(len);
+    let response = at_limit
+        .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+        .await;
+    assert_eq!(
+        response.status(),
+        202,
+        "a body of exactly max_body_bytes must be accepted"
+    );
+
+    let one_short = PushReceiver::new(Arc::new(verifier())).with_max_body_bytes(len - 1);
+    let response = one_short
+        .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+        .await;
+    assert_eq!(response.status(), 400);
+    assert_eq!(response.error_code(), Some(SetErrorCode::InvalidRequest));
+    assert_eq!(error_body(&response)["err"], "invalid_request");
+    assert!(error_body(&response)["description"]
+        .as_str()
+        .unwrap()
+        .contains("exceeds the maximum"));
+}
+
+#[tokio::test]
+async fn the_default_body_cap_lets_a_real_set_through() {
+    let receiver = PushReceiver::new(Arc::new(verifier()));
+    assert_eq!(receiver.max_body_bytes(), DEFAULT_MAX_BODY_BYTES);
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let token = sign(&with_claim(session_revoked_claims(), "iat", json!(now)));
+    assert!(token.len() < DEFAULT_MAX_BODY_BYTES);
+    assert!(receiver
+        .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+        .await
+        .is_accepted());
+
+    // A body over the default is refused without the verifier ever being consulted.
+    let oversized = vec![b'a'; DEFAULT_MAX_BODY_BYTES + 1];
+    let response = receiver.receive(Some(SET_MEDIA_TYPE), &oversized).await;
+    assert_eq!(response.status(), 400);
+    assert_eq!(response.error_code(), Some(SetErrorCode::InvalidRequest));
 }

--- a/crates/authkestra-ssf/tests/conformance.rs
+++ b/crates/authkestra-ssf/tests/conformance.rs
@@ -1397,3 +1397,194 @@ async fn a_verified_set_carries_its_decoded_events() {
     assert_eq!(set.iss, ISSUER);
     assert_eq!(events.len(), 1);
 }
+
+// ---------------------------------------------------------------------------
+// A handler failure must give the replay slot back (PR #309 re-review, P1)
+// ---------------------------------------------------------------------------
+
+/// A handler that fails for the first `fail_first` calls and succeeds afterwards, recording every
+/// event it was handed. Models the realistic case: the datastore is down, the transmitter
+/// retries, the datastore is back.
+struct FlakyHandler {
+    fail_first: AtomicUsize,
+    seen: Mutex<Vec<String>>,
+}
+
+impl FlakyHandler {
+    fn failing_once() -> Self {
+        Self {
+            fail_first: AtomicUsize::new(1),
+            seen: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.seen.lock().unwrap().len()
+    }
+}
+
+#[async_trait]
+impl SetHandler for FlakyHandler {
+    async fn handle(
+        &self,
+        _set: &SecurityEventToken,
+        event: &CaepEvent,
+    ) -> Result<(), HandlerError> {
+        self.seen
+            .lock()
+            .unwrap()
+            .push(event.event_type_uri().to_string());
+        if self
+            .fail_first
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(HandlerError::Internal("session store unreachable".into()));
+        }
+        Ok(())
+    }
+}
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+#[tokio::test]
+async fn a_handler_failure_releases_the_slot_so_the_retry_is_dispatched() {
+    // The bug this guards: the replay slot is taken during verification, so if a handler fails
+    // after that point and the receiver answers 500, the transmitter's retry (RFC 8935 §4) would
+    // hit the recorded slot, be acknowledged 202 as a duplicate, and the event would never be
+    // processed by anyone.
+    let handler = Arc::new(FlakyHandler::failing_once());
+    let guard = Arc::new(InMemorySetReplayGuard::new(Duration::from_secs(3600)));
+    let verifier = SetVerifier::builder(ISSUER)
+        .audience(AUDIENCE)
+        .algorithms([Algorithm::HS256])
+        .key(decoding_key())
+        .replay_guard(guard.clone())
+        .build()
+        .unwrap();
+    let receiver = PushReceiver::new(Arc::new(verifier)).with_handler(handler.clone());
+
+    let token = sign(&with_claim(
+        session_revoked_claims(),
+        "iat",
+        json!(now_secs()),
+    ));
+
+    let first = receiver
+        .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+        .await;
+    assert_eq!(first.status(), 500, "a handler failure asks for a retry");
+    assert_eq!(first.error_code(), None);
+    assert_eq!(handler.calls(), 1);
+    assert!(
+        guard.is_empty(),
+        "the slot must be given back before the 500, or the retry cannot be dispatched"
+    );
+
+    // The retransmission: byte-for-byte the same SET, same jti.
+    let retry = receiver
+        .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+        .await;
+    assert_eq!(retry.status(), 202);
+    // *This* is the load-bearing assertion. Without the release, the retry is still answered 202
+    // — by the replay path, with the handler never invoked and the event silently dropped.
+    assert_eq!(
+        handler.calls(),
+        2,
+        "the retry must actually reach the handler, not be swallowed as a duplicate"
+    );
+    assert_eq!(
+        handler.seen.lock().unwrap().as_slice(),
+        [EVENT_TYPE_SESSION_REVOKED, EVENT_TYPE_SESSION_REVOKED]
+    );
+    assert_eq!(
+        guard.len(),
+        1,
+        "a delivery that succeeded must leave the slot recorded"
+    );
+
+    // And once it has succeeded, the slot is held again: a third delivery is a real duplicate.
+    let third = receiver
+        .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+        .await;
+    assert_eq!(third.status(), 202);
+    assert_eq!(
+        handler.calls(),
+        2,
+        "a duplicate after a successful delivery must not re-dispatch"
+    );
+}
+
+#[tokio::test]
+async fn a_rejected_event_keeps_the_slot() {
+    // The other half of the decision: a 400 tells the transmitter not to retry, so nothing is
+    // waiting on the slot and a re-send of an already-refused SET must not run the handlers again.
+    let handler = Arc::new(FailingHandler {
+        error: HandlerError::Rejected("unknown tenant".to_string()),
+        calls: AtomicUsize::new(0),
+    });
+    let receiver =
+        PushReceiver::new(Arc::new(verifier_with_replay_guard())).with_handler(handler.clone());
+
+    let token = sign(&with_claim(
+        session_revoked_claims(),
+        "iat",
+        json!(now_secs()),
+    ));
+
+    let first = receiver
+        .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+        .await;
+    assert_eq!(first.status(), 400);
+    assert_eq!(first.error_code(), Some(SetErrorCode::AccessDenied));
+    assert_eq!(handler.calls.load(Ordering::SeqCst), 1);
+
+    let resend = receiver
+        .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+        .await;
+    assert_eq!(
+        resend.status(),
+        202,
+        "the slot was kept, so this is a duplicate"
+    );
+    assert_eq!(
+        handler.calls.load(Ordering::SeqCst),
+        1,
+        "a rejected SET must not be dispatched again"
+    );
+}
+
+#[tokio::test]
+async fn releasing_a_slot_that_was_never_taken_is_harmless() {
+    // Two shapes of "unknown": a verifier with a guard that has no such entry, and a verifier
+    // with no guard configured at all.
+    let guarded = verifier_with_replay_guard();
+    guarded.release_replay_slot("never-recorded", ISSUER).await;
+
+    let token = sign(&session_revoked_claims());
+    assert!(
+        guarded.verify_at(&token, NOW).await.is_ok(),
+        "a spurious release must not disturb the guard"
+    );
+    guarded
+        .release_replay_slot("24c63fb56e5a2d77a6b512616ca9fa24", "https://someone-else/")
+        .await;
+    assert!(
+        matches!(
+            guarded.verify_at(&token, NOW).await,
+            Err(SetError::Replay { .. })
+        ),
+        "releasing a different issuer's entry must not free this one"
+    );
+
+    let guardless = verifier();
+    guardless.release_replay_slot("anything", ISSUER).await;
+    assert!(guardless.verify_at(&token, NOW).await.is_ok());
+}

--- a/crates/authkestra-ssf/tests/conformance.rs
+++ b/crates/authkestra-ssf/tests/conformance.rs
@@ -1,0 +1,888 @@
+//! End-to-end conformance suite for SET ingestion (RFC 8417), CAEP 1.0 event decoding, and
+//! RFC 8935 push delivery.
+//!
+//! Every test here drives the public API only — mint a token with the fixture transmitter in
+//! [`support`], hand it to a verifier or a receiver, and assert on the outcome a specification
+//! paragraph requires. Where a test encodes a specific normative sentence, the citation is in
+//! the test's own comment.
+
+mod support;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use jsonwebtoken::{Algorithm, DecodingKey};
+use serde_json::json;
+
+use authkestra_ssf::{
+    AssuranceLevel, CaepEvent, ChangeDirection, ChangeType, ComplianceStatus, CredentialType,
+    HandlerError, InMemorySetReplayGuard, InitiatingEntity, LoggingHandler, PushReceiver,
+    PushResponse, SecurityEventToken, SetError, SetErrorCode, SetHandler, SetVerifier,
+    StaticKeyResolver, SubjectIdentifier, EVENT_TYPE_ASSURANCE_LEVEL_CHANGE,
+    EVENT_TYPE_CREDENTIAL_CHANGE, EVENT_TYPE_DEVICE_COMPLIANCE_CHANGE, EVENT_TYPE_SESSION_REVOKED,
+    EVENT_TYPE_TOKEN_CLAIMS_CHANGE, SET_MEDIA_TYPE,
+};
+
+use support::{
+    decoding_key, session_revoked_claims, sign, sign_with, tamper_signature, unsecured, with_claim,
+    with_events, AUDIENCE, ISSUER, NOW,
+};
+
+/// A verifier with the audience check on and no replay guard.
+fn verifier() -> SetVerifier {
+    SetVerifier::builder(ISSUER)
+        .audience(AUDIENCE)
+        .algorithms([Algorithm::HS256])
+        .key(decoding_key())
+        .build()
+        .expect("fixture verifier configuration is complete")
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn accepts_a_well_formed_set() {
+    let token = sign(&session_revoked_claims());
+    let set = verifier()
+        .verify_at(&token, NOW)
+        .await
+        .expect("a conformant SET must be accepted");
+
+    assert_eq!(set.iss, ISSUER);
+    assert_eq!(set.jti, "24c63fb56e5a2d77a6b512616ca9fa24");
+    assert_eq!(set.iat, NOW);
+    assert!(set.aud.as_ref().unwrap().contains(AUDIENCE));
+    assert!(set.contains_event(EVENT_TYPE_SESSION_REVOKED));
+    // RFC 8417 §2.2: `exp` is NOT RECOMMENDED, so its absence is not an error.
+    assert!(set.exp.is_none());
+}
+
+#[tokio::test]
+async fn accepts_the_full_media_type_spelling_of_typ() {
+    // RFC 8417 §2.3 says the `application/` prefix SHOULD be omitted — "should", not "must".
+    let token = sign_with(
+        Some("application/secevent+jwt"),
+        Algorithm::HS256,
+        None,
+        &session_revoked_claims(),
+    );
+    assert!(verifier().verify_at(&token, NOW).await.is_ok());
+}
+
+#[tokio::test]
+async fn accepts_a_set_without_aud_when_no_audience_is_configured() {
+    let claims = with_claim(session_revoked_claims(), "aud", json!(null));
+    let token = sign(&claims);
+
+    let verifier = SetVerifier::builder(ISSUER)
+        .algorithms([Algorithm::HS256])
+        .key(decoding_key())
+        .build()
+        .unwrap();
+    assert!(verifier.verify_at(&token, NOW).await.is_ok());
+}
+
+#[tokio::test]
+async fn accepts_an_audience_array_containing_the_expected_value() {
+    let claims = with_claim(
+        session_revoked_claims(),
+        "aud",
+        json!(["https://other.example.com/", AUDIENCE]),
+    );
+    let token = sign(&claims);
+    assert!(verifier().verify_at(&token, NOW).await.is_ok());
+}
+
+#[tokio::test]
+async fn verify_uses_the_system_clock() {
+    // `verify` differs from `verify_at` only in where "now" comes from; mint a SET at the real
+    // current time to prove that path is wired up.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let claims = with_claim(session_revoked_claims(), "iat", json!(now));
+    let token = sign(&claims);
+    assert!(verifier().verify(&token).await.is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// Explicit typing (RFC 8417 §2.3)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn rejects_a_missing_typ_header() {
+    let token = sign_with(None, Algorithm::HS256, None, &session_revoked_claims());
+    let err = verifier().verify_at(&token, NOW).await.unwrap_err();
+    assert!(matches!(err, SetError::MissingType), "{err:?}");
+    assert_eq!(err.code(), SetErrorCode::InvalidRequest);
+}
+
+#[tokio::test]
+async fn rejects_a_wrong_typ_header() {
+    // An ID Token presented as a SET is exactly the confusion RFC 8417 §4.1 warns about.
+    let token = sign_with(
+        Some("JWT"),
+        Algorithm::HS256,
+        None,
+        &session_revoked_claims(),
+    );
+    let err = verifier().verify_at(&token, NOW).await.unwrap_err();
+    assert_eq!(err, SetError::UnexpectedType("JWT".to_string()));
+}
+
+// ---------------------------------------------------------------------------
+// Signature and algorithm
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn rejects_a_tampered_signature() {
+    let token = tamper_signature(&sign(&session_revoked_claims()));
+    let err = verifier().verify_at(&token, NOW).await.unwrap_err();
+    assert!(matches!(err, SetError::InvalidSignature(_)), "{err:?}");
+    assert_eq!(err.code(), SetErrorCode::AuthenticationFailed);
+}
+
+#[tokio::test]
+async fn rejects_an_unsecured_jwt() {
+    // RFC 8417 §2.4's own worked example is an unsecured JWT. Accepting one would make every
+    // other check in this suite decorative.
+    let token = unsecured(&session_revoked_claims());
+    let err = verifier().verify_at(&token, NOW).await.unwrap_err();
+    match &err {
+        SetError::DisallowedAlgorithm(message) => assert!(message.contains("none"), "{message}"),
+        other => panic!("expected DisallowedAlgorithm, got {other:?}"),
+    }
+    assert_eq!(err.code(), SetErrorCode::InvalidKey);
+}
+
+#[tokio::test]
+async fn rejects_an_algorithm_outside_the_allow_list() {
+    let token = sign_with(
+        Some("secevent+jwt"),
+        Algorithm::HS384,
+        None,
+        &session_revoked_claims(),
+    );
+    let err = verifier().verify_at(&token, NOW).await.unwrap_err();
+    match &err {
+        SetError::DisallowedAlgorithm(message) => {
+            assert!(message.contains("allow-list"), "{message}")
+        }
+        other => panic!("expected DisallowedAlgorithm, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rejects_a_garbage_body() {
+    let err = verifier().verify_at("not-a-jwt", NOW).await.unwrap_err();
+    assert!(matches!(err, SetError::Malformed(_)), "{err:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Key resolution by kid
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn resolves_the_key_by_kid() {
+    let resolver = Arc::new(StaticKeyResolver::new().with_key("k1", decoding_key()));
+    let verifier = SetVerifier::builder(ISSUER)
+        .audience(AUDIENCE)
+        .algorithms([Algorithm::HS256])
+        .key_resolver(resolver)
+        .build()
+        .unwrap();
+
+    let token = sign_with(
+        Some("secevent+jwt"),
+        Algorithm::HS256,
+        Some("k1"),
+        &session_revoked_claims(),
+    );
+    assert!(verifier.verify_at(&token, NOW).await.is_ok());
+
+    let token = sign_with(
+        Some("secevent+jwt"),
+        Algorithm::HS256,
+        Some("k2"),
+        &session_revoked_claims(),
+    );
+    let err = verifier.verify_at(&token, NOW).await.unwrap_err();
+    assert!(matches!(err, SetError::KeyResolution(_)), "{err:?}");
+    assert_eq!(err.code(), SetErrorCode::InvalidKey);
+}
+
+// ---------------------------------------------------------------------------
+// Issuer and audience (RFC 8935 §2)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn rejects_an_unrecognised_issuer() {
+    let claims = with_claim(
+        session_revoked_claims(),
+        "iss",
+        json!("https://evil.example.com/"),
+    );
+    let token = sign(&claims);
+    let err = verifier().verify_at(&token, NOW).await.unwrap_err();
+    assert_eq!(
+        err,
+        SetError::IssuerMismatch {
+            expected: ISSUER.to_string(),
+            found: "https://evil.example.com/".to_string(),
+        }
+    );
+    assert_eq!(err.code(), SetErrorCode::InvalidIssuer);
+}
+
+#[tokio::test]
+async fn rejects_a_set_addressed_to_someone_else() {
+    let claims = with_claim(
+        session_revoked_claims(),
+        "aud",
+        json!("https://other.example.com/caep"),
+    );
+    let token = sign(&claims);
+    let err = verifier().verify_at(&token, NOW).await.unwrap_err();
+    assert!(matches!(err, SetError::AudienceMismatch { .. }), "{err:?}");
+    assert_eq!(err.code(), SetErrorCode::InvalidAudience);
+}
+
+#[tokio::test]
+async fn rejects_a_missing_aud_when_an_audience_is_configured() {
+    let claims = with_claim(session_revoked_claims(), "aud", json!(null));
+    let token = sign(&claims);
+    let err = verifier().verify_at(&token, NOW).await.unwrap_err();
+    assert!(matches!(err, SetError::MissingAudience { .. }), "{err:?}");
+    assert_eq!(err.code(), SetErrorCode::InvalidAudience);
+}
+
+// ---------------------------------------------------------------------------
+// Freshness
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn rejects_an_iat_beyond_the_leeway_but_accepts_one_inside_it() {
+    let verifier = SetVerifier::builder(ISSUER)
+        .audience(AUDIENCE)
+        .algorithms([Algorithm::HS256])
+        .key(decoding_key())
+        .iat_leeway(Duration::from_secs(30))
+        .build()
+        .unwrap();
+
+    let inside = sign(&with_claim(
+        session_revoked_claims(),
+        "iat",
+        json!(NOW + 30),
+    ));
+    assert!(verifier.verify_at(&inside, NOW).await.is_ok());
+
+    let beyond = sign(&with_claim(
+        session_revoked_claims(),
+        "iat",
+        json!(NOW + 31),
+    ));
+    let err = verifier.verify_at(&beyond, NOW).await.unwrap_err();
+    assert!(matches!(err, SetError::IatInFuture { .. }), "{err:?}");
+}
+
+#[tokio::test]
+async fn rejects_a_set_older_than_the_configured_maximum_age() {
+    let verifier = SetVerifier::builder(ISSUER)
+        .audience(AUDIENCE)
+        .algorithms([Algorithm::HS256])
+        .key(decoding_key())
+        .iat_leeway(Duration::from_secs(0))
+        .max_age(Duration::from_secs(60))
+        .build()
+        .unwrap();
+
+    let token = sign(&with_claim(
+        session_revoked_claims(),
+        "iat",
+        json!(NOW - 61),
+    ));
+    let err = verifier.verify_at(&token, NOW).await.unwrap_err();
+    assert!(matches!(err, SetError::TooOld { .. }), "{err:?}");
+}
+
+#[tokio::test]
+async fn honours_exp_when_a_transmitter_sends_one() {
+    let verifier = SetVerifier::builder(ISSUER)
+        .audience(AUDIENCE)
+        .algorithms([Algorithm::HS256])
+        .key(decoding_key())
+        .iat_leeway(Duration::from_secs(0))
+        .build()
+        .unwrap();
+
+    let token = sign(&with_claim(session_revoked_claims(), "exp", json!(NOW - 1)));
+    let err = verifier.verify_at(&token, NOW).await.unwrap_err();
+    assert!(matches!(err, SetError::Expired { .. }), "{err:?}");
+
+    let token = sign(&with_claim(session_revoked_claims(), "exp", json!(NOW + 1)));
+    assert!(verifier.verify_at(&token, NOW).await.is_ok());
+}
+
+#[tokio::test]
+async fn accepts_and_ignores_an_nbf_claim() {
+    // RFC 8417 never profiles `nbf`. A SET carrying one — even a wildly future one — is not
+    // thereby invalid, and the claim is still surfaced to the caller.
+    let token = sign(&with_claim(
+        session_revoked_claims(),
+        "nbf",
+        json!(NOW + 86_400),
+    ));
+    let set = verifier().verify_at(&token, NOW).await.unwrap();
+    assert_eq!(set.nbf, Some(NOW + 86_400));
+}
+
+// ---------------------------------------------------------------------------
+// Claims profile
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn rejects_an_empty_events_claim() {
+    let token = sign(&with_events(session_revoked_claims(), json!({})));
+    let err = verifier().verify_at(&token, NOW).await.unwrap_err();
+    assert_eq!(err, SetError::EmptyEvents);
+    assert_eq!(err.code(), SetErrorCode::InvalidRequest);
+}
+
+#[tokio::test]
+async fn rejects_a_set_missing_a_required_claim() {
+    for missing in ["iss", "jti", "iat", "events"] {
+        let token = sign(&with_claim(session_revoked_claims(), missing, json!(null)));
+        let err = verifier().verify_at(&token, NOW).await.unwrap_err();
+        match &err {
+            SetError::InvalidClaims(message) => assert!(message.contains(missing), "{message}"),
+            // A missing `iss` is caught by the claim parser, not the issuer check, because the
+            // claim is not optional in the model.
+            other => panic!("expected InvalidClaims for {missing}, got {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn parses_the_sub_id_claim() {
+    let claims = with_claim(
+        session_revoked_claims(),
+        "sub_id",
+        json!({ "format": "iss_sub", "iss": ISSUER, "sub": "145234573" }),
+    );
+    let set = verifier().verify_at(&sign(&claims), NOW).await.unwrap();
+    assert_eq!(
+        set.sub_id,
+        Some(SubjectIdentifier::IssSub {
+            iss: ISSUER.to_string(),
+            sub: "145234573".to_string(),
+        })
+    );
+}
+
+#[tokio::test]
+async fn rejects_a_malformed_sub_id_claim() {
+    let claims = with_claim(
+        session_revoked_claims(),
+        "sub_id",
+        json!({ "email": "a@b" }),
+    );
+    let err = verifier().verify_at(&sign(&claims), NOW).await.unwrap_err();
+    assert!(matches!(err, SetError::InvalidClaims(_)), "{err:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Replay (RFC 8417 §2.2)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn detects_a_replayed_jti() {
+    let verifier = SetVerifier::builder(ISSUER)
+        .audience(AUDIENCE)
+        .algorithms([Algorithm::HS256])
+        .key(decoding_key())
+        .replay_guard(Arc::new(InMemorySetReplayGuard::new(Duration::from_secs(
+            3600,
+        ))))
+        .build()
+        .unwrap();
+
+    let token = sign(&session_revoked_claims());
+    assert!(verifier.verify_at(&token, NOW).await.is_ok());
+
+    let err = verifier.verify_at(&token, NOW).await.unwrap_err();
+    assert_eq!(
+        err,
+        SetError::Replay {
+            jti: "24c63fb56e5a2d77a6b512616ca9fa24".to_string(),
+            iss: ISSUER.to_string(),
+        }
+    );
+}
+
+#[tokio::test]
+async fn a_rejected_set_does_not_consume_its_jti() {
+    // The replay guard runs last precisely so that a SET rejected for some other reason can be
+    // corrected and retransmitted under the same jti.
+    let verifier = SetVerifier::builder(ISSUER)
+        .audience(AUDIENCE)
+        .algorithms([Algorithm::HS256])
+        .key(decoding_key())
+        .replay_guard(Arc::new(InMemorySetReplayGuard::new(Duration::from_secs(
+            3600,
+        ))))
+        .build()
+        .unwrap();
+
+    let bad = sign_with(
+        Some("JWT"),
+        Algorithm::HS256,
+        None,
+        &session_revoked_claims(),
+    );
+    assert!(verifier.verify_at(&bad, NOW).await.is_err());
+
+    let good = sign(&session_revoked_claims());
+    assert!(
+        verifier.verify_at(&good, NOW).await.is_ok(),
+        "the same jti must still be accepted after an unrelated rejection"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CAEP event decoding, end to end
+// ---------------------------------------------------------------------------
+
+async fn decode_single_event(events: serde_json::Value) -> CaepEvent {
+    let token = sign(&with_events(session_revoked_claims(), events));
+    let set = verifier()
+        .verify_at(&token, NOW)
+        .await
+        .expect("fixture SET must verify");
+    let mut decoded = set.caep_events().expect("event payloads must decode");
+    assert_eq!(decoded.len(), 1);
+    decoded.remove(0)
+}
+
+#[tokio::test]
+async fn decodes_every_modelled_caep_event_type() {
+    let event = decode_single_event(json!({
+        EVENT_TYPE_SESSION_REVOKED: {
+            "subject": { "format": "email", "email": "user@example.com" },
+            "initiating_entity": "admin",
+            "reason_admin": { "en": "Compromised credentials" }
+        }
+    }))
+    .await;
+    let CaepEvent::SessionRevoked(revoked) = &event else {
+        panic!("expected SessionRevoked, got {event:?}");
+    };
+    assert_eq!(
+        revoked.metadata.initiating_entity,
+        Some(InitiatingEntity::Admin)
+    );
+    assert_eq!(
+        event.subject(),
+        Some(&SubjectIdentifier::Email {
+            email: "user@example.com".to_string()
+        })
+    );
+
+    let event = decode_single_event(json!({
+        EVENT_TYPE_TOKEN_CLAIMS_CHANGE: { "claims": { "role": "ro-admin" } }
+    }))
+    .await;
+    let CaepEvent::TokenClaimsChange(change) = &event else {
+        panic!("expected TokenClaimsChange, got {event:?}");
+    };
+    assert_eq!(change.claims["role"], "ro-admin");
+
+    let event = decode_single_event(json!({
+        EVENT_TYPE_CREDENTIAL_CHANGE: {
+            "credential_type": "fido2-platform",
+            "change_type": "revoke",
+            "friendly_name": "Work laptop"
+        }
+    }))
+    .await;
+    let CaepEvent::CredentialChange(change) = &event else {
+        panic!("expected CredentialChange, got {event:?}");
+    };
+    assert_eq!(change.credential_type, CredentialType::Fido2Platform);
+    assert_eq!(change.change_type, ChangeType::Revoke);
+
+    let event = decode_single_event(json!({
+        EVENT_TYPE_ASSURANCE_LEVEL_CHANGE: {
+            "current_level": "nist-aal3",
+            "previous_level": "nist-aal1",
+            "change_direction": "increase"
+        }
+    }))
+    .await;
+    let CaepEvent::AssuranceLevelChange(change) = &event else {
+        panic!("expected AssuranceLevelChange, got {event:?}");
+    };
+    assert_eq!(change.current_level, AssuranceLevel::Aal3);
+    assert_eq!(change.previous_level, AssuranceLevel::Aal1);
+    assert_eq!(change.change_direction, ChangeDirection::Increase);
+
+    let event = decode_single_event(json!({
+        EVENT_TYPE_DEVICE_COMPLIANCE_CHANGE: {
+            "previous_status": "compliant",
+            "current_status": "not-compliant"
+        }
+    }))
+    .await;
+    let CaepEvent::DeviceComplianceChange(change) = &event else {
+        panic!("expected DeviceComplianceChange, got {event:?}");
+    };
+    assert_eq!(change.previous_status, ComplianceStatus::Compliant);
+    assert_eq!(change.current_status, ComplianceStatus::NotCompliant);
+}
+
+#[tokio::test]
+async fn preserves_an_unknown_event_alongside_a_known_one() {
+    let risc = "https://schemas.openid.net/secevent/risc/event-type/account-disabled";
+    let token = sign(&with_events(
+        session_revoked_claims(),
+        json!({
+            EVENT_TYPE_SESSION_REVOKED: {},
+            risc: { "reason": "hijacking" }
+        }),
+    ));
+    let set = verifier().verify_at(&token, NOW).await.unwrap();
+    let events = set.caep_events().unwrap();
+
+    assert_eq!(events.len(), 2);
+    assert!(events
+        .iter()
+        .any(|event| matches!(event, CaepEvent::SessionRevoked(_))));
+    let unknown = events
+        .iter()
+        .find(|event| event.event_type_uri() == risc)
+        .expect("the unknown event must survive decoding");
+    match unknown {
+        CaepEvent::Unknown { payload, .. } => assert_eq!(payload["reason"], "hijacking"),
+        other => panic!("expected Unknown, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RFC 8935 push delivery
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct RecordingHandler {
+    seen: Mutex<Vec<String>>,
+}
+
+#[async_trait]
+impl SetHandler for RecordingHandler {
+    async fn handle(
+        &self,
+        _set: &SecurityEventToken,
+        event: &CaepEvent,
+    ) -> Result<(), HandlerError> {
+        self.seen
+            .lock()
+            .unwrap()
+            .push(event.event_type_uri().to_string());
+        Ok(())
+    }
+}
+
+struct FailingHandler {
+    error: HandlerError,
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl SetHandler for FailingHandler {
+    async fn handle(
+        &self,
+        _set: &SecurityEventToken,
+        _event: &CaepEvent,
+    ) -> Result<(), HandlerError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Err(self.error.clone())
+    }
+}
+
+fn receiver_with(handler: Arc<dyn SetHandler>) -> PushReceiver {
+    PushReceiver::new(Arc::new(verifier())).with_handler(handler)
+}
+
+fn error_body(response: &PushResponse) -> serde_json::Value {
+    serde_json::from_slice(response.body()).expect("a failure body is JSON")
+}
+
+#[tokio::test]
+async fn accepts_a_pushed_set_and_dispatches_its_events() {
+    let handler = Arc::new(RecordingHandler::default());
+    let receiver = receiver_with(handler.clone());
+
+    // A fresh `iat` because `PushReceiver` verifies against the real clock.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let token = sign(&with_claim(session_revoked_claims(), "iat", json!(now)));
+
+    let response = receiver
+        .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+        .await;
+
+    // RFC 8935 §2.2: 202 with an empty body.
+    assert_eq!(response.status(), 202);
+    assert!(response.body().is_empty());
+    assert!(response.is_accepted());
+    assert_eq!(
+        handler.seen.lock().unwrap().as_slice(),
+        [EVENT_TYPE_SESSION_REVOKED]
+    );
+}
+
+#[tokio::test]
+async fn rejects_a_wrong_content_type() {
+    let receiver = receiver_with(Arc::new(LoggingHandler));
+    let response = receiver
+        .receive(Some("application/json"), b"whatever")
+        .await;
+    assert_eq!(response.status(), 400);
+    assert_eq!(response.error_code(), Some(SetErrorCode::InvalidRequest));
+    assert_eq!(response.content_type(), Some("application/json"));
+    assert_eq!(response.content_language(), Some("en"));
+    assert_eq!(error_body(&response)["err"], "invalid_request");
+}
+
+#[tokio::test]
+async fn rejects_a_missing_content_type() {
+    let receiver = receiver_with(Arc::new(LoggingHandler));
+    let response = receiver.receive(None, b"whatever").await;
+    assert_eq!(response.status(), 400);
+    assert_eq!(response.error_code(), Some(SetErrorCode::InvalidRequest));
+}
+
+#[tokio::test]
+async fn rejects_a_non_utf8_body() {
+    let receiver = receiver_with(Arc::new(LoggingHandler));
+    let response = receiver.receive(Some(SET_MEDIA_TYPE), &[0xff, 0xfe]).await;
+    assert_eq!(response.status(), 400);
+    assert_eq!(response.error_code(), Some(SetErrorCode::InvalidRequest));
+    assert!(error_body(&response)["description"]
+        .as_str()
+        .unwrap()
+        .contains("UTF-8"));
+}
+
+#[tokio::test]
+async fn maps_each_validation_failure_to_its_registered_error_code() {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let fresh = |claims: serde_json::Value| with_claim(claims, "iat", json!(now));
+
+    // invalid_request: a JWT that is not explicitly typed as a SET.
+    let cases: Vec<(String, SetErrorCode)> = vec![
+        (
+            sign_with(
+                Some("JWT"),
+                Algorithm::HS256,
+                None,
+                &fresh(session_revoked_claims()),
+            ),
+            SetErrorCode::InvalidRequest,
+        ),
+        // invalid_key: an unsecured JWT.
+        (
+            unsecured(&fresh(session_revoked_claims())),
+            SetErrorCode::InvalidKey,
+        ),
+        // authentication_failed: a tampered signature.
+        (
+            tamper_signature(&sign(&fresh(session_revoked_claims()))),
+            SetErrorCode::AuthenticationFailed,
+        ),
+        // invalid_issuer.
+        (
+            sign(&fresh(with_claim(
+                session_revoked_claims(),
+                "iss",
+                json!("https://evil.example.com/"),
+            ))),
+            SetErrorCode::InvalidIssuer,
+        ),
+        // invalid_audience.
+        (
+            sign(&fresh(with_claim(
+                session_revoked_claims(),
+                "aud",
+                json!("https://other.example.com/"),
+            ))),
+            SetErrorCode::InvalidAudience,
+        ),
+        // invalid_request: an event payload that does not conform to its definition.
+        (
+            sign(&fresh(with_events(
+                session_revoked_claims(),
+                json!({ EVENT_TYPE_CREDENTIAL_CHANGE: {} }),
+            ))),
+            SetErrorCode::InvalidRequest,
+        ),
+    ];
+
+    let receiver = receiver_with(Arc::new(LoggingHandler));
+    for (token, expected) in cases {
+        let response = receiver
+            .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+            .await;
+        assert_eq!(response.status(), 400);
+        assert_eq!(response.error_code(), Some(expected));
+        assert_eq!(error_body(&response)["err"], expected.as_str());
+        assert!(!error_body(&response)["description"]
+            .as_str()
+            .unwrap()
+            .is_empty());
+    }
+}
+
+#[tokio::test]
+async fn a_rejecting_handler_yields_access_denied() {
+    let handler = Arc::new(FailingHandler {
+        error: HandlerError::Rejected("unknown tenant".to_string()),
+        calls: AtomicUsize::new(0),
+    });
+    let receiver = receiver_with(handler.clone());
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let token = sign(&with_claim(session_revoked_claims(), "iat", json!(now)));
+
+    let response = receiver
+        .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+        .await;
+    assert_eq!(response.status(), 400);
+    assert_eq!(response.error_code(), Some(SetErrorCode::AccessDenied));
+    assert_eq!(error_body(&response)["err"], "access_denied");
+    assert_eq!(error_body(&response)["description"], "unknown tenant");
+    assert_eq!(handler.calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn a_failing_handler_yields_a_server_error_not_a_set_error_code() {
+    let handler = Arc::new(FailingHandler {
+        error: HandlerError::Internal("session store unreachable".to_string()),
+        calls: AtomicUsize::new(0),
+    });
+    let receiver = receiver_with(handler.clone());
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let token = sign(&with_claim(session_revoked_claims(), "iat", json!(now)));
+
+    let response = receiver
+        .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+        .await;
+    assert_eq!(response.status(), 500);
+    assert!(response.body().is_empty());
+    assert_eq!(response.error_code(), None);
+}
+
+#[tokio::test]
+async fn a_retransmitted_set_is_acknowledged_without_re_dispatching() {
+    // RFC 8935 §2: "The SET Transmitter MAY transmit the same SET to the SET Recipient multiple
+    // times... The SET Recipient MUST respond as it would if the SET had not been previously
+    // received by the SET Recipient." So: 202 both times, handlers run once.
+    let verifier = SetVerifier::builder(ISSUER)
+        .audience(AUDIENCE)
+        .algorithms([Algorithm::HS256])
+        .key(decoding_key())
+        .replay_guard(Arc::new(InMemorySetReplayGuard::new(Duration::from_secs(
+            3600,
+        ))))
+        .build()
+        .unwrap();
+    let handler = Arc::new(RecordingHandler::default());
+    let receiver = PushReceiver::new(Arc::new(verifier)).with_handler(handler.clone());
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let token = sign(&with_claim(session_revoked_claims(), "iat", json!(now)));
+
+    let first = receiver
+        .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+        .await;
+    let second = receiver
+        .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+        .await;
+
+    assert_eq!(first.status(), 202);
+    assert_eq!(second.status(), 202, "a retransmission must not 400");
+    assert_eq!(
+        handler.seen.lock().unwrap().len(),
+        1,
+        "handlers must not run twice for the same SET"
+    );
+}
+
+#[tokio::test]
+async fn a_receiver_without_handlers_still_validates() {
+    let receiver = PushReceiver::new(Arc::new(verifier()));
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    let token = sign(&with_claim(session_revoked_claims(), "iat", json!(now)));
+    assert!(receiver
+        .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+        .await
+        .is_accepted());
+
+    let token = tamper_signature(&token);
+    assert!(!receiver
+        .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+        .await
+        .is_accepted());
+}
+
+#[tokio::test]
+async fn tolerates_surrounding_whitespace_in_the_body() {
+    let receiver = PushReceiver::new(Arc::new(verifier()));
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let token = sign(&with_claim(session_revoked_claims(), "iat", json!(now)));
+    let body = format!("\n{token}\n");
+
+    assert!(receiver
+        .receive(Some(SET_MEDIA_TYPE), body.as_bytes())
+        .await
+        .is_accepted());
+}
+
+#[tokio::test]
+async fn the_verifier_is_debug_printable_without_leaking_keys() {
+    let debug = format!("{:?}", verifier());
+    assert!(debug.contains("issuer"));
+    assert!(!debug.contains("DecodingKey"), "{debug}");
+}
+
+#[test]
+fn decoding_key_helper_is_usable_standalone() {
+    // Guards against the fixture drifting from `DecodingKey::from_secret`.
+    let _: DecodingKey = decoding_key();
+}

--- a/crates/authkestra-ssf/tests/conformance.rs
+++ b/crates/authkestra-ssf/tests/conformance.rs
@@ -21,7 +21,7 @@ use authkestra_ssf::{
     ComplianceStatus, CredentialChange, CredentialType, DeviceComplianceChange, HandlerError,
     InMemorySetReplayGuard, InitiatingEntity, LoggingHandler, PushReceiver, PushResponse,
     SecurityEventToken, SessionRevoked, SetError, SetErrorCode, SetHandler, SetVerifier,
-    StaticKeyResolver, SubjectIdentifier, TokenClaimsChange, DEFAULT_MAX_BODY_BYTES,
+    StaticKeyResolver, SubjectIdentifier, TokenClaimsChange, VerifiedSet, DEFAULT_MAX_BODY_BYTES,
     EVENT_TYPE_ASSURANCE_LEVEL_CHANGE, EVENT_TYPE_CREDENTIAL_CHANGE,
     EVENT_TYPE_DEVICE_COMPLIANCE_CHANGE, EVENT_TYPE_SESSION_REVOKED,
     EVENT_TYPE_TOKEN_CLAIMS_CHANGE, SET_MEDIA_TYPE,
@@ -49,10 +49,11 @@ fn verifier() -> SetVerifier {
 #[tokio::test]
 async fn accepts_a_well_formed_set() {
     let token = sign(&session_revoked_claims());
-    let set = verifier()
+    let verified = verifier()
         .verify_at(&token, NOW)
         .await
         .expect("a conformant SET must be accepted");
+    let set = verified.set;
 
     assert_eq!(set.iss, ISSUER);
     assert_eq!(set.jti, "24c63fb56e5a2d77a6b512616ca9fa24");
@@ -340,7 +341,7 @@ async fn accepts_and_ignores_an_nbf_claim() {
         "nbf",
         json!(NOW + 86_400),
     ));
-    let set = verifier().verify_at(&token, NOW).await.unwrap();
+    let set = verifier().verify_at(&token, NOW).await.unwrap().set;
     assert_eq!(set.nbf, Some(NOW + 86_400));
 }
 
@@ -377,7 +378,7 @@ async fn parses_the_sub_id_claim() {
         "sub_id",
         json!({ "format": "iss_sub", "iss": ISSUER, "sub": "145234573" }),
     );
-    let set = verifier().verify_at(&sign(&claims), NOW).await.unwrap();
+    let set = verifier().verify_at(&sign(&claims), NOW).await.unwrap().set;
     assert_eq!(
         set.sub_id,
         Some(SubjectIdentifier::IssSub {
@@ -462,11 +463,11 @@ async fn a_rejected_set_does_not_consume_its_jti() {
 
 async fn decode_single_event(events: serde_json::Value) -> CaepEvent {
     let token = sign(&with_events(session_revoked_claims(), events));
-    let set = verifier()
+    let mut decoded = verifier()
         .verify_at(&token, NOW)
         .await
-        .expect("fixture SET must verify");
-    let mut decoded = set.caep_events().expect("event payloads must decode");
+        .expect("fixture SET must verify")
+        .events;
     assert_eq!(decoded.len(), 1);
     decoded.remove(0)
 }
@@ -557,8 +558,7 @@ async fn preserves_an_unknown_event_alongside_a_known_one() {
             risc: { "reason": "hijacking" }
         }),
     ));
-    let set = verifier().verify_at(&token, NOW).await.unwrap();
-    let events = set.caep_events().unwrap();
+    let events = verifier().verify_at(&token, NOW).await.unwrap().events;
 
     assert_eq!(events.len(), 2);
     assert!(events
@@ -1055,4 +1055,248 @@ async fn the_default_body_cap_lets_a_real_set_through() {
     let response = receiver.receive(Some(SET_MEDIA_TYPE), &oversized).await;
     assert_eq!(response.status(), 400);
     assert_eq!(response.error_code(), Some(SetErrorCode::InvalidRequest));
+}
+
+// ---------------------------------------------------------------------------
+// A rejected event payload must not spend the jti (PR #309 review, P1)
+// ---------------------------------------------------------------------------
+
+/// A verifier with replay protection on, for the jti-consumption tests.
+fn verifier_with_replay_guard() -> SetVerifier {
+    SetVerifier::builder(ISSUER)
+        .audience(AUDIENCE)
+        .algorithms([Algorithm::HS256])
+        .key(decoding_key())
+        .replay_guard(Arc::new(InMemorySetReplayGuard::new(Duration::from_secs(
+            3600,
+        ))))
+        .build()
+        .expect("fixture verifier configuration is complete")
+}
+
+/// Claims carrying a `credential-change` event with an empty payload: authentic, correctly
+/// signed, and invalid only because CAEP 1.0 §3.3.1 makes `credential_type` and `change_type`
+/// REQUIRED.
+fn claims_with_a_malformed_event(jti: &str, iat: i64) -> serde_json::Value {
+    let claims = with_events(
+        session_revoked_claims(),
+        json!({ EVENT_TYPE_CREDENTIAL_CHANGE: {} }),
+    );
+    let claims = with_claim(claims, "jti", json!(jti));
+    with_claim(claims, "iat", json!(iat))
+}
+
+#[tokio::test]
+async fn a_malformed_event_payload_is_refused_before_the_replay_guard_runs() {
+    let verifier = verifier_with_replay_guard();
+    let jti = "same-jti-across-both-transmissions";
+
+    let broken = sign(&claims_with_a_malformed_event(jti, NOW));
+    let err = verifier.verify_at(&broken, NOW).await.unwrap_err();
+    match &err {
+        SetError::EventPayload(inner) => assert_eq!(inner.uri(), EVENT_TYPE_CREDENTIAL_CHANGE),
+        other => panic!("expected EventPayload, got {other:?}"),
+    }
+    assert_eq!(err.code(), SetErrorCode::InvalidRequest);
+
+    // The decisive assertion: the slot was never taken, so the corrected SET is accepted rather
+    // than mistaken for a retransmission of something already ingested.
+    let fixed = with_claim(session_revoked_claims(), "jti", json!(jti));
+    assert!(
+        verifier.verify_at(&sign(&fixed), NOW).await.is_ok(),
+        "a SET refused for a malformed event payload must not consume its jti"
+    );
+}
+
+#[tokio::test]
+async fn a_corrected_retransmission_still_reaches_the_handlers() {
+    // The end-to-end shape of the same bug: RFC 8935 §2 lets a transmitter retransmit under the
+    // same jti, so if the first (invalid) delivery recorded the jti, the corrected one would come
+    // back 202 from the replay path with the event never dispatched.
+    let handler = Arc::new(RecordingHandler::default());
+    let receiver =
+        PushReceiver::new(Arc::new(verifier_with_replay_guard())).with_handler(handler.clone());
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let jti = "same-jti-across-both-transmissions";
+
+    let broken = sign(&claims_with_a_malformed_event(jti, now));
+    let response = receiver
+        .receive(Some(SET_MEDIA_TYPE), broken.as_bytes())
+        .await;
+    assert_eq!(response.status(), 400);
+    assert_eq!(response.error_code(), Some(SetErrorCode::InvalidRequest));
+    assert!(
+        handler.seen.lock().unwrap().is_empty(),
+        "nothing should have been dispatched from a SET with a malformed event payload"
+    );
+
+    let fixed = with_claim(
+        with_claim(session_revoked_claims(), "jti", json!(jti)),
+        "iat",
+        json!(now),
+    );
+    let response = receiver
+        .receive(Some(SET_MEDIA_TYPE), sign(&fixed).as_bytes())
+        .await;
+    assert_eq!(response.status(), 202);
+    assert_eq!(
+        handler.seen.lock().unwrap().as_slice(),
+        [EVENT_TYPE_SESSION_REVOKED],
+        "the corrected retransmission must be dispatched, not swallowed as a replay"
+    );
+}
+
+#[tokio::test]
+async fn a_pre_signature_rejection_also_leaves_the_jti_free() {
+    // The sibling of `a_rejected_set_does_not_consume_its_jti`, which only covers a wrong-`typ`
+    // rejection in step 1. This one covers a rejection that happens *after* the signature has
+    // been verified and the claims parsed, which is where the ordering is easy to get wrong.
+    let verifier = verifier_with_replay_guard();
+    let jti = "jti-for-the-post-signature-path";
+
+    let stale = with_claim(
+        with_claim(session_revoked_claims(), "jti", json!(jti)),
+        "iat",
+        json!(NOW + 10_000),
+    );
+    assert!(matches!(
+        verifier.verify_at(&sign(&stale), NOW).await.unwrap_err(),
+        SetError::IatInFuture { .. }
+    ));
+
+    let good = with_claim(session_revoked_claims(), "jti", json!(jti));
+    assert!(
+        verifier.verify_at(&sign(&good), NOW).await.is_ok(),
+        "a freshness rejection must not consume the jti either"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Failure bodies must not disclose deployment configuration (PR #309 review, P2)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn failure_bodies_do_not_disclose_the_configured_issuer_or_audience() {
+    let receiver = PushReceiver::new(Arc::new(verifier()));
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let fresh = |claims: serde_json::Value| with_claim(claims, "iat", json!(now));
+
+    let cases: Vec<(&str, String, SetErrorCode)> = vec![
+        (
+            "wrong issuer",
+            sign(&fresh(with_claim(
+                session_revoked_claims(),
+                "iss",
+                json!("https://evil.example.com/"),
+            ))),
+            SetErrorCode::InvalidIssuer,
+        ),
+        (
+            "wrong audience",
+            sign(&fresh(with_claim(
+                session_revoked_claims(),
+                "aud",
+                json!("https://someone-elses-receiver.example.com/"),
+            ))),
+            SetErrorCode::InvalidAudience,
+        ),
+        (
+            "missing audience",
+            sign(&fresh(with_claim(
+                session_revoked_claims(),
+                "aud",
+                json!(null),
+            ))),
+            SetErrorCode::InvalidAudience,
+        ),
+    ];
+
+    for (label, token, expected_code) in cases {
+        let response = receiver
+            .receive(Some(SET_MEDIA_TYPE), token.as_bytes())
+            .await;
+        assert_eq!(response.status(), 400, "{label}");
+        assert_eq!(response.error_code(), Some(expected_code), "{label}");
+
+        let body = String::from_utf8(response.body().to_vec()).expect("the body is UTF-8 JSON");
+        assert!(
+            !body.contains(ISSUER),
+            "{label}: the failure body leaked the configured issuer: {body}"
+        );
+        assert!(
+            !body.contains(AUDIENCE),
+            "{label}: the failure body leaked the configured audience: {body}"
+        );
+
+        // Still useful to a human: the registered code plus a non-empty description.
+        let parsed = error_body(&response);
+        assert_eq!(parsed["err"], expected_code.as_str(), "{label}");
+        assert!(
+            !parsed["description"].as_str().unwrap().is_empty(),
+            "{label}"
+        );
+    }
+}
+
+#[test]
+fn the_redacted_errors_still_carry_their_values_for_the_caller() {
+    // Redaction is on `Display` only. A caller driving `SetVerifier` directly — and the crate's
+    // own tracing — still get the values as structured data.
+    let err = SetError::IssuerMismatch {
+        expected: ISSUER.to_string(),
+        found: "https://evil.example.com/".to_string(),
+    };
+    match &err {
+        SetError::IssuerMismatch { expected, found } => {
+            assert_eq!(expected, ISSUER);
+            assert_eq!(found, "https://evil.example.com/");
+        }
+        other => panic!("unexpected variant {other:?}"),
+    }
+    assert!(!err.to_string().contains(ISSUER));
+
+    let err = SetError::AudienceMismatch {
+        expected: vec![AUDIENCE.to_string()],
+    };
+    match &err {
+        SetError::AudienceMismatch { expected } => assert_eq!(expected, &[AUDIENCE.to_string()]),
+        other => panic!("unexpected variant {other:?}"),
+    }
+    assert!(!err.to_string().contains(AUDIENCE));
+
+    let err = SetError::MissingAudience {
+        expected: vec![AUDIENCE.to_string()],
+    };
+    assert!(!err.to_string().contains(AUDIENCE));
+}
+
+// ---------------------------------------------------------------------------
+// VerifiedSet
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_verified_set_carries_its_decoded_events() {
+    let token = sign(&session_revoked_claims());
+    let verified = verifier().verify_at(&token, NOW).await.unwrap();
+
+    assert_eq!(verified.set.jti, "24c63fb56e5a2d77a6b512616ca9fa24");
+    assert_eq!(verified.events.len(), 1);
+    assert_eq!(
+        verified.events[0].event_type_uri(),
+        EVENT_TYPE_SESSION_REVOKED
+    );
+
+    let rebuilt = VerifiedSet::new(verified.set.clone(), verified.events.clone());
+    assert_eq!(rebuilt, verified);
+
+    let (set, events) = verified.into_parts();
+    assert_eq!(set.iss, ISSUER);
+    assert_eq!(events.len(), 1);
 }

--- a/crates/authkestra-ssf/tests/support/mod.rs
+++ b/crates/authkestra-ssf/tests/support/mod.rs
@@ -1,0 +1,101 @@
+//! A test-only SET Transmitter: mints Security Event Tokens in the exact wire shape
+//! [`authkestra_ssf::SetVerifier`] expects, since nothing in this repo issues SETs yet.
+//!
+//! Signing is HMAC-SHA256 throughout. That is not a recommendation for production — a real
+//! transmitter signs asymmetrically so recipients need no shared secret — but it is what
+//! RFC 8935 §2.1's own example transmission uses, it needs no key generation, and every check
+//! this suite exercises (`typ`, `alg` allow-listing, issuer, audience, freshness, replay,
+//! delivery semantics) is independent of the signature algorithm. The one property that is
+//! *not* independent — that a tampered signature is rejected — is covered directly by
+//! [`tamper_signature`].
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use jsonwebtoken::{encode, Algorithm, DecodingKey, EncodingKey, Header};
+use serde_json::{json, Value};
+
+/// The issuer every fixture SET claims, and every fixture verifier expects.
+pub const ISSUER: &str = "https://idp.example.com/";
+/// The audience every fixture verifier answers to.
+pub const AUDIENCE: &str = "https://sp.example.com/caep";
+/// The shared secret the fixture transmitter signs with.
+pub const SECRET: &[u8] = b"a-test-only-shared-secret-for-hs256-signing";
+/// A fixed "now" so freshness assertions do not depend on the wall clock.
+pub const NOW: i64 = 1_700_000_000;
+
+/// The decoding key matching [`SECRET`].
+pub fn decoding_key() -> DecodingKey {
+    DecodingKey::from_secret(SECRET)
+}
+
+/// A minimal, valid claims set carrying one CAEP Session Revoked event.
+pub fn session_revoked_claims() -> Value {
+    json!({
+        "iss": ISSUER,
+        "jti": "24c63fb56e5a2d77a6b512616ca9fa24",
+        "iat": NOW,
+        "aud": AUDIENCE,
+        "events": {
+            authkestra_ssf::EVENT_TYPE_SESSION_REVOKED: {
+                "subject": { "format": "opaque", "id": "dMTlD|1600802906" },
+                "initiating_entity": "policy",
+                "event_timestamp": NOW - 10
+            }
+        }
+    })
+}
+
+/// Signs `claims` with `typ: secevent+jwt` and `alg: HS256`.
+pub fn sign(claims: &Value) -> String {
+    sign_with(Some("secevent+jwt"), Algorithm::HS256, None, claims)
+}
+
+/// Signs `claims` with an explicit `typ`, `alg` and `kid`, for the negative cases.
+pub fn sign_with(typ: Option<&str>, alg: Algorithm, kid: Option<&str>, claims: &Value) -> String {
+    let header = Header {
+        typ: typ.map(str::to_string),
+        kid: kid.map(str::to_string),
+        ..Header::new(alg)
+    };
+    encode(&header, claims, &EncodingKey::from_secret(SECRET)).expect("fixture SET must encode")
+}
+
+/// Builds the unsecured JWT of RFC 8417 §2.4: `alg: none`, empty signature segment.
+pub fn unsecured(claims: &Value) -> String {
+    let header =
+        URL_SAFE_NO_PAD.encode(json!({ "typ": "secevent+jwt", "alg": "none" }).to_string());
+    let payload = URL_SAFE_NO_PAD.encode(claims.to_string());
+    format!("{header}.{payload}.")
+}
+
+/// Replaces the signature segment with a different, well-formed base64url string.
+pub fn tamper_signature(token: &str) -> String {
+    let (signing_input, signature) = token
+        .rsplit_once('.')
+        .expect("a compact JWS has 3 segments");
+    let mut bytes = URL_SAFE_NO_PAD
+        .decode(signature)
+        .expect("fixture signatures are base64url");
+    bytes[0] ^= 0xff;
+    format!("{signing_input}.{}", URL_SAFE_NO_PAD.encode(bytes))
+}
+
+/// Replaces the `events` claim of `claims` with `events`.
+pub fn with_events(mut claims: Value, events: Value) -> Value {
+    claims
+        .as_object_mut()
+        .expect("claims are a JSON object")
+        .insert("events".to_string(), events);
+    claims
+}
+
+/// Sets (or, with `Value::Null`, removes) a top-level claim.
+pub fn with_claim(mut claims: Value, name: &str, value: Value) -> Value {
+    let object = claims.as_object_mut().expect("claims are a JSON object");
+    if value.is_null() {
+        object.remove(name);
+    } else {
+        object.insert(name.to_string(), value);
+    }
+    claims
+}

--- a/crates/authkestra/Cargo.toml
+++ b/crates/authkestra/Cargo.toml
@@ -17,6 +17,7 @@ authkestra-axum = { workspace = true, optional = true, default-features = false 
 authkestra-actix = { workspace = true, optional = true, default-features = false }
 authkestra-providers = { workspace = true, optional = true, default-features = false }
 authkestra-resource = { workspace = true, optional = true, default-features = false }
+authkestra-ssf = { workspace = true, optional = true, default-features = false }
 
 [dev-dependencies]
 reqwest = { version = "0.13", default-features = false, features = ["json"] }
@@ -90,6 +91,9 @@ session = ["authkestra-engine/session"]
 token = ["authkestra-engine/token"]
 oidc = ["dep:authkestra-oidc"]
 resource = ["dep:authkestra-resource", "authkestra-actix?/resource", "authkestra-axum?/resource"]
+# Shared Signals Framework / CAEP ingestion. No adapter feature to forward: `authkestra-ssf` is
+# framework-agnostic and ships no axum/actix wiring yet (see authkestra#25).
+ssf = ["dep:authkestra-ssf"]
 
 # Web frameworks
 axum = ["dep:authkestra-axum", "authkestra-axum/macros", "authkestra-axum/session", "authkestra-axum/token", "authkestra-axum/resource"]

--- a/crates/authkestra/src/lib.rs
+++ b/crates/authkestra/src/lib.rs
@@ -20,6 +20,14 @@ pub use authkestra_engine as token;
 #[cfg(feature = "oidc")]
 pub use authkestra_oidc as oidc;
 
+/// Shared Signals Framework (RFC 8417 / RFC 8935) and CAEP event ingestion.
+///
+/// Only the receiving half — validating SETs and decoding CAEP events. Reacting to an event
+/// (session revocation, middleware enforcement) is not implemented yet; see the crate docs and
+/// [authkestra#25](https://github.com/marcjazz/authkestra/issues/25).
+#[cfg(feature = "ssf")]
+pub use authkestra_ssf as ssf;
+
 #[cfg(feature = "axum")]
 pub use authkestra_axum as axum;
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,6 +106,8 @@ The RFC-001 consolidation is done; these are the crates that actually exist toda
 - `authkestra-op/` — OpenID Provider (authorization server)
 - `authkestra-devsig/` — device-bound signature authentication
 - `authkestra-crypto-util/` — shared strict signature/key verification helpers
+- `authkestra-ssf/` — Shared Signals Framework: SET (RFC 8417) ingestion, CAEP 1.0 events, and the
+  RFC 8935 push receiver
 - `authkestra-axum/`, `authkestra-actix/` — framework adapters
 - `authkestra-macros/` — `AxumState` / `ActixState` / `KvStore` derives
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -57,3 +57,7 @@ version_group = "authkestra"
 [[package]]
 name = "authkestra-store-testsuite"
 version_group = "authkestra"
+
+[[package]]
+name = "authkestra-ssf"
+version_group = "authkestra"

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -48,6 +48,7 @@ export default defineConfig({
 						{ label: 'Resource Server (API)', slug: 'advanced/resource-server' },
 						{ label: 'OpenID Provider (OP)', slug: 'advanced/op-server' },
 						{ label: 'Device Attestation', slug: 'guides/device-attestation' },
+						{ label: 'Continuous Access Evaluation (CAEP/SSF)', slug: 'advanced/continuous-access-evaluation' },
 					],
 				},
 				{

--- a/website/src/content/docs/advanced/continuous-access-evaluation.md
+++ b/website/src/content/docs/advanced/continuous-access-evaluation.md
@@ -125,9 +125,10 @@ asynchronous shape RFC 8935 §2 suggests, enqueue inside the handler and return 
   get a `400 invalid_request`, the replay slot stays free, and the corrected retransmission under
   the same `jti` is processed normally instead of being mistaken for a duplicate.
 - **Error responses do not echo your configuration.** A wrong-issuer or wrong-audience SET gets
-  `invalid_issuer` / `audience mismatch` and nothing more: the push endpoint is unauthenticated,
-  so the expected values stay in your logs (as structured tracing fields) rather than going back
-  to whoever POSTed.
+  `invalid_issuer` / `audience mismatch` and nothing more, and a stale or future-dated one does
+  not reveal your `iat_leeway` or `max_age`: the push endpoint is unauthenticated, so anything
+  that describes your policy stays in your logs (as structured tracing fields) rather than going
+  back to whoever POSTed.
 - **Explicit typing is mandatory here.** RFC 8417 §2.3 only requires `typ: secevent+jwt` when a
   SET could be confused with another kind of JWT — which is exactly the situation a general
   receiver is in, so this crate always requires it.

--- a/website/src/content/docs/advanced/continuous-access-evaluation.md
+++ b/website/src/content/docs/advanced/continuous-access-evaluation.md
@@ -125,3 +125,39 @@ asynchronous shape RFC 8935 §2 suggests, enqueue inside the handler and return 
   receiver is in, so this crate always requires it.
 - **`exp` is optional; `nbf` is ignored.** A SET describes something that already happened, so
   RFC 8417 §2.2 discourages `exp` entirely and never profiles `nbf`. Freshness comes from `iat`.
+- **An empty `jti` is refused.** RFC 8417 §2.2 makes `jti` the SET's unique identifier. An empty
+  or whitespace-only one identifies nothing, and would collapse the replay guard to one slot per
+  issuer — so it is a `400 invalid_request`.
+
+## Body size limits
+
+`PushReceiver` refuses any body larger than `DEFAULT_MAX_BODY_BYTES` (1 MiB) with
+`400 invalid_request`, before it parses anything. Change it with:
+
+```rust
+let receiver = PushReceiver::new(verifier).with_max_body_bytes(64 * 1024);
+```
+
+**Set a limit in your HTTP layer as well.** By the time `receive` is called, the body has already
+been read into memory by the framework, so this check is a second line of defence — it stops an
+oversized body reaching the parser and the signature verifier, but it cannot prevent the
+allocation. What actually bounds what gets buffered is axum's `DefaultBodyLimit`, actix's
+`PayloadConfig`, or your reverse proxy's `client_max_body_size`.
+
+## Building the models in your own tests
+
+The public models are `#[non_exhaustive]`, so they cannot be built with struct-literal syntax from
+outside the crate — but every one of them has a constructor, precisely so that the code you write
+to map a CAEP event onto your own domain stays unit-testable without minting and verifying a real
+SET:
+
+```rust
+use authkestra_ssf::{CaepMetadata, CredentialChange, CredentialType, ChangeType, SecurityEventToken};
+
+let set = SecurityEventToken::new("https://idp.example.com/", "jti-1", 1_700_000_000, events);
+let mut change = CredentialChange::new(CredentialType::Password, ChangeType::Update);
+change.metadata = CaepMetadata::empty();
+```
+
+None of these constructors validate anything: a SET your service should act on comes out of
+`SetVerifier`, never out of a constructor.

--- a/website/src/content/docs/advanced/continuous-access-evaluation.md
+++ b/website/src/content/docs/advanced/continuous-access-evaluation.md
@@ -1,0 +1,127 @@
+---
+title: Continuous Access Evaluation (CAEP/SSF)
+description: Ingesting and validating Security Event Tokens so an external IdP or EDR can tell your service that something changed.
+---
+
+A session that was legitimate when it started does not stay legitimate. The user's password gets
+reset, their laptop drops out of compliance, an administrator revokes their session — and none of
+that reaches your service until the next token refresh, which may be an hour away.
+
+The **Shared Signals Framework** closes that gap: a cooperating provider pushes you a signed
+**Security Event Token (SET)** the moment something changes. `authkestra-ssf` is the receiving
+side of that exchange.
+
+## Standards implemented
+
+| Specification | What it defines | Where it lands |
+| --- | --- | --- |
+| [RFC 8417](https://www.rfc-editor.org/rfc/rfc8417) | The SET itself: a JWT whose payload is a set of events | `SecurityEventToken`, `SetVerifier` |
+| [RFC 8935](https://www.rfc-editor.org/rfc/rfc8935) | Push delivery over HTTP, and the 202/400 response semantics | `PushReceiver`, `PushResponse` |
+| [RFC 9493](https://www.rfc-editor.org/rfc/rfc9493) | Structured subject identifiers (`sub_id`) | `SubjectIdentifier` |
+| [OpenID CAEP 1.0](https://openid.net/specs/openid-caep-specification-1_0.html) | The event vocabulary: session revoked, credential change, and friends | `CaepEvent` |
+
+## What is implemented today — and what is not
+
+Implemented:
+
+- **Ingest and validate SETs.** Explicit `typ` checking, an algorithm allow-list that can never
+  contain `none`, signature verification against a single key or a `kid`-based resolver, issuer
+  and audience checks, `iat` freshness with configurable leeway and optional maximum age, `exp`
+  honoured when a transmitter sends one, non-empty `events`, and `jti` replay detection.
+- **Typed CAEP events.** All five CAEP 1.0 event types with their specific claims. Event types
+  this crate does not model (RISC, SCIM, vendor extensions) are preserved verbatim rather than
+  dropped, so a handler that understands them still can.
+- **A framework-agnostic push receiver** implementing the RFC 8935 response semantics, including
+  the registered error codes (`invalid_request`, `invalid_key`, `invalid_issuer`,
+  `invalid_audience`, `authentication_failed`, `access_denied`).
+
+Not implemented yet:
+
+- **Session state is not updated when a revocation signal arrives.** Nothing in the engine reacts
+  to a `session-revoked` event on its own; you write a `SetHandler` and do it yourself.
+- **No middleware rejects tokens invalidated by a CAEP event.**
+- **No Axum or Actix routes are wired.** `PushReceiver::receive` returns a plain data structure;
+  turning it into a route is a few lines in your own handler today.
+
+The three gaps are tracked in
+[authkestra#25](https://github.com/marcjazz/authkestra/issues/25).
+
+## Setting up a receiver
+
+```toml
+[dependencies]
+authkestra-ssf = "0.7"
+jsonwebtoken = { version = "11", features = ["rust_crypto"] }
+```
+
+```rust
+use std::sync::Arc;
+use std::time::Duration;
+
+use authkestra_ssf::{InMemorySetReplayGuard, PushReceiver, SetVerifier};
+use jsonwebtoken::{Algorithm, DecodingKey};
+
+let verifier = SetVerifier::builder("https://idp.example.com/")
+    .audience("https://sp.example.com/caep")
+    .algorithms([Algorithm::EdDSA])
+    .key(transmitter_key)
+    .max_age(Duration::from_secs(60 * 60))
+    .replay_guard(Arc::new(InMemorySetReplayGuard::new(Duration::from_secs(60 * 60))))
+    .build()?;
+
+let receiver = PushReceiver::new(Arc::new(verifier))
+    .with_handler(Arc::new(MyHandler));
+```
+
+Then, in whatever HTTP handler you expose at your delivery endpoint:
+
+```rust
+let response = receiver.receive(content_type_header, body_bytes).await;
+// response.status()           -> 202, 400 or 500
+// response.content_type()     -> "application/json" on failure
+// response.content_language() -> "en" on failure (RFC 8935 §2.3 requires it)
+// response.body()             -> {"err": ..., "description": ...} on failure
+```
+
+## Reacting to an event
+
+```rust
+use async_trait::async_trait;
+use authkestra_ssf::{CaepEvent, HandlerError, SecurityEventToken, SetHandler};
+
+struct MyHandler;
+
+#[async_trait]
+impl SetHandler for MyHandler {
+    async fn handle(
+        &self,
+        set: &SecurityEventToken,
+        event: &CaepEvent,
+    ) -> Result<(), HandlerError> {
+        if let CaepEvent::SessionRevoked(revoked) = event {
+            // `revoked.metadata.subject` is the RFC 9493 subject identifier, when the
+            // transmitter sent one; `set.sub_id` is the SET-level one.
+            let _ = revoked;
+            // ... look the subject up and drop its sessions ...
+        }
+        Ok(())
+    }
+}
+```
+
+Returning `HandlerError::Rejected` answers the transmitter with `400 access_denied`; returning
+`HandlerError::Internal` answers `500`, so a conformant transmitter retries. Handlers run *before*
+the response is produced, because this crate has no store of its own — if you want the
+asynchronous shape RFC 8935 §2 suggests, enqueue inside the handler and return immediately.
+
+## Behaviours that surprise people
+
+- **A retransmitted SET is answered `202`, not an error.** RFC 8935 §2 requires the recipient to
+  respond to a repeat transmission exactly as it would to a first one, so replay detection
+  suppresses handler dispatch, not the acknowledgement.
+- **`Content-Type` must be `application/secevent+jwt`.** Anything else is a `400 invalid_request`.
+- **Explicit typing is mandatory here.** RFC 8417 §2.3 only requires `typ: secevent+jwt` when a
+  SET could be confused with another kind of JWT — which is exactly the situation a general
+  receiver is in, so this crate always requires it.
+- **`exp` is optional; `nbf` is ignored.** A SET describes something that already happened, so
+  RFC 8417 §2.2 discourages `exp` entirely and never profiles `nbf`. Freshness comes from `iat`.

--- a/website/src/content/docs/advanced/continuous-access-evaluation.md
+++ b/website/src/content/docs/advanced/continuous-access-evaluation.md
@@ -120,6 +120,14 @@ asynchronous shape RFC 8935 §2 suggests, enqueue inside the handler and return 
   respond to a repeat transmission exactly as it would to a first one, so replay detection
   suppresses handler dispatch, not the acknowledgement.
 - **`Content-Type` must be `application/secevent+jwt`.** Anything else is a `400 invalid_request`.
+- **A malformed event payload is refused without spending the `jti`.** Events are decoded as part
+  of verification, so if a transmitter sends a `credential-change` missing its required claims you
+  get a `400 invalid_request`, the replay slot stays free, and the corrected retransmission under
+  the same `jti` is processed normally instead of being mistaken for a duplicate.
+- **Error responses do not echo your configuration.** A wrong-issuer or wrong-audience SET gets
+  `invalid_issuer` / `audience mismatch` and nothing more: the push endpoint is unauthenticated,
+  so the expected values stay in your logs (as structured tracing fields) rather than going back
+  to whoever POSTed.
 - **Explicit typing is mandatory here.** RFC 8417 §2.3 only requires `typ: secevent+jwt` when a
   SET could be confused with another kind of JWT — which is exactly the situation a general
   receiver is in, so this crate always requires it.

--- a/website/src/content/docs/advanced/continuous-access-evaluation.md
+++ b/website/src/content/docs/advanced/continuous-access-evaluation.md
@@ -114,6 +114,26 @@ Returning `HandlerError::Rejected` answers the transmitter with `400 access_deni
 the response is produced, because this crate has no store of its own — if you want the
 asynchronous shape RFC 8935 §2 suggests, enqueue inside the handler and return immediately.
 
+### Your handlers must be idempotent
+
+The replay slot for a SET is taken during verification, before any handler runs — that is what
+makes two *concurrent* deliveries of the same SET dispatch only once. When a handler returns
+`HandlerError::Internal`, the receiver gives that slot back before answering 500, so the
+transmitter's retry is actually verified and dispatched instead of being acknowledged as a
+duplicate and dropped.
+
+The consequence is that a retry replays the **whole** delivery: every event in the SET, through
+every handler, including the ones that already succeeded before the one that failed. Write
+handlers that can run twice — key your writes on `set.jti`, or make them upserts.
+
+`HandlerError::Rejected` keeps the slot, since a `400` tells the transmitter not to retry.
+
+One window is left open deliberately: a concurrent duplicate that arrives between the record and
+the release is answered `202` without dispatch. If the original delivery then fails, that
+particular duplicate has already been answered — but the transmitter's retry of the failed
+delivery finds the slot free and delivers the event, so it is not lost. Holding the slot across
+dispatch instead would close the window at the cost of losing an event on every handler failure.
+
 ## Behaviours that surprise people
 
 - **A retransmitted SET is answered `202`, not an error.** RFC 8935 §2 requires the recipient to


### PR DESCRIPTION
Refs #25

Adds `crates/authkestra-ssf`, the receiving half of the Shared Signals Framework: an external IdP
or EDR pushes a signed Security Event Token, and this crate parses it, authenticates it, and hands
back typed CAEP events.

## Acceptance criteria

| # | Criterion | Status |
| --- | --- | --- |
| 1 | Engine can ingest and validate SETs (RFC 8417) | **met** |
| 2 | Session state is updated immediately upon receiving a revocation signal | **not attempted** — follow-up |
| 3 | Middleware rejects tokens invalidated by a CAEP event | **not attempted** — follow-up |

This PR deliberately owns only criterion 1 plus the typed CAEP event model and a
framework-agnostic push receiver. Criteria 2 and 3 need to decide *which* engine abstraction owns
session attenuation, which is a separate design question; nothing here pre-empts it. `Closes`
keywords are intentionally omitted so #25 stays open.

## What is implemented

- **`SetVerifier`** — the RFC 8935 §2 recipient checks over the RFC 8417 §2.2 claim profile:
  - explicit `typ` (§2.3), accepting both `secevent+jwt` and `application/secevent+jwt`
    case-insensitively, rejecting anything else with a distinct error;
  - an algorithm allow-list, with `alg: "none"` rejected *by name* on the raw header before
    `jsonwebtoken`'s typed API sees it (its `Algorithm` has no `none` variant and hard-fails on
    unknown names, so a typed parse cannot tell "unsecured JWT" from "corrupt token");
  - signature verification against either a single `DecodingKey` or an async `SetKeyResolver`
    keyed by `kid`, so a JWKS-backed resolver drops in later;
  - issuer, audience (`aud` as string *or* array), `iat` freshness with configurable leeway,
    optional maximum age, `exp` honoured when a transmitter sends one, non-empty `jti`,
    non-empty `events`;
  - event payloads decoded as part of verification, before the replay slot is spent;
  - `(iss, jti)` replay detection behind a `SetReplayGuard` trait, with an in-memory
    TTL-expiring implementation.
- **`SubjectIdentifier`** — RFC 9493 `iss_sub`, `email`, `opaque` and `phone_number`, with every
  other format (`account`, `did`, `uri`, `aliases`, …) preserved verbatim.
- **`CaepEvent`** — all five OpenID CAEP 1.0 event types (`session-revoked`,
  `token-claims-change`, `credential-change`, `assurance-level-change`,
  `device-compliance-change`) with their common (§2) and event-specific (§3.1–§3.5) claims.
  Unmodelled event types are preserved as `Unknown { uri, payload }`, never dropped.
- **`PushReceiver`** — RFC 8935 push delivery semantics: 202 on success, 400 with
  `{"err", "description"}` using the registered §2.4 error codes, `Content-Type` and
  `Content-Language` per §2.3, and a configurable body-size cap.

## Review round 1 — changes since first push (`bee42c3`)

Two independent reviews (security, API/conventions). The security pass found no vulnerability
across `alg: none`, HS256/EC key confusion, `kid` substitution, `typ` confusion, claims edge
cases, cross-issuer replay, concurrent replay races and RFC 8935 body-leak checks, and confirmed
that three injected mutants (signature verification made a no-op, `typ` check made a no-op, replay
guard always reporting "fresh") are each caught by the suite. Three changes came out of the API
review:

1. **The public models are now `#[non_exhaustive]`** — `SecurityEventToken`, `CaepMetadata`,
   `SessionRevoked`, `TokenClaimsChange`, `CredentialChange`, `AssuranceLevelChange`,
   `DeviceComplianceChange` — matching `SetError`/`CaepEvent`/`SubjectIdentifier`. Each also gains
   a constructor taking exactly the claims its spec marks REQUIRED (`CaepMetadata::empty`,
   `SessionRevoked::default` where there are none), because sealing an *output* type with no way
   to build one is what makes #282 painful downstream, and these are output types for the same
   reason. Every constructor documents that it validates nothing. A new integration test builds
   all seven from outside the crate; a scratch probe confirmed struct-literal syntax now fails
   with `E0639`, so the attribute is doing something.
2. **An empty or whitespace-only `jti` is refused** with a dedicated `SetError::EmptyJti`
   (→ `invalid_request`). RFC 8417 §2.2 makes `jti` the SET's unique identifier; an empty one
   identifies nothing and would collapse the replay guard to one slot per issuer, so the first
   such SET would permanently suppress every later one. Covered end to end, including that
   poisoning scenario.
3. **`PushReceiver` caps the body** at `DEFAULT_MAX_BODY_BYTES` (1 MiB), configurable with
   `with_max_body_bytes`, refusing anything larger with `400 invalid_request` before the content
   type is even inspected. Documented in the receiver, README and website page as a *second* line
   of defence — the body is already buffered by the time `receive` is called, so the framework's
   own limit (`DefaultBodyLimit`, `PayloadConfig`, `client_max_body_size`) is what actually bounds
   allocation. Tested at exactly the limit (accepted) and one byte over (refused).

## Review round 2 — changes since `bee42c3` (now `d4757fa`)

Two threads from the repo's AI reviewer, both fixed:

- **P1, correctness — an event-payload rejection used to spend the `jti`.** `verify_at` recorded
  the `(iss, jti)` replay slot and returned, leaving `PushReceiver::receive` to decode the event
  payloads afterwards; a malformed payload was then refused with 400 *after* the slot was taken,
  so the transmitter's corrected retransmission under the same `jti` (RFC 8935 §2) came back 202
  from the replay path and never reached a handler. Decoding now happens inside `verify_at` as
  step 4, before the replay check, and the decoded events travel back with the token in a new
  `VerifiedSet { set, events }` so the receiver does not decode twice. `VerifiedSet` is
  `#[non_exhaustive]` with `new`/`into_parts` like the other models.
- **P2, security — failure bodies echoed the configured issuer/audience.** `IssuerMismatch`,
  `MissingAudience` and `AudienceMismatch` embedded the expected values in `Display`, which the
  receiver pipes into the RFC 8935 §2.3 `description` — reaching an unauthenticated caller, since
  the push endpoint defines no authentication. The three messages are now bare; the values stay in
  the variants and are emitted by `reject` as structured tracing fields.

Both were checked by reverting them: with the decode moved back after the replay guard the two new
`jti` tests fail, and with the old `Display` strings restored the two new redaction tests fail —
nothing else moves either way. Five conformance tests added in total, including
`a_pre_signature_rejection_also_leaves_the_jti_free`, the post-signature sibling the reviewer
correctly noted was missing.

Follow-up in `c0ecce7`, at the maintainer's request: `IatInFuture` and `TooOld` put the configured
`leeway` and `max_age` into the same unauthenticated body, so they are redacted the same way —
bare messages, values moved to structured tracing fields (`iat`, `now`, `leeway_secs`,
`max_age_secs`). Reverting the format strings fails the new unit test and the new
`failure_bodies_do_not_disclose_the_configured_freshness_policy`, and nothing else. That covers
every configuration value that reached the wire-facing `description`; `Expired` still names the
SET's own `exp` and the current time, but both are transmitter-supplied or effectively public via
`Date`, and neither describes this receiver's policy.

## Review round 3 — changes in `a2a2bf3`

One P1 from the re-review: **a handler failure lost the event.** The `(iss, jti)` slot is recorded
during verification — that is what dedupes genuinely concurrent duplicate deliveries — but the
receiver answers 500 on `HandlerError::Internal` precisely so the transmitter retries. The retry
then hit the recorded slot, was acknowledged 202 as a duplicate, and the event was never processed
by anyone until the entry aged out.

- `SetReplayGuard` gains a required `release(jti, iss)`; releasing an absent or expired entry is a
  no-op. Implemented for `InMemorySetReplayGuard`.
- `SetVerifier::release_replay_slot` is the counterpart to the record in step 5, and
  `PushReceiver` calls it on the `Internal` path immediately before answering 500. It is public
  rather than crate-private because `verify_at` is public: anything driving verification and
  dispatching on its own has the same obligation and no other way to meet it. That is the only
  API addition beyond the trait method.
- `HandlerError::Rejected` **keeps** the slot — a 400 tells the transmitter not to retry, so
  nothing is waiting on it and re-sending an already-refused SET should not re-run the handlers.

Two things are now documented on the trait, on `receive`, on both `HandlerError` variants, in the
README and on the website page: **handlers must be idempotent**, because a retry replays the whole
delivery including handlers that already succeeded; and the window that stays open by design — a
concurrent duplicate arriving between the record and the release is answered 202 without dispatch,
but the retry of the failed delivery still finds the slot free and delivers the event.

Mutation-checked: deleting the `release_replay_slot` call makes
`a_handler_failure_releases_the_slot_so_the_retry_is_dispatched` fail on the guard-emptiness and
handler-invocation assertions, and nothing else.

## Decisions worth reviewing

- **A retransmitted SET is answered `202`, not `400`.** RFC 8935 §2 says the recipient "MUST
  respond as it would if the SET had not been previously received", so the replay guard suppresses
  *handler dispatch*, not the acknowledgement. Answering 400 would make a conformant transmitter
  retry forever. `SetError::Replay` still exists for callers driving `SetVerifier` directly.
- **`nbf` is parsed and deliberately not validated.** RFC 8417 never profiles it — the word does
  not appear in the document — so rejecting on it would refuse valid SETs, and dropping it would
  hide it from profiles that do give it meaning.
- **Handlers run before the response**, because this crate has no store of its own, so the handler
  *is* the persistence step RFC 8935 §2 asks for before acknowledging. Documented, with the
  enqueue-and-return escape hatch spelled out.
- **`HandlerError::Internal` maps to 500, not 400.** Every RFC 8935 error code describes something
  wrong with the *SET*; telling a transmitter its good SET was invalid would stop it retrying.

## Not in this PR

- **No Axum/Actix routes.** Per `AGENTS.md`'s "Framework Agnostic" rule, `PushReceiver::receive`
  takes a content type and a byte slice and returns a plain `PushResponse`. Adapter wiring is a
  follow-up. (`AGENTS.md`'s framework-wiring DoD covers handlers added to `authkestra-op`; nothing
  here is an `authkestra-op` handler.)
- No session revocation, no middleware — see the table above.

## Wiring

- New workspace member and `[workspace.dependencies]` entry.
- Re-exported from the `authkestra` facade as `authkestra::ssf` behind a new `ssf` feature,
  following how `oidc`/`resource` are exposed.
- `crates/authkestra-ssf/README.md`, a new docs page at
  `website/src/content/docs/advanced/continuous-access-evaluation.md` (plus a sidebar entry), and
  the crate tables in `README.md` / `docs/README.md`.

## Verification

| Command | Exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-features -- -D warnings` | 0 |
| `cargo test -p authkestra-ssf --all-features` | 0 — 129 tests (74 unit, 54 integration, 1 doc) |
| `cargo deny check` | 0 — advisories/bans/licenses/sources ok |

The workspace-wide `cargo test --workspace --all-features` is run centrally. Locally it was green
apart from `authkestra --test examples_e2e`, which spawns a nested `cargo run --example` that
blocked on a shared build-directory file lock and tripped the test's own 180 s startup budget (the
log line before the panic is literally `Blocking waiting for file lock on build directory`); the
same test passes on this branch in a run without that contention. Environmental, unrelated to this
change.

Coverage for the new crate, `cargo llvm-cov -p authkestra-ssf --all-features`:
**98.68 % lines / 97.97 % regions / 98.97 % functions**, no file below 97.03 % lines. The 22
uncovered lines are `panic!` arms in test match guards and tracing-macro branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



