### PR TITLE
fix(axum): return 404 for an unknown OAuth provider (#320)

### DIFF
--- a/crates/authkestra-actix/src/helpers/api.rs
+++ b/crates/authkestra-actix/src/helpers/api.rs
@@ -18,14 +18,40 @@ use super::cookie::create_actix_cookie;
 /// finite. `authkestra-axum` bounds it identically — the two adapters return
 /// the same body by design, and a fix to one that skipped the other would
 /// quietly break that.
+///
+/// The budget is in **bytes**, not characters. What matters for a reflection is
+/// how much attacker-controlled data comes back, and 64 characters is up to 256
+/// bytes of UTF-8 — so a character bound does not actually bound the response.
+/// The cut is moved down to a `char` boundary so the result is still valid UTF-8.
 fn provider_for_display(provider: &str) -> String {
-    const MAX: usize = 64;
-    let shown: String = provider.chars().take(MAX).collect();
-    if shown.chars().count() < provider.chars().count() {
-        format!("{shown}\u{2026}")
-    } else {
-        shown
+    const MAX_BYTES: usize = 64;
+    if provider.len() <= MAX_BYTES {
+        return provider.to_string();
     }
+    let mut end = MAX_BYTES;
+    while !provider.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}\u{2026}", &provider[..end])
+}
+
+/// The 404 for an unregistered provider.
+///
+/// Built in one place because the `Content-Type` is load-bearing and easy to
+/// forget: `HttpResponseBuilder::body` sets no content type at all, and a
+/// response with none *and* an echoed path segment is sniffed as HTML by
+/// browsers — which turns this message into a reflected-XSS sink reachable from
+/// a plain link. `authkestra-axum` gets `text/plain` for free from
+/// `(StatusCode, String)`; actix does not, so it is set explicitly here, with
+/// `nosniff` as the belt to that braces.
+fn provider_not_found(provider: &str) -> HttpResponse {
+    HttpResponse::NotFound()
+        .content_type(actix_web::http::header::ContentType::plaintext())
+        .insert_header(("x-content-type-options", "nosniff"))
+        .body(format!(
+            "Provider {} not found",
+            provider_for_display(provider)
+        ))
 }
 
 #[derive(serde::Deserialize)]
@@ -186,10 +212,7 @@ pub async fn actix_login_handler<S, T>(
     let flow: &std::sync::Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return HttpResponse::NotFound().body(format!(
-                "Provider {} not found",
-                provider_for_display(&provider)
-            ));
+            return provider_not_found(&provider);
         }
     };
 
@@ -221,10 +244,7 @@ where
     let flow: &std::sync::Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Ok(HttpResponse::NotFound().body(format!(
-                "Provider {} not found",
-                provider_for_display(&provider)
-            )));
+            return Ok(provider_not_found(&provider));
         }
     };
 
@@ -369,10 +389,7 @@ where
     let flow: &std::sync::Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Ok(HttpResponse::NotFound().body(format!(
-                "Provider {} not found",
-                provider_for_display(&provider)
-            )));
+            return Ok(provider_not_found(&provider));
         }
     };
 

--- a/crates/authkestra-actix/src/helpers/api.rs
+++ b/crates/authkestra-actix/src/helpers/api.rs
@@ -9,6 +9,25 @@ use std::sync::Arc;
 #[cfg(feature = "session")]
 use super::cookie::create_actix_cookie;
 
