### PR TITLE
fix(engine): allow any port on loopback redirect URIs (RFC 8252 §7.3) — port of #307 to next

### DIFF
--- a/crates/authkestra-engine/src/oauth2/client.rs
+++ b/crates/authkestra-engine/src/oauth2/client.rs
@@ -3,6 +3,8 @@ use argon2::{
     Argon2,
 };
 use serde::{Deserialize, Serialize};
+use std::net::{Ipv4Addr, Ipv6Addr};
+use url::{Host, Url};
 
 /// OAuth2/OIDC grant types a client may be permitted to use.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -86,7 +88,9 @@ pub enum TokenEndpointAuthMethod {
 ///
 /// `redirect_uris` are matched **exactly** (no prefix/wildcard matching) —
 /// see RFC-003 §7. This is the single most important invariant in this
-/// type; do not relax it for convenience.
+/// type; do not relax it for convenience. The one exception, which RFC 8252
+/// §7.3 makes mandatory, is the port of a loopback IP redirect URI; see
+/// [`ClientRegistration::allows_redirect_uri`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClientRegistration {
     /// Public client identifier.
@@ -95,6 +99,15 @@ pub struct ClientRegistration {
     /// `None` for public clients (e.g. SPAs, native apps using PKCE).
     pub client_secret_hash: Option<String>,
     /// Exact-match redirect URIs this client is permitted to use.
+    ///
+    /// One entry, one URI, compared byte-for-byte — with a single exception:
+    /// registering a loopback IP URI (`http://127.0.0.1/...` or
+    /// `http://[::1]/...`) means "this client may redirect to that host and
+    /// path on **any** port", because RFC 8252 §7.3 requires it for native
+    /// apps that take an ephemeral port from the OS at request time. Whatever
+    /// port is written here is therefore not binding, and writing one is only
+    /// a documentation aid. See
+    /// [`ClientRegistration::allows_redirect_uri`] (authkestra#291).
     pub redirect_uris: Vec<String>,
     /// Grant types this client is permitted to use.
     pub grant_types: Vec<GrantType>,
@@ -140,11 +153,42 @@ pub struct ClientRegistration {
 }
 
 impl ClientRegistration {
-    /// Returns true if `redirect_uri` exactly matches one of this client's
-    /// registered URIs. Intentionally a plain `==` comparison — no
-    /// normalization, no prefix matching.
+    /// Returns true if `redirect_uri` matches one of this client's registered
+    /// URIs.
+    ///
+    /// The first and normal check is a plain `==` comparison — no
+    /// normalization, no prefix matching. That exactness is the defence
+    /// against open redirects and is not negotiable for ordinary URIs.
+    ///
+    /// The one relaxation is the port of a **loopback IP** redirect URI, which
+    /// RFC 8252 §7.3 makes a MUST: a native app binds `127.0.0.1:0`, gets a
+    /// kernel-assigned port, and cannot possibly have registered it. So a
+    /// registered `http://127.0.0.1/cb` also matches
+    /// `http://127.0.0.1:54321/cb`. Only the port is ignored; scheme, host,
+    /// userinfo, path, query and fragment must still be equal, and both sides
+    /// must be `http` on the IP literal `127.0.0.1` or `::1`. The name
+    /// `localhost` deliberately does **not** qualify (RFC 8252 §8.3: it
+    /// resolves through a name service the app does not control), nor does any
+    /// other address in `127.0.0.0/8`. Since the exemption cannot apply to a
+    /// non-loopback host, it does not widen the open-redirect surface: an
+    /// attacker able to bind a port on the user's own loopback interface
+    /// already has code execution there. See authkestra#291.
     pub fn allows_redirect_uri(&self, redirect_uri: &str) -> bool {
-        self.redirect_uris.iter().any(|u| u == redirect_uri)
+        self.redirect_uris.iter().any(|registered| {
+            if registered == redirect_uri {
+                return true;
+            }
+            if loopback_match(registered, redirect_uri) {
+                tracing::debug!(
+                    client_id = %self.client_id,
+                    registered_uri = %registered,
+                    presented_uri = %redirect_uri,
+                    "redirect_uri accepted on the RFC 8252 §7.3 loopback any-port exemption"
+                );
+                return true;
+            }
+            false
+        })
     }
 
     /// Checks if the client is allowed to use a specific grant type.
@@ -179,5 +223,233 @@ impl ClientRegistration {
             // No secret stored means public client; shouldn't be used for confidential flows
             false
         }
+    }
+}
+
+/// RFC 8252 §7.3: compares a registered against a presented redirect URI on
+/// every component **except** the port, and only when both are loopback IP
+/// URIs. Returns false for anything else, so the caller's exact `==` remains
+/// the only path by which a non-loopback URI can match.
+///
+/// Both sides are re-checked independently and symmetrically on purpose: a
+/// loopback *registration* must not let a non-loopback URI through, and a
+/// loopback URI presented against a non-loopback registration must not match
+/// either. Everything the URI carries other than the port — including
+/// userinfo, which no legitimate loopback redirect uses — has to be equal, so
+/// the only authority this grants a caller is "some port on the user's own
+/// machine".
+fn loopback_match(registered: &str, presented: &str) -> bool {
+    let (Ok(registered), Ok(presented)) = (Url::parse(registered), Url::parse(presented)) else {
+        // A URI that does not parse cannot be reasoned about; it can still
+        // match byte-for-byte at the call site, but never here.
+        return false;
+    };
+
+    if registered.scheme() != "http" || presented.scheme() != "http" {
+        return false;
+    }
+
+    let (Some(registered_host), Some(presented_host)) = (registered.host(), presented.host())
+    else {
+        return false;
+    };
+    if !is_loopback_ip(&registered_host) || !is_loopback_ip(&presented_host) {
+        return false;
+    }
+
+    registered_host == presented_host
+        && registered.path() == presented.path()
+        && registered.query() == presented.query()
+        && registered.fragment() == presented.fragment()
+        && registered.username() == presented.username()
+        && registered.password() == presented.password()
+}
+
+/// True only for the two IP literals RFC 8252 §7.3 names: `127.0.0.1` and
+/// `::1`.
+///
+/// Deliberately not `Ipv4Addr::is_loopback()`: that accepts all of
+/// `127.0.0.0/8`, and §7.3 enumerates the two addresses rather than the
+/// ranges. `Host::Domain` is always false — that is what keeps `localhost`
+/// out, since resolving it depends on a name service the app does not
+/// control.
+///
+/// Two of the exclusions here are narrower than the RFC and are **meant to
+/// stay that way** — neither is an oversight to be tidied up later:
+///
+/// - **IPv4-mapped IPv6 loopback (`http://[::ffff:127.0.0.1]/cb`) is not
+///   exempt.** `Ipv6Addr::LOCALHOST` is `::1`, so the mapped form compares
+///   unequal and falls through to exact `==`. It is a second spelling of an
+///   address §7.3 already covers in two canonical forms, no OS hands one to
+///   an app that binds `127.0.0.1:0` or `[::1]:0`, and admitting it would
+///   mean either accepting a third literal or normalising mapped to plain
+///   IPv4 — the latter being exactly the kind of pre-comparison rewriting
+///   that redirect-URI matching should not be doing. Add it only with a test
+///   that pins which spellings become equivalent to which.
+/// - **`localhost` is refused outright**, which is stricter than §8.3: the
+///   RFC says NOT RECOMMENDED, not MUST NOT. The stricter line is chosen
+///   because the whole security argument for this exemption is that the host
+///   is unambiguously the user's own machine; `localhost` reaches that host
+///   only via a resolver the app does not control, and it is `Host::Domain`
+///   here, so it can never be told apart from any other name. Relaxing it
+///   would need a fresh argument, not just a citation of §8.3's wording.
+fn is_loopback_ip(host: &Host<&str>) -> bool {
+    match host {
+        Host::Ipv4(addr) => *addr == Ipv4Addr::LOCALHOST,
+        Host::Ipv6(addr) => *addr == Ipv6Addr::LOCALHOST,
+        Host::Domain(_) => false,
+    }
+}
+
+#[cfg(test)]
+#[allow(deprecated)] // `require_pkce` (authkestra#273) — these fixtures don't exercise it
+mod tests {
+    use super::*;
+
+    fn client_with_redirect_uris(uris: &[&str]) -> ClientRegistration {
+        ClientRegistration {
+            client_id: "native-app".to_string(),
+            client_secret_hash: None,
+            redirect_uris: uris.iter().map(|u| (*u).to_string()).collect(),
+            grant_types: vec![GrantType::AuthorizationCode],
+            scopes: vec![],
+            require_pkce: false,
+            allowed_audiences: vec![],
+            token_endpoint_auth_method: None,
+            jwks: None,
+        }
+    }
+
+    /// The authkestra#291 regression: a native app binds an ephemeral port it
+    /// could not have registered, and RFC 8252 §7.3 makes accepting it a MUST.
+    #[test]
+    fn loopback_registration_accepts_any_ephemeral_port() {
+        let client = client_with_redirect_uris(&["http://127.0.0.1/cb"]);
+        assert!(client.allows_redirect_uri("http://127.0.0.1:54321/cb"));
+        assert!(client.allows_redirect_uri("http://127.0.0.1:1/cb"));
+        // The registered value itself must keep working.
+        assert!(client.allows_redirect_uri("http://127.0.0.1/cb"));
+    }
+
+    /// A port written at registration time is not binding — §7.3 is about the
+    /// port being unknowable, so a registered port is documentation, not a
+    /// constraint.
+    #[test]
+    fn loopback_registration_with_a_port_accepts_a_different_port() {
+        let client = client_with_redirect_uris(&["http://127.0.0.1:8080/cb"]);
+        assert!(client.allows_redirect_uri("http://127.0.0.1:9090/cb"));
+        assert!(client.allows_redirect_uri("http://127.0.0.1/cb"));
+    }
+
+    #[test]
+    fn ipv6_loopback_literal_gets_the_same_exemption() {
+        let client = client_with_redirect_uris(&["http://[::1]/cb"]);
+        assert!(client.allows_redirect_uri("http://[::1]:54321/cb"));
+    }
+
+    /// RFC 8252 §8.3: `localhost` resolves through a name service the app does
+    /// not control, so it never earns the exemption — in either position.
+    #[test]
+    fn localhost_never_qualifies() {
+        let registered_localhost = client_with_redirect_uris(&["http://localhost/cb"]);
+        assert!(!registered_localhost.allows_redirect_uri("http://localhost:54321/cb"));
+        assert!(!registered_localhost.allows_redirect_uri("http://127.0.0.1:54321/cb"));
+
+        let registered_ip = client_with_redirect_uris(&["http://127.0.0.1/cb"]);
+        assert!(!registered_ip.allows_redirect_uri("http://localhost:54321/cb"));
+
+        // Exact equality still applies to `localhost`, as to anything else.
+        assert!(registered_localhost.allows_redirect_uri("http://localhost/cb"));
+    }
+
+    /// §7.3 names `127.0.0.1`, not `127.0.0.0/8` — and names it in that one
+    /// spelling, so the IPv4-mapped IPv6 form is out too. Both exclusions are
+    /// deliberate; see `is_loopback_ip` for why, and change this test only
+    /// alongside that reasoning.
+    #[test]
+    fn other_addresses_in_127_slash_8_never_qualify() {
+        let client = client_with_redirect_uris(&["http://127.0.0.2/cb"]);
+        assert!(!client.allows_redirect_uri("http://127.0.0.2:54321/cb"));
+
+        let client = client_with_redirect_uris(&["http://127.0.0.1/cb"]);
+        assert!(!client.allows_redirect_uri("http://127.0.0.2:54321/cb"));
+
+        // IPv4-mapped IPv6 loopback: not `::1`, so no exemption in either
+        // position. Exact `==` still works, as for any other URI.
+        assert!(!client.allows_redirect_uri("http://[::ffff:127.0.0.1]:54321/cb"));
+        let client = client_with_redirect_uris(&["http://[::ffff:127.0.0.1]/cb"]);
+        assert!(!client.allows_redirect_uri("http://[::ffff:127.0.0.1]:54321/cb"));
+        assert!(!client.allows_redirect_uri("http://127.0.0.1:54321/cb"));
+        assert!(client.allows_redirect_uri("http://[::ffff:127.0.0.1]/cb"));
+    }
+
+    #[test]
+    fn scheme_must_match_and_must_be_http() {
+        let client = client_with_redirect_uris(&["https://127.0.0.1/cb"]);
+        assert!(!client.allows_redirect_uri("http://127.0.0.1:54321/cb"));
+        assert!(!client.allows_redirect_uri("https://127.0.0.1:54321/cb"));
+
+        let client = client_with_redirect_uris(&["http://127.0.0.1/cb"]);
+        assert!(!client.allows_redirect_uri("https://127.0.0.1:54321/cb"));
+    }
+
+    #[test]
+    fn only_the_port_is_ignored() {
+        let client = client_with_redirect_uris(&["http://127.0.0.1/cb?x=1#frag"]);
+        // Different path.
+        assert!(!client.allows_redirect_uri("http://127.0.0.1:54321/other?x=1#frag"));
+        // Different query.
+        assert!(!client.allows_redirect_uri("http://127.0.0.1:54321/cb?x=2#frag"));
+        // Missing query.
+        assert!(!client.allows_redirect_uri("http://127.0.0.1:54321/cb#frag"));
+        // Different fragment.
+        assert!(!client.allows_redirect_uri("http://127.0.0.1:54321/cb?x=1#other"));
+        // Only the port differs.
+        assert!(client.allows_redirect_uri("http://127.0.0.1:54321/cb?x=1#frag"));
+    }
+
+    #[test]
+    fn userinfo_must_match() {
+        let client = client_with_redirect_uris(&["http://127.0.0.1/cb"]);
+        assert!(!client.allows_redirect_uri("http://attacker@127.0.0.1:54321/cb"));
+        assert!(!client.allows_redirect_uri("http://:secret@127.0.0.1:54321/cb"));
+    }
+
+    /// The exemption must not leak into ordinary URIs: for anything that is
+    /// not loopback, the port is part of the exact match as it always was.
+    #[test]
+    fn non_loopback_uris_still_match_exactly_including_the_port() {
+        let client = client_with_redirect_uris(&["https://app.example.com/cb"]);
+        assert!(!client.allows_redirect_uri("https://app.example.com:8443/cb"));
+        assert!(client.allows_redirect_uri("https://app.example.com/cb"));
+
+        let client = client_with_redirect_uris(&["http://app.example.com:8080/cb"]);
+        assert!(!client.allows_redirect_uri("http://app.example.com:9090/cb"));
+    }
+
+    /// A loopback registration must not become a wildcard for other hosts.
+    #[test]
+    fn loopback_registration_does_not_admit_a_non_loopback_uri() {
+        let client = client_with_redirect_uris(&["http://127.0.0.1/cb"]);
+        assert!(!client.allows_redirect_uri("http://evil.example.com/cb"));
+        assert!(!client.allows_redirect_uri("http://evil.example.com:54321/cb"));
+        assert!(!client.allows_redirect_uri("http://127.0.0.1.evil.example.com:54321/cb"));
+    }
+
+    #[test]
+    fn malformed_presented_uri_does_not_match() {
+        let client = client_with_redirect_uris(&["http://127.0.0.1/cb"]);
+        assert!(!client.allows_redirect_uri("not a url"));
+        assert!(!client.allows_redirect_uri("127.0.0.1:54321/cb"));
+        assert!(!client.allows_redirect_uri(""));
+    }
+
+    /// A registration that does not parse as a URL is still usable through the
+    /// exact `==` path; it just never reaches the loopback comparison.
+    #[test]
+    fn unparseable_registration_still_matches_exactly() {
+        let client = client_with_redirect_uris(&["not a url"]);
+        assert!(client.allows_redirect_uri("not a url"));
+        assert!(!client.allows_redirect_uri("http://127.0.0.1:54321/cb"));
     }
 }

