### PR TITLE
fix(release): unblock release-plz publish of authkestra-store-testsuite

### DIFF
--- a/crates/authkestra-store-testsuite/Cargo.toml
+++ b/crates/authkestra-store-testsuite/Cargo.toml
@@ -34,7 +34,19 @@ authkestra-engine = { workspace = true, default-features = true, features = ["re
 authkestra-op = { workspace = true, default-features = true, features = ["redis"] }
 testcontainers = "0.27.3"
 testcontainers-modules = { version = "0.15.0", features = ["redis", "postgres", "mysql"] }
-authkestra-store-sqlx = { workspace = true, default-features = true, features = ["sqlite"] }
+# Deliberately path-only, no version (not `workspace = true`, which would
+# inherit one): a dev-dependency *with* a version isn't stripped from the
+# published manifest, so `cargo package` needs it already on crates.io.
+# authkestra-store-sqlx is published for the first time in the same
+# release batch as this crate, so at packaging time it never is yet —
+# "no matching package named `authkestra-store-sqlx` found" (authkestra
+# release-plz run, 2026-09-03). Version-less path dev-deps are dropped
+# from the published manifest entirely, sidestepping the whole problem;
+# the only cost is that `tests/sqlx_store.rs` can't run against a copy
+# installed from crates.io, which was never a supported use case anyway.
+authkestra-store-sqlx = { path = "../authkestra-store-sqlx", default-features = true, features = [
+    "sqlite",
+] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
 # This crate's own tests/*.rs use #[tokio::test], which needs "macros" —
 # declared explicitly rather than relying on it arriving via


### PR DESCRIPTION
## Summary
- `release-plz`'s first publish attempt for this release batch failed: `authkestra-store-testsuite`'s dev-dependency on `authkestra-store-sqlx` used `workspace = true`, which pulls in a `version` requirement. A dev-dependency *with* a version isn't stripped from the published manifest, so `cargo package` needed `authkestra-store-sqlx` already on crates.io — but both crates are publishing for the first time in the same batch, so it wasn't there yet:
  ```
  error: failed to prepare local package for uploading
  Caused by:
    no matching package named `authkestra-store-sqlx` found
  ```
- Switched that one dependency to a plain `path = "../authkestra-store-sqlx"` with no version. Cargo drops a version-less path dev-dependency from the published manifest entirely, so packaging no longer needs to resolve it against the registry. Only cost: `tests/sqlx_store.rs` can't run against a copy installed from crates.io, which was never a supported use case for this workspace-internal integration test.

## Test plan
- [x] `cargo build --workspace --all-features --examples --tests` passes
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` passes
- [x] `cargo test --workspace --all-features` passes
- [x] `cargo publish -p authkestra-store-testsuite --dry-run --no-verify` — previously failed with the `authkestra-store-sqlx` resolution error, now succeeds and reaches the upload step

🤖 Generated with [Claude Code](https://claude.com/claude-code)