+/// The provider name, bounded, for use in a response body.
+///
+/// The name is an unvalidated, URL-decoded path segment, and the 404 body
+/// echoes it back so the caller can see what was not found. Echoing it
+/// unbounded means an arbitrarily long attacker-controlled string is reflected
+/// into a response; bounding it keeps the message useful and the reflection
+/// finite. `authkestra-axum` bounds it identically — the two adapters return
+/// the same body by design, and a fix to one that skipped the other would
+/// quietly break that.
+fn provider_for_display(provider: &str) -> String {
+    const MAX: usize = 64;
+    let shown: String = provider.chars().take(MAX).collect();
+    if shown.chars().count() < provider.chars().count() {
+        format!("{shown}\u{2026}")
+    } else {
+        shown
+    }
+}
+
 #[derive(serde::Deserialize)]
 #[non_exhaustive]
 pub struct OAuthCallbackParams {
@@ -167,7 +186,10 @@ pub async fn actix_login_handler<S, T>(
     let flow: &std::sync::Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return HttpResponse::NotFound().body(format!("Provider {provider} not found"));
+            return HttpResponse::NotFound().body(format!(
+                "Provider {} not found",
+                provider_for_display(&provider)
+            ));
         }
     };
 
@@ -199,7 +221,10 @@ where
     let flow: &std::sync::Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Ok(HttpResponse::NotFound().body(format!("Provider {provider} not found")));
+            return Ok(HttpResponse::NotFound().body(format!(
+                "Provider {} not found",
+                provider_for_display(&provider)
+            )));
         }
     };
 
@@ -344,7 +369,10 @@ where
     let flow: &std::sync::Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Ok(HttpResponse::NotFound().body(format!("Provider {provider} not found")));
+            return Ok(HttpResponse::NotFound().body(format!(
+                "Provider {} not found",
+                provider_for_display(&provider)
+            )));
         }
     };
 

--- a/crates/authkestra-actix/tests/engine_session_integration.rs
+++ b/crates/authkestra-actix/tests/engine_session_integration.rs
@@ -363,3 +363,87 @@ async fn callback_rejects_provider_exchange_failure() {
 
     assert_eq!(callback_resp.status(), StatusCode::UNAUTHORIZED);
 }
+
+/// An unregistered provider is a client error, and the body that names it must
+/// not be sniffable as HTML.
+///
+/// The actix adapter has always answered 404 here — issue #320 was that axum
+/// answered 500 for the same request. What was missing on this side is the
+/// content type: `HttpResponseBuilder::body` sets none, and a typeless response
+/// echoing a URL-decoded path segment is sniffed as HTML by browsers, which
+/// makes this message a reflected-XSS sink reachable from a plain link.
+#[actix_web::test]
+async fn an_unknown_provider_is_not_found_and_not_sniffable() {
+    let engine = build_engine();
+    let state = AppState {
+        auth: engine.clone(),
+    };
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(state.clone()))
+            .configure(move |cfg| state.configure_authkestra(cfg))
+            .service(engine.actix_scope()),
+    )
+    .await;
+
+    // A payload that is inert as text and executable as HTML.
+    let req = test::TestRequest::get()
+        .uri("/auth/login/%3Cimg%20src%3Dx%20onerror%3Dalert(1)%3E")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let content_type = resp
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .map(|v| v.to_str().unwrap().to_string())
+        .expect("a body echoing a path segment must declare its content type");
+    assert!(
+        content_type.starts_with("text/plain"),
+        "the 404 body must be text/plain, got {content_type:?}"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("x-content-type-options")
+            .map(|v| v.to_str().unwrap()),
+        Some("nosniff"),
+        "without nosniff a browser may still sniff the echoed name as HTML"
+    );
+}
+
+/// The 404 body echoes the provider name, so the reflection has to be bounded.
+/// `authkestra-axum` bounds it identically; this is the test that keeps the two
+/// in step, rather than a pair of doc comments asserting it.
+#[actix_web::test]
+async fn a_long_provider_name_is_truncated_in_the_body() {
+    let engine = build_engine();
+    let state = AppState {
+        auth: engine.clone(),
+    };
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(state.clone()))
+            .configure(move |cfg| state.configure_authkestra(cfg))
+            .service(engine.actix_scope()),
+    )
+    .await;
+
+    let long = "a".repeat(5_000);
+    let req = test::TestRequest::get()
+        .uri(&format!("/auth/login/{long}"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let body = test::read_body(resp).await;
+    let body = String::from_utf8(body.to_vec()).unwrap();
+    assert!(
+        body.len() < 200,
+        "the body reflected {} bytes: {body:.120?}",
+        body.len()
+    );
+    assert!(
+        body.contains('\u{2026}'),
+        "truncation should be visible: {body:?}"
+    );
+}

--- a/crates/authkestra-axum/src/helpers/api.rs
+++ b/crates/authkestra-axum/src/helpers/api.rs
@@ -285,7 +285,8 @@ where
         Some(f) => f,
         None => {
             return Err(AxumError::NotFound(format!(
-                "Provider {provider} not found"
+                "Provider {} not found",
+                provider_for_display(&provider)
             )));
         }
     };
