### PR TITLE
Link the docs site to the playground

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -15,6 +15,12 @@ export default defineConfig({
 			],
 			sidebar: [
 				{
+					label: 'Playground',
+					link: 'https://play.authkestra.com',
+					attrs: { target: '_blank', rel: 'noreferrer' },
+					badge: { text: 'Live', variant: 'tip' },
+				},
+				{
 					label: 'Welcome',
 					items: [
 						{ label: 'Why Authkestra?', slug: 'concepts/architecture' },

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -10,6 +10,10 @@ hero:
     - text: Quickstart Guide
       link: /guides/quickstart/
       icon: right-arrow
+    - text: Try the Playground
+      link: https://play.authkestra.com
+      icon: rocket
+      variant: secondary
     - text: View on GitHub
       link: https://github.com/marcjazz/authkestra
       icon: external


### PR DESCRIPTION
Adds cross-links between authkestra.com and the playground.

## What changed

- **Landing page hero** gains a `Try the Playground` action (`website/src/content/docs/index.mdx`)
- **Sidebar** gains a `Playground` entry with a `Live` badge, so it is reachable from every docs page rather than only the front page (`website/astro.config.mjs`)

The sidebar link opens in a new tab (`target="_blank" rel="noreferrer"`) so a reader following it does not lose their place in the docs.

The reverse direction is already live: the playground's header links to `https://authkestra.com`.

## ⚠️ Do not merge yet

`play.authkestra.com` has **no DNS record**, so merging this today would publish a dead link on the live site. Merge once the record exists and resolves.

Current state: the playground runs at `authkestra-playground-api.onrender.com` (API) and a Vercel URL (frontend). If you would rather link the Vercel URL now and switch to the custom domain later, say so and I will change it — but two link changes seemed worse than one wait.

## Verified

Built the site with the changes — 24 pages, no errors — and confirmed both links appear in the output HTML with the intended `target`/`rel`:

```
dist/index.html                    href="https://play.authkestra.com"  ("Try the Playground")
dist/guides/quickstart/index.html  href="https://play.authkestra.com" target="_blank" rel="noreferrer"
```

Opened as a PR rather than pushed to `main`: this is a public-facing site and not the repository I was working in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)