--- a/crates/authkestra-engine/src/oauth2/code.rs
+++ b/crates/authkestra-engine/src/oauth2/code.rs
@@ -17,7 +17,11 @@ pub struct AuthorizationCode {
     /// The client this code was issued to.
     pub client_id: String,
     /// The exact redirect_uri presented at `/authorize`; `/token` must
-    /// receive the same value.
+    /// receive the same value. For a loopback IP redirect this is the URI
+    /// *with* the ephemeral port the client actually bound, not the portless
+    /// registered form it was matched against (RFC 8252 §7.3,
+    /// authkestra#291), which is what keeps `/token`'s exact comparison
+    /// (RFC 6749 §4.1.3) both correct and unchanged.
     pub redirect_uri: String,
     /// Space-delimited scopes granted.
     pub scope: String,

--- a/crates/authkestra-op/src/error.rs
+++ b/crates/authkestra-op/src/error.rs
@@ -7,9 +7,12 @@ pub enum OpError {
     #[error("unknown client: {0}")]
     UnknownClient(String),
 
-    /// The provided redirect_uri does not exactly match a registered URI
-    /// for this client. Always treat this as a hard failure — never fall
-    /// back to a "closest match" or prefix comparison.
+    /// The provided redirect_uri does not match a registered URI for this
+    /// client — exactly, or, for a loopback IP URI, on every component but
+    /// the port (RFC 8252 §7.3; see
+    /// [`crate::client::ClientRegistration::allows_redirect_uri`]). Always
+    /// treat this as a hard failure — never fall back to a "closest match"
+    /// or prefix comparison.
     #[error("redirect_uri does not match a registered URI for this client")]
     RedirectUriMismatch,
 

--- a/crates/authkestra-op/src/handlers/authorize.rs
+++ b/crates/authkestra-op/src/handlers/authorize.rs
@@ -14,7 +14,10 @@ use rand::RngCore;
 pub struct AuthorizeRequest {
     /// Client ID requesting authorization.
     pub client_id: String,
-    /// Exact match redirect URI.
+    /// The redirect URI the client is asking to be sent back to. Matched
+    /// against the registration by
+    /// [`crate::client::ClientRegistration::allows_redirect_uri`] — exactly,
+    /// save for a loopback IP URI's port (RFC 8252 §7.3).
     pub redirect_uri: String,
     /// Response type (must be "code").
     pub response_type: String,
@@ -68,7 +71,12 @@ pub async fn handle_authorize(
         }
     };
 
-    // 2. Validate exact redirect_uri
+    // 2. Validate the redirect_uri against the registration. Exact, except
+    // for a loopback IP URI's port (RFC 8252 §7.3, authkestra#291) — the
+    // carve-out lives in `allows_redirect_uri`, not here. Everything
+    // downstream (the redirect built below, and the value recorded on the
+    // code) uses the URI *as presented*, so the ephemeral port survives to
+    // `/token`.
     if !client.allows_redirect_uri(&req.redirect_uri) {
         tracing::warn!(
             client_id = %req.client_id,
@@ -532,6 +540,76 @@ mod tests {
         } else {
             panic!("Expected Redirect");
         }
+    }
+
+    /// authkestra#291, end to end: a native app registered
+    /// `http://127.0.0.1/callback` and binds whatever ephemeral port the OS
+    /// hands it. RFC 8252 §7.3 makes accepting that a MUST, and before the fix
+    /// this request could only ever be a `DirectError(RedirectUriMismatch)`.
+    ///
+    /// The second half of the assertion matters as much as the first: the
+    /// browser is redirected to — and the code is persisted with — the
+    /// *presented* URI including its port, not the registered portless one.
+    /// That is what keeps `/token`'s exact `auth_code.redirect_uri !=
+    /// req_redirect_uri` comparison (RFC 6749 §4.1.3) correct and untouched.
+    #[tokio::test]
+    async fn loopback_redirect_on_an_ephemeral_port_is_accepted() {
+        let clients = authkestra_engine::store::memory::MemoryStore::<
+            crate::client::ClientRegistration,
+        >::new();
+        clients
+            .set(
+                "native-app",
+                ClientRegistration {
+                    client_id: "native-app".to_string(),
+                    client_secret_hash: None,
+                    redirect_uris: vec!["http://127.0.0.1/callback".to_string()],
+                    grant_types: vec![GrantType::AuthorizationCode],
+                    scopes: vec!["openid".to_string()],
+                    require_pkce: false,
+                    allowed_audiences: vec![],
+                    token_endpoint_auth_method: None,
+                    jwks: None,
+                },
+                std::time::Duration::from_secs(31536000),
+            )
+            .await
+            .unwrap();
+
+        let mut codes =
+            authkestra_engine::store::memory::MemoryStore::<crate::code::AuthorizationCode>::new();
+        let config = test_config();
+
+        let req = AuthorizeRequest {
+            client_id: "native-app".to_string(),
+            redirect_uri: "http://127.0.0.1:54321/callback".to_string(),
+            response_type: "code".to_string(),
+            scope: "openid".to_string(),
+            state: Some("abc".to_string()),
+            code_challenge: Some("s256challenge".to_string()),
+            code_challenge_method: Some("S256".to_string()),
+            nonce: None,
+        };
+
+        let outcome = handle_authorize(req, test_identity(), &config, &mut crate::store::CompositeOpStore::new(clients, codes.clone(), authkestra_engine::store::memory::MemoryStore::<crate::refresh::RefreshToken>::new(), authkestra_engine::store::memory::MemoryStore::<crate::device::DeviceCodeSession>::new())).await;
+
+        let AuthorizeOutcome::Redirect(url) = outcome else {
+            panic!("expected a Redirect, got {outcome:?}");
+        };
+        assert!(
+            url.starts_with("http://127.0.0.1:54321/callback?code="),
+            "redirect must go to the presented port, got {url}"
+        );
+
+        let code_val = url
+            .split("code=")
+            .nth(1)
+            .unwrap()
+            .split('&')
+            .next()
+            .unwrap();
+        let persisted = codes.consume_code(code_val).await.unwrap().unwrap();
+        assert_eq!(persisted.redirect_uri, "http://127.0.0.1:54321/callback");
     }
 
     /// authkestra#280: an omitted `scope` (RFC 6749 §3.3 makes this legal)

--- a/crates/authkestra-op/src/handlers/token.rs
+++ b/crates/authkestra-op/src/handlers/token.rs
@@ -878,7 +878,16 @@ pub async fn default_handle_authorization_code<S: OpStore + ?Sized>(
         });
     }
 
-    // 5. Validate redirect_uri matches
+    // 5. Validate redirect_uri matches. Deliberately an exact string
+    // comparison, and deliberately *not* routed through
+    // `ClientRegistration::allows_redirect_uri`: RFC 6749 §4.1.3 requires the
+    // token request to repeat the identical value from the authorization
+    // request, which is a different question from whether the client was
+    // allowed to use it at all. The RFC 8252 §7.3 loopback any-port carve-out
+    // (authkestra#291) has no business here — `auth_code.redirect_uri` already
+    // holds the concrete port the client presented at `/authorize`, so
+    // ignoring the port would only let one loopback port be swapped for
+    // another mid-flow.
     if auth_code.redirect_uri != req_redirect_uri {
         tracing::warn!(
             expected_uri = %auth_code.redirect_uri,

--- a/docs/book/ch09-security-and-threat-model.md
+++ b/docs/book/ch09-security-and-threat-model.md
@@ -19,7 +19,7 @@ To prevent user tracking and correlation between services:
 
 ## 4. Modern Hardened Defaults
 - **PKCE Mandatory**: No OAuth flows without Proof Key for Code Exchange.
-- **Exact Redirect Matching**: Preventing open redirector vulnerabilities.
+- **Exact Redirect Matching**: Preventing open redirector vulnerabilities. The only relaxation is the one RFC 8252 §7.3 requires: a registered loopback IP redirect URI (`http://127.0.0.1/...`, `http://[::1]/...`) matches on any port, since a native app is handed an ephemeral port by the OS at request time. Everything else about the URI still has to match exactly, `localhost` is not accepted as a substitute for the IP literal (§8.3), and the exemption cannot reach a non-loopback host — so it does not widen the open-redirect surface.
 - **Sender-Constrained Tokens**: Using DPoP to bind tokens to the client's cryptographic key.
 
 ## 5. SD-JWT: Fail-Closed Disclosure Verification

--- a/docs/rfc-003-oidc-provider.md
+++ b/docs/rfc-003-oidc-provider.md
@@ -96,6 +96,7 @@ pub struct ClientRegistration {
     pub client_id: String,
     pub client_secret_hash: String, // never store plaintext
     pub redirect_uris: Vec<String>, // exact-match only; no wildcard/prefix matching
+                                    // (except a loopback IP URI's port — see §7)
     pub grant_types: Vec<GrantType>,
     pub scopes: Vec<String>,
 }
@@ -137,6 +138,17 @@ pluggable backends, in-memory implementation ships first).
   string match** against the client's registered URIs — no partial or
   prefix matching. This is the single most common OAuth implementation bug
   (open redirect).
+  - **Amended by authkestra#291**: one carve-out, which RFC 8252 §7.3 makes a
+    MUST — a registered **loopback IP** redirect URI (`http://127.0.0.1/...`
+    or `http://[::1]/...`) matches on **any** port, because a native app takes
+    an ephemeral port from the OS at request time and cannot register it.
+    Only the port is ignored; scheme, host, userinfo, path, query and fragment
+    must still be equal, and the host must be the IP literal — `localhost` is
+    excluded per §8.3, as is the rest of `127.0.0.0/8`. This applies to the
+    registration check at `/authorize` only. The `/token` comparison of the
+    request's `redirect_uri` against the one recorded on the authorization
+    code stays an exact string match (RFC 6749 §4.1.3): the recorded value
+    already carries the concrete port the client used.
 - PKCE (`code_challenge`/`code_verifier`) is mandatory for public clients
   and recommended for all clients, per OAuth 2.1.
 - Authorization codes are single-use and short-lived (recommend ≤60s); the


### PR DESCRIPTION
## What this is

This is the **port of #307 to the `next` branch**. #307 fixes the same bug against `main`. Only one of the two should be kept — see "Merge order" below.

`ClientRegistration::allows_redirect_uri` compares redirect URIs by plain string equality with no loopback carve-out, so a native app that binds an ephemeral port — the case RFC 8252 §7.3 makes a **MUST** — can never authenticate: the port is not knowable at registration time, so no registered value can match and `/authorize` fails with `invalid redirect_uri` every time.

Exact `==` stays the first and normal check, and now falls back to `loopback_match`, which applies **only** when both URIs parse, both have scheme `http`, and both hosts equal the IP literal `127.0.0.1` (`url::Host::Ipv4`) or `::1` (`url::Host::Ipv6`). Scheme, host, userinfo, path, query and fragment must all still be equal; **only the port is ignored**. A `tracing::debug!` fires when the exemption, rather than exact equality, is what allowed the match.

Three spellings stay excluded on purpose, with the reasoning recorded on `is_loopback_ip` so nobody "fixes" them casually: `localhost` (refused outright — stricter than §8.3's NOT RECOMMENDED, because the host must be unambiguously the user's own machine and `localhost` is `Host::Domain` here), the rest of `127.0.0.0/8` (hence not `Ipv4Addr::is_loopback()`), and IPv4-mapped IPv6 loopback `[::ffff:127.0.0.1]` (`Ipv6Addr::LOCALHOST` is `::1`).

## Where it landed on `next`, and how that differs from #307

On `next`, PR #300 has already moved `ClientRegistration`/`GrantType`/`AuthorizationCode` into `authkestra_engine::oauth2::{client,code}` and reduced `crates/authkestra-op/src/client.rs` to a re-export. So:

| | `main` (#307) | `next` (this PR) |
| --- | --- | --- |
| `allows_redirect_uri`, `loopback_match`, `is_loopback_ip`, 12 unit tests | `crates/authkestra-op/src/client.rs` | `crates/authkestra-engine/src/oauth2/client.rs` |
| `AuthorizationCode::redirect_uri` doc note | `crates/authkestra-op/src/code.rs` | `crates/authkestra-engine/src/oauth2/code.rs` |
| handler test, `/token` comment, `OpError` doc, `docs/` | same paths | same paths |

`url` and `tracing` are already direct dependencies of `authkestra-engine`, so **no `Cargo.toml` changed** here either (and `cargo deny check` is therefore not applicable).

Two deviations from #307, both forced by `next` and both test-only — called out rather than left to be noticed:

- the ported handler test passes `&mut crate::store::CompositeOpStore::new(..)`, because on `next` `handle_authorize` takes `&mut dyn OpStore` rather than `&dyn OpStore`;
- its `codes` binding is `let mut codes`, because `consume_code` takes `&mut self` on `next`.

Everything else — helper names, tracing message and fields, doc comments, test names and assertions — is byte-identical to #307.

## The `/token` check is untouched here too

I verified on `next` that `default_handle_authorization_code` still compares `auth_code.redirect_uri != req_redirect_uri` with a plain `!=`, and it stays that way. That is RFC 6749 §4.1.3 — the token request must repeat the identical value from the authorization request — which is a different question from whether the client was allowed to use the URI at all. The recorded value already carries the concrete ephemeral port, so applying the §7.3 carve-out there would only let one loopback port be swapped for another mid-flow. A comment at that site now says so.

## Tests

12 unit tests in `crates/authkestra-engine/src/oauth2/client.rs` (ephemeral port accepted; registered port not binding; `[::1]`; `localhost` refused in both positions; `127.0.0.2` and `[::ffff:127.0.0.1]` refused; `https` vs `http`; differing path/query/fragment/userinfo; non-loopback URIs still exact including port; loopback registration does not admit `evil.example.com` or `127.0.0.1.evil.example.com`; malformed presented URI; unparseable registration still matches via `==`), plus `loopback_redirect_on_an_ephemeral_port_is_accepted` in `crates/authkestra-op/src/handlers/authorize.rs`, which asserts end to end that the 302 goes to the presented port **and** that the persisted `AuthorizationCode::redirect_uri` keeps that port.

Mutant check on this branch: short-circuiting the `loopback_match` fallback makes 4 of the 12 fail (`loopback_registration_accepts_any_ephemeral_port`, `loopback_registration_with_a_port_accepts_a_different_port`, `ipv6_loopback_literal_gets_the_same_exemption`, `only_the_port_is_ignored`); restored, all 12 pass.

## Verification

All run with `CARGO_TARGET_DIR`, `DOCKER_HOST` and `CARGO_BUILD_JOBS=6` exported. **`DOCKER_HOST` must point at the user socket under rootless Docker** (e.g. `export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock`), or the `sqlx`/`redis` testcontainer suites fail with `PermissionDenied` rather than skipping.

| command | exit |
| --- | --- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-features -- -D warnings` | 0 |
| `cargo test -p authkestra-engine --all-features` | 0 (141 lib tests incl. the 12 new ones) |
| `cargo test -p authkestra-op --all-features` | 0 (184 lib tests incl. the handler test) |
| `cargo build --workspace --all-features --examples` | 0 |
| `cargo test --workspace --all-features` | **101 — see below** |

**I am not reporting the workspace test as green, because it is not.** It fails on this machine, and I could not get a clean run. Both failures are environmental and neither is caused by this change:

- `authkestra-store-sqlx --lib`: 9 `mysql_tests` fail with `WaitContainer(StartupTimeout)`. **I checked this against a pristine `origin/next` (95ede6d) with none of this branch's changes applied: it fails 9/9 there too** — in fact worse than the 7/9 seen on this branch. This crate is not touched by this PR. The box is running many other containers concurrently and MySQL never finishes starting.
- `authkestra --test examples_e2e`: `axum_oauth2_github failed to start after 180s`. The test spawns the example through cargo, and the log shows `Blocking waiting for file lock on build directory` — a shared-target-dir contention stall, not a product failure. Run on its own it passes (`cargo test -p authkestra --all-features --test examples_e2e`, exit 0, 169.87s — note that is already close to the 180s budget even without contention).

With `--no-fail-fast`, those two targets are the *only* failures in the whole workspace; every other target passes, including all of `authkestra-engine` and `authkestra-op`. CI, which is not sharing a machine with several other builds, should be green — but I would rather say plainly that I could not prove it here than hand over a green I do not trust.

## Pre-existing gap noticed while porting (not fixed here)

The move in #300 dropped four `ClientRegistration` unit tests that exist on `main` — `test_verify_secret_valid`, `test_verify_secret_invalid`, `test_verify_secret_public_client` and `test_grant_type_serialization`. They are in `crates/authkestra-op/src/client.rs` on `origin/main` and appear **nowhere** in the tree on `origin/next` (`git grep` finds no match). That is a real coverage regression on `next`, including the only direct coverage of `verify_secret`'s argon2 path.

I have deliberately **not** restored them here: that is #300's content and its author's call, and quietly folding them into an unrelated PR would hide the regression rather than surface it. Flagging it instead.

## Merge order

- If **#307 lands first** (into `main`) and `next` is then merged, whoever resolves that merge must keep both copies of the fix in the right place, or the `authkestra-engine` copy will be lost.
- If **#300 lands first**, take *this* PR and close #307 as superseded.
- Either way, exactly one of #307 / this PR should survive into `main`. #307 carries the `Closes #291`; this one is deliberately `Refs #291` so it cannot close the issue on its own.

Refs #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)