@@ -329,7 +330,8 @@ where
         Some(f) => f,
         None => {
             return Err(AxumError::NotFound(format!(
-                "Provider {provider} not found"
+                "Provider {} not found",
+                provider_for_display(&provider)
             )));
         }
     };
@@ -374,7 +376,8 @@ where
         Some(f) => f,
         None => {
             return Err(AxumError::NotFound(format!(
-                "Provider {provider} not found"
+                "Provider {} not found",
+                provider_for_display(&provider)
             )));
         }
     };
@@ -420,6 +423,25 @@ where
                 AxumError::Internal(msg)
             }
         })
+}
+
+/// The provider name, bounded, for use in a response body.
+///
+/// The name is an unvalidated, URL-decoded path segment, and the 404 body
+/// echoes it back so the caller can see what was not found. Echoing it
+/// unbounded means an arbitrarily long attacker-controlled string is reflected
+/// into a response; bounding it keeps the message useful and the reflection
+/// finite. `authkestra-actix` bounds it identically — the two adapters return
+/// the same body by design, and a fix to one that skipped the other would
+/// quietly break that.
+fn provider_for_display(provider: &str) -> String {
+    const MAX: usize = 64;
+    let shown: String = provider.chars().take(MAX).collect();
+    if shown.chars().count() < provider.chars().count() {
+        format!("{shown}\u{2026}")
+    } else {
+        shown
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/authkestra-axum/src/helpers/api.rs
+++ b/crates/authkestra-axum/src/helpers/api.rs
@@ -434,14 +434,21 @@ where
 /// finite. `authkestra-actix` bounds it identically — the two adapters return
 /// the same body by design, and a fix to one that skipped the other would
 /// quietly break that.
+///
+/// The budget is in **bytes**, not characters. What matters for a reflection is
+/// how much attacker-controlled data comes back, and 64 characters is up to 256
+/// bytes of UTF-8 — so a character bound does not actually bound the response.
+/// The cut moves down to a `char` boundary so the result stays valid UTF-8.
 fn provider_for_display(provider: &str) -> String {
-    const MAX: usize = 64;
-    let shown: String = provider.chars().take(MAX).collect();
-    if shown.chars().count() < provider.chars().count() {
-        format!("{shown}\u{2026}")
-    } else {
-        shown
+    const MAX_BYTES: usize = 64;
+    if provider.len() <= MAX_BYTES {
+        return provider.to_string();
     }
+    let mut end = MAX_BYTES;
+    while !provider.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}\u{2026}", &provider[..end])
 }
 
 #[derive(Debug, Clone)]
@@ -474,7 +481,18 @@ impl IntoResponse for AxumError {
             AxumError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
             AxumError::ComponentMissing(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
         };
-        (status, message).into_response()
+        // `(StatusCode, String)` already sets `text/plain; charset=utf-8`, which
+        // is what keeps the echoed provider name in a 404 from being sniffed as
+        // HTML. `nosniff` states that explicitly rather than relying on the
+        // tuple impl keeping that behaviour, and matches what `authkestra-actix`
+        // sends — where the content type has to be set by hand because
+        // `HttpResponseBuilder::body` sets none at all.
+        (
+            status,
+            [(axum::http::header::X_CONTENT_TYPE_OPTIONS, "nosniff")],
+            message,
+        )
+            .into_response()
     }
 }
 

--- a/crates/authkestra-axum/src/helpers/api.rs
+++ b/crates/authkestra-axum/src/helpers/api.rs
@@ -284,7 +284,9 @@ where
     let flow: &Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Err(AxumError::Internal("Provider not found".to_string()));
+            return Err(AxumError::NotFound(format!(
+                "Provider {provider} not found"
+            )));
         }
     };
 
