### PR TITLE
fix(axum)!: make AxumError non_exhaustive

### DIFF
--- a/crates/authkestra-axum/src/helpers/api.rs
+++ b/crates/authkestra-axum/src/helpers/api.rs
@@ -451,7 +451,22 @@ fn provider_for_display(provider: &str) -> String {
     format!("{}\u{2026}", &provider[..end])
 }
 
+/// How the axum adapter reports a failure.
+///
+/// `#[non_exhaustive]`, so a future variant is an additive change rather than a
+/// major version. That is not free — downstream code cannot match on this
+/// exhaustively and needs a wildcard arm — but the alternative is worse. #320
+/// was exactly this: the enum had no not-found variant, every unregistered
+/// provider fell through to `Internal`, and the fix could not ship as a patch
+/// because adding one is breaking under
+/// [Cargo's SemVer reference](https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new).
+/// The next status this adapter needs to distinguish should not have to wait
+/// for a major release too.
+///
+/// Applied in 0.9.0 because that release is already breaking; after it, adding
+/// the attribute would itself cost a major.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum AxumError {
     Unauthorized(String),
     /// The caller asked for something that does not exist — an unregistered


### PR DESCRIPTION
## Summary

#320 was a variant that did not exist: the enum had no not-found case, so every unregistered OAuth provider fell through to `Internal` and returned 500. The fix could not ship as a patch, because adding a variant to a public enum is a major change under Cargo's SemVer reference unless the enum is `#[non_exhaustive]`. A one-line status correction cost a major version.

The next status this adapter needs to distinguish shouldn't have to wait for the same reason, so `AxumError` is now `#[non_exhaustive]`.

This is not free — downstream code can no longer match on it exhaustively and needs a wildcard arm — which is exactly why #323 left the decision to a maintainer rather than folding it into a bug fix. Taking it now because 0.9.0 is already a breaking release: after that ships, adding the attribute becomes its own major bump, so this is the last cheap moment to make it.

`Display` and `IntoResponse` still match exhaustively, which the attribute permits inside the defining crate — a new variant will fail to compile there until someone decides what status it maps to.

**Breaking:** `AuthError` is now `#[non_exhaustive]`. Code matching on it outside this crate must add a wildcard arm.

## Test plan

- [x] `cargo check -p authkestra-axum --all-features`