### PR TITLE
fix(providers): make single-provider builds work (#321)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,27 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --all-features
 
+  provider-features:
+    # Every other job builds with --all-features, which is why a dependency
+    # gated behind one provider feature but used by all of them compiled
+    # cleanly here and broke for anyone selecting a single provider.
+    # See https://github.com/marcjazz/authkestra/issues/321.
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        feature: [github, google, discord]
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry and build
+        uses: swatinem/rust-cache@v2
+      - name: Build with one provider and nothing else
+        run: |
+          cargo check -p authkestra-providers --no-default-features \
+            --features ${{ matrix.feature }},rustls-aws-lc-rs
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,12 @@ jobs:
       - name: Cache cargo registry and build
         uses: swatinem/rust-cache@v2
       - name: Build with one provider and nothing else
+        # --all-targets on purpose: without it this only compiles the lib, and
+        # the tests and examples — where a feature-gating slip is just as easy
+        # to make — are never built. Requires the provider tests to declare
+        # `required-features`, which they do.
         run: |
-          cargo check -p authkestra-providers --no-default-features \
+          cargo check --all-targets -p authkestra-providers --no-default-features \
             --features ${{ matrix.feature }},rustls-aws-lc-rs
 
   lint:

--- a/crates/authkestra-providers/Cargo.toml
+++ b/crates/authkestra-providers/Cargo.toml
@@ -15,6 +15,13 @@ default = ["rustls-aws-lc-rs"]
 github = []
 google = []
 discord = []
+# A no-op, kept deliberately. `urlencoding` used to be an optional dependency,
+# which gave this crate an implicit feature of the same name. Making it a real
+# dependency removes that feature, and a manifest asking for a feature that no
+# longer exists fails to resolve — an error a downstream crate cannot work
+# around. Anyone who reached for `features = ["urlencoding"]` to get past #321
+# keeps resolving.
+urlencoding = []
 
 # TLS backend, forwarded to authkestra-engine. See its documentation for the
 # `rustls-no-provider` contract.
@@ -43,3 +50,21 @@ tracing = "0.1"
 [dev-dependencies]
 wiremock = "0.6.5"
 tokio = { version = "1.0", features = ["full"] }
+
+# Each test drives one provider, so it only compiles when that provider is
+# enabled. Declared explicitly rather than `#![cfg(feature = ...)]` inside the
+# file, matching `authkestra-axum`'s integration tests — and, more to the point,
+# so `--all-targets` can be used to guard single-provider builds. Without this
+# the guard job cannot see tests or examples at all, which is where the next
+# feature-gating slip would hide.
+[[test]]
+name = "github_oauth"
+required-features = ["github"]
+
+[[test]]
+name = "google_oauth"
+required-features = ["google"]
+
+[[test]]
+name = "discord_oauth"
+required-features = ["discord"]

--- a/crates/authkestra-providers/Cargo.toml
+++ b/crates/authkestra-providers/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 default = ["rustls-aws-lc-rs"]
 github = []
 google = []
-discord = ["urlencoding"]
+discord = []
 
 # TLS backend, forwarded to authkestra-engine. See its documentation for the
 # `rustls-no-provider` contract.
@@ -34,7 +34,10 @@ reqwest = { version = "0.13.1", default-features = false, features = [
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-urlencoding = { version = "2.1", optional = true }
+# Used by `define_oauth_provider!` for every provider it generates, so it
+# cannot be optional: gating it behind one provider feature breaks the
+# others. See https://github.com/marcjazz/authkestra/issues/321.
+urlencoding = "2.1"
 tracing = "0.1"
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes #321. **Patch-safe: nothing in the public API changes.**

`authkestra-providers` gated `urlencoding` behind the `discord` feature alone, but uses it in the macro that generates *every* provider. So `features = ["github"]` failed to compile inside the dependency:

```
error[E0433]: cannot find module or crate `urlencoding`
   --> authkestra-providers-0.8.0/src/macros.rs:108:36
```

`urlencoding` is now a plain dependency and `discord` an empty feature, matching what `authkestra-oidc` already does.

### Keeping it a patch

Two things had to be handled, both raised in review:

- Making the dependency non-optional also removes the **implicit feature** named `urlencoding` that the optional dependency created. Anyone who enabled it to work around #321 would hit `does not have the feature urlencoding` — a resolution error, not a compile error, so unworkable-around downstream. It is kept as a no-op.
- The `AxumError::NotFound` work originally in this PR has moved out. Adding a variant to a public enum that is neither `#[non_exhaustive]` nor unreachable is a major bump under Cargo's SemVer rules, and `AxumError` is `pub use`d at the crate root and serves as the extractor `Rejection` type. It will land in the next minor instead.

### The guard

A `provider-features` matrix builds each provider on its own. It fails on the parent commit and passes here.

It initially ran `cargo check` without `--all-targets`, which compiles only the lib — so it guarded one shape of the bug rather than the class. The provider tests had no feature gating, and

```sh
cargo check --all-targets -p authkestra-providers --no-default-features \
  --features github,rustls-aws-lc-rs
```

failed with unresolved imports of the `google` and `discord` modules while the job passed. The tests now declare `required-features` (the pattern `authkestra-axum` already uses) and the job builds `--all-targets`.

Verified load-bearing by removing `required-features` from one test and watching the job's exact command fail, then restoring it.

### Note for the release

Worth a changelog line: the `urlencoding` feature still exists but does nothing, and can be dropped at the next major.

### Why the workspace never saw this

Correcting what this section said earlier: I claimed `crates/authkestra/Cargo.toml:29` pinned the provider features on the facade's *dependency* line. It does not — line 29 is in `[dev-dependencies]`. The facade's real dependencies (13-19) are all `optional = true, default-features = false`, which is right.

The mechanism is dev-dependency feature unification instead. Any workspace test build compiles those dev-dependencies, so the single `authkestra-providers` in the graph gets `github`, `google` and `discord` all enabled, and `urlencoding` is always present. Combined with every CI job building `--all-features`, no build in the repo had ever resolved a single provider on its own.

The conclusion stands and so does the fix; the explanation was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