@@ -326,7 +328,9 @@ where
     let flow: &Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Err(AxumError::Internal("Provider not found".to_string()));
+            return Err(AxumError::NotFound(format!(
+                "Provider {provider} not found"
+            )));
         }
     };
 
@@ -369,7 +373,9 @@ where
     let flow: &Arc<dyn ErasedOAuthFlow> = match authkestra.providers.get(&provider) {
         Some(f) => f,
         None => {
-            return Err(AxumError::Internal("Provider not found".to_string()));
+            return Err(AxumError::NotFound(format!(
+                "Provider {provider} not found"
+            )));
         }
     };
 
@@ -419,6 +425,9 @@ where
 #[derive(Debug, Clone)]
 pub enum AxumError {
     Unauthorized(String),
+    /// The caller asked for something that does not exist — an unregistered
+    /// OAuth provider, say. A client error, not a server fault.
+    NotFound(String),
     Internal(String),
     /// A required component (e.g., SessionManager, TokenManager) is missing
     ComponentMissing(String),
@@ -428,6 +437,7 @@ impl std::fmt::Display for AxumError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             AxumError::Unauthorized(msg) => write!(f, "Unauthorized: {}", msg),
+            AxumError::NotFound(msg) => write!(f, "Not Found: {}", msg),
             AxumError::Internal(msg) => write!(f, "Internal Error: {}", msg),
             AxumError::ComponentMissing(msg) => write!(f, "Component Missing: {}", msg),
         }
