### PR TITLE
fix(actix): redirect with 303, matching axum

### DIFF
--- a/crates/authkestra-actix/src/helpers/api.rs
+++ b/crates/authkestra-actix/src/helpers/api.rs
@@ -109,7 +109,12 @@ pub fn initiate_oauth_login_erased(
         .max_age(actix_web::cookie::time::Duration::minutes(15))
         .finish();
 
-    HttpResponse::Found()
+    // 303, not 302: the target is fetched with GET regardless of how this
+    // route was reached, which is exactly what a redirect-to-the-provider
+    // means. `authkestra-axum` sends 303 here too — `Redirect::to` is 303 —
+    // and the two adapters must not disagree on the status code for the same
+    // request. See issue #320 for the class of bug that causes.
+    HttpResponse::SeeOther()
         .insert_header((header::LOCATION, url))
         .cookie(cookie)
         .finish()
@@ -197,7 +202,7 @@ pub async fn handle_oauth_callback_erased(
         .success_url
         .unwrap_or_else(|| "/".to_string());
 
-    Ok(HttpResponse::Found()
+    Ok(HttpResponse::SeeOther()
         .insert_header((header::LOCATION, final_success_url))
         .cookie(cookie)
         .cookie(remove_cookie)
@@ -301,7 +306,7 @@ pub async fn logout(
 
     let remove_cookie = create_actix_cookie(&config, "".to_string());
 
-    Ok(HttpResponse::Found()
+    Ok(HttpResponse::SeeOther()
         .insert_header((header::LOCATION, redirect_to))
         .cookie(remove_cookie)
         .finish())

--- a/crates/authkestra-actix/src/op.rs
+++ b/crates/authkestra-actix/src/op.rs
@@ -48,7 +48,7 @@ pub async fn actix_authorize_handler(
             let login_url = String::from("/login");
             // NOTE: We omit return_to encoding to avoid adding urlencoding dependency for now.
             // login_url.push_str(&format!("?return_to=/authorize?..."));
-            return actix_web::HttpResponse::Found()
+            return actix_web::HttpResponse::SeeOther()
                 .insert_header(("Location", login_url))
                 .finish();
         }
@@ -59,7 +59,7 @@ pub async fn actix_authorize_handler(
     // for why that matters for a pool-backed store.
     let mut store = op_store.get_ref().clone_op_store();
     match handle_authorize(req.into_inner(), identity, config.get_ref(), &mut *store).await {
-        AuthorizeOutcome::Redirect(url) => HttpResponse::Found()
+        AuthorizeOutcome::Redirect(url) => HttpResponse::SeeOther()
             .insert_header(("Location", url))
             .finish(),
         AuthorizeOutcome::DirectError(err) => HttpResponse::BadRequest().json(serde_json::json!({
@@ -288,7 +288,7 @@ pub async fn actix_device_verify_handler(
         None => {
             tracing::info!("Unauthenticated user on /device/verify, redirecting to /login");
             let login_url = String::from("/login");
-            return actix_web::HttpResponse::Found()
+            return actix_web::HttpResponse::SeeOther()
                 .insert_header(("Location", login_url))
                 .finish();
         }

--- a/crates/authkestra-actix/tests/engine_session_integration.rs
+++ b/crates/authkestra-actix/tests/engine_session_integration.rs
@@ -206,7 +206,7 @@ async fn full_login_callback_session_and_logout_round_trip() {
         .uri("/auth/login/mock")
         .to_request();
     let login_resp = test::call_service(&app, login_req).await;
-    assert_eq!(login_resp.status(), StatusCode::FOUND);
+    assert_eq!(login_resp.status(), StatusCode::SEE_OTHER);
 
     let location = login_resp
         .headers()
@@ -232,7 +232,7 @@ async fn full_login_callback_session_and_logout_round_trip() {
         .cookie(Cookie::new("ak_state", ak_state_cookie))
         .to_request();
     let callback_resp = test::call_service(&app, callback_req).await;
-    assert_eq!(callback_resp.status(), StatusCode::FOUND);
+    assert_eq!(callback_resp.status(), StatusCode::SEE_OTHER);
 
     let session_cookie = set_cookie_value(&callback_resp, "authkestra_session")
         .expect("a successful callback must set the session cookie");
@@ -256,7 +256,7 @@ async fn full_login_callback_session_and_logout_round_trip() {
         .cookie(Cookie::new("authkestra_session", session_cookie.clone()))
         .to_request();
     let logout_resp = test::call_service(&app, logout_req).await;
-    assert_eq!(logout_resp.status(), StatusCode::FOUND);
+    assert_eq!(logout_resp.status(), StatusCode::SEE_OTHER);
 
     // 5. ...so presenting the very same session cookie again is rejected.
     let after_logout_req = test::TestRequest::get()
@@ -445,5 +445,43 @@ async fn a_long_provider_name_is_truncated_in_the_body() {
     assert!(
         body.contains('\u{2026}'),
         "truncation should be visible: {body:?}"
+    );
+}
+
+/// The login redirect is a 303, matching `authkestra-axum`.
+///
+/// This adapter answered 302 until the parity sweep: the same request produced
+/// a different status code depending on which adapter an application happened
+/// to be built on, which is the class of divergence issue #320 was filed about.
+/// Every route here is a GET, so both codes send the browser to the same place
+/// — but 303 says "fetch the other resource with GET" without relying on the
+/// method-rewriting that made 302 ambiguous in the first place.
+///
+/// The axum suite pins the same code in
+/// `a_registered_provider_still_redirects`. Both are needed: a comment saying
+/// the adapters agree is not a thing that can fail.
+#[actix_web::test]
+async fn the_login_redirect_is_a_see_other_like_axum() {
+    let engine = build_engine();
+    let state = AppState {
+        auth: engine.clone(),
+    };
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(state.clone()))
+            .configure(move |cfg| state.configure_authkestra(cfg))
+            .service(engine.actix_scope()),
+    )
+    .await;
+
+    let req = test::TestRequest::get()
+        .uri("/auth/login/mock")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    assert!(
+        resp.headers().contains_key(header::LOCATION),
+        "a redirect must carry a Location header"
     );
 }

--- a/crates/authkestra-actix/tests/engine_token_integration.rs
+++ b/crates/authkestra-actix/tests/engine_token_integration.rs
@@ -153,7 +153,7 @@ async fn stateless_login_callback_issues_a_working_bearer_token() {
         .uri("/auth/login/mock")
         .to_request();
     let login_resp = test::call_service(&app, login_req).await;
-    assert_eq!(login_resp.status(), StatusCode::FOUND);
+    assert_eq!(login_resp.status(), StatusCode::SEE_OTHER);
     let location = login_resp
         .headers()
         .get(header::LOCATION)

--- a/website/src/content/docs/guides/wired-endpoints.md
+++ b/website/src/content/docs/guides/wired-endpoints.md
@@ -17,7 +17,7 @@ The auto-wired router generates three standard endpoints, all resolving the prov
 This endpoint **initiates the OAuth2/OIDC flow**. 
 - It constructs the authorization URL using the provider's configuration.
 - It generates a cryptographically secure `state` and `nonce`, storing them in an encrypted, HTTP-only cookie.
-- Finally, it returns an HTTP 302 Redirect to send the user to the provider (e.g., Google or GitHub).
+- Finally, it returns an HTTP 303 See Other to send the user to the provider (e.g., Google or GitHub). Both adapters use 303, so the status code does not change if you swap axum for actix.
 
 #### 2. `GET /auth/callback/{provider}`
 This endpoint **handles the provider's redirect callback**.


### PR DESCRIPTION
Follow-up to #323. Reviewing that PR turned up a status-code divergence between the adapters that was out of its scope: `a_registered_provider_still_redirects` pins 303 on the axum side, while actix returned 302 for the identical request.

## Scope

Wider than the login redirect. **Six** actix sites diverged:

| | axum | actix (before) |
| --- | --- | --- |
| `GET /auth/login/{provider}` | 303 | 302 |
| `GET /auth/callback/{provider}` success | 303 | 302 |
| `GET /auth/logout` | 303 | 302 |
| OP `/authorize`, unauthenticated → `/login` | 303 | 302 |
| OP authorize redirect | 303 | 302 |
| OP consent path | 303 | 302 |

axum reaches all of these through `Redirect::to`, which is `SEE_OTHER`. actix used `HttpResponse::Found`.

## Why 303, and why actix moves

Every affected route is a `GET` on both sides, so 302 and 303 send the browser to the same place — no client behaviour changes in practice. 303 is the precise reading ("fetch the other resource with GET") without the method-rewriting that made 302 ambiguous, and it is what `Redirect::to` already picks. Converging there means one crate changes rather than two.

RFC 6749 §4.1.2 shows `302` in its authorization-response example. That is an example, not a requirement, and OIDC Core mandates no particular 3xx — so agreeing with the other adapter is worth more here than matching a non-normative snippet.

## Tests

Four actix assertions move from `FOUND` to `SEE_OTHER`, and the actix suite gains `the_login_redirect_is_a_see_other_like_axum`, mirroring axum's. Both are needed: a doc comment claiming the two adapters agree is not a thing that can fail, which is precisely how this drifted.

The `wired-endpoints` guide documented "HTTP 302 Redirect" and now says 303, noting the code is the same on either adapter.

## Not addressed

A site-by-site audit of the non-redirect statuses. actix reports errors through `ErrorUnauthorized` / `ErrorInternalServerError` where axum uses `AxumError` variants, and whether those line up condition for condition is a separate question. Worth its own issue if you want it swept.

## Gate

`fmt`, `clippy --workspace --all-features --all-targets -D warnings`, and `test --workspace --all-features` all green locally — 60 test binaries, same as before the change.

Note the `BREAKING CHANGE:` footer: the status code actix returns is observable, so a client asserting on 302 will see it change. 0.9.0 is already queued as breaking in #324.