@@ -438,6 +448,7 @@ impl IntoResponse for AxumError {
     fn into_response(self) -> axum::response::Response {
         let (status, message) = match self {
             AxumError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg),
+            AxumError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
             AxumError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
             AxumError::ComponentMissing(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
         };

--- a/crates/authkestra-axum/tests/engine_session_integration.rs
+++ b/crates/authkestra-axum/tests/engine_session_integration.rs
@@ -416,3 +416,56 @@ async fn callback_rejects_provider_exchange_failure() {
 
     assert_eq!(callback_resp.status(), StatusCode::UNAUTHORIZED);
 }
+
+/// An unregistered provider is a client error, not a server fault.
+///
+/// This returned 500 until #321's sibling fix: `AxumError` had no not-found
+/// variant, so the three `providers.get()` misses fell back to `Internal`.
+/// The actix adapter answered 404 for the identical condition, so the two
+/// adapters disagreed on the HTTP contract for the same request.
+/// See https://github.com/marcjazz/authkestra/issues/320.
+#[tokio::test]
+async fn an_unknown_provider_is_not_found_rather_than_a_server_error() {
+    for uri in [
+        "/auth/login/nope",
+        "/auth/callback/nope?code=valid-code&state=whatever",
+    ] {
+        let resp = build_app()
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "{uri} should be 404, not a 5xx"
+        );
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        // The name the caller asked for, as actix has always reported it.
+        assert!(
+            body.contains("nope"),
+            "the response should name the provider: {body:?}"
+        );
+    }
+}
+
+/// The registered provider must keep working — a 404 for everything would
+/// satisfy the test above just as well.
+#[tokio::test]
+async fn a_registered_provider_still_redirects() {
+    let resp = build_app()
+        .oneshot(
+            Request::builder()
+                .uri("/auth/login/mock")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+}

--- a/crates/authkestra-axum/tests/engine_session_integration.rs
+++ b/crates/authkestra-axum/tests/engine_session_integration.rs
@@ -453,6 +453,40 @@ async fn an_unknown_provider_is_not_found_rather_than_a_server_error() {
     }
 }
 
+/// The 404 body echoes the provider name, which is an unvalidated path
+/// segment. Useful, but it must not reflect an unbounded attacker-controlled
+/// string, so it is truncated. `authkestra-actix` truncates identically.
+#[tokio::test]
+async fn a_long_provider_name_is_truncated_in_the_body() {
+    let long = "a".repeat(5_000);
+    let resp = build_app()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/auth/login/{long}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+
+    assert!(
+        body.len() < 200,
+        "the body reflected {} bytes: {body:.120?}",
+        body.len()
+    );
+    assert!(
+        body.contains('\u{2026}'),
+        "truncation should be visible: {body:?}"
+    );
+}
+
 /// The registered provider must keep working — a 404 for everything would
 /// satisfy the test above just as well.
 #[tokio::test]

--- a/crates/authkestra-axum/tests/engine_token_integration.rs
+++ b/crates/authkestra-axum/tests/engine_token_integration.rs
@@ -233,3 +233,21 @@ async fn protected_route_rejects_garbage_bearer_token() {
 
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
+
+/// The stateless router shares the third `providers.get()` site, which had the
+/// same 500-instead-of-404 bug. See
+/// https://github.com/marcjazz/authkestra/issues/320.
+#[tokio::test]
+async fn an_unknown_provider_is_not_found_on_the_stateless_router() {
+    let resp = build_app()
+        .oneshot(
+            Request::builder()
+                .uri("/auth/callback/nope?code=valid-code&state=whatever")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
Fixes #320. **Split out of #322 because it cannot be a patch** — see below.

An unregistered OAuth provider returned 500 from the axum adapter and 404 from actix, so the two disagreed on the HTTP contract for the same request. `AxumError` had no not-found variant, so all three `providers.get()` misses fell back to `Internal`.

Adds `AxumError::NotFound`, maps it to 404, and uses it at all three sites in `crates/authkestra-axum/src/helpers/api.rs` (284, 328, 373).

### Why this is a minor, not a patch

Adding a variant to a public enum is a major change under [Cargo's SemVer reference](https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new) unless the enum is `#[non_exhaustive]`. `AxumError` is `pub use`d at the crate root *and* is the `Rejection` type for the extractors, so downstream code can and plausibly does match it exhaustively. `BREAKING CHANGE:` is in the commit footer, so release-plz will take this to 0.9.0.

I deliberately did **not** add `#[non_exhaustive]`. It would prevent a recurrence, but it forecloses exhaustive matching for every downstream user from here on — that is your call to make, not something to fold into a bug fix. Adding it now would also be breaking in its own right, so it costs nothing extra to decide later.

### The reflected provider name

Review of #322 flagged that the 404 body echoes the provider name, which is an unvalidated, URL-decoded path segment — an unbounded attacker-controlled reflection where the previous code returned a constant. A 5000-character path came back as a 5019-byte body.

Not exploitable in a current browser, since the body is `text/plain; charset=utf-8` with no sniffing opportunity. Closed anyway, in **both** adapters: truncated at 64 characters with an ellipsis, each carrying a comment noting the other does the same. Fixing one and not the other would have quietly broken the parity that motivated the whole change.

Relocating the helper in actix surfaced a bug of my own making: it had landed under the `#[cfg(feature = "session")]` belonging to `handle_oauth_callback`, so the helper took the gate and the function lost it. Clippy's `empty_line_after_outer_attr` caught it; a `--no-default-features` build confirms the helper is not dead code where the features are off.

### Tests

Four new cases across the stateful and stateless routers, including one asserting a *registered* provider still redirects — a blanket 404 would satisfy the other assertions just as well.

Both new tests were verified load-bearing by reverting the fix they cover:

- the 404 test fails with `left: 500, right: 404`
- the truncation test fails with 5019 reflected bytes

That check mattered here: my first attempt at the 404 test **passed against the reverted fix**, because `sed` had not matched — rustfmt had wrapped the call sites across lines, so I was testing unmodified code. The first green run proved nothing.

Local gate green: fmt, clippy `-D warnings` across the workspace, and `cargo test --workspace --all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
