### PR TITLE
fix(engine): derive a stable WebAuthn user handle instead of a random one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5577,6 +5577,7 @@ dependencies = [
  "getrandom 0.4.3",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/crates/authkestra-engine/CHANGELOG.md
+++ b/crates/authkestra-engine/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- *(engine)* WebAuthn `start_register` no longer substitutes a random UUID for the user handle when
+  the application's `user_id` is not UUID-shaped. The handle is now derived deterministically with
+  the new `auth::webauthn::derive_user_handle`: a `user_id` that already parses as a UUID is used
+  verbatim (byte-identical to previous behaviour), and anything else is hashed into a UUIDv5 over
+  the documented `auth::webauthn::USER_HANDLE_NAMESPACE`. Previously, an application with non-UUID
+  user ids got a different, unstable handle on every registration, which silently broke discoverable
+  ("usernameless") sign-in ([#333](https://github.com/marcjazz/authkestra/issues/333)).
+
+  **This change is additive and does not re-map existing credentials.** A user handle is stored
+  inside the authenticator at registration time and cannot be rewritten server-side, so passkeys
+  already enrolled under a random handle keep that handle and must be re-enrolled to gain a stable
+  one. Applications with UUID user ids are unaffected.
+
+### Added
+
+- *(engine)* `auth::webauthn::WebAuthnAuthMethod::start_register_with_handle`, for applications that
+  allocate WebAuthn user handles themselves or need a display name distinct from the username
+  (`start_register` passes the username for both).
+- *(engine)* `auth::webauthn::derive_user_handle` and `auth::webauthn::USER_HANDLE_NAMESPACE`, so an
+  application can reproduce the same handle out-of-band and index credentials by it.
+
 ## [0.9.0](https://github.com/marcjazz/authkestra/compare/authkestra-engine-v0.8.1...authkestra-engine-v0.9.0) - 2026-09-05
 
 ### Fixed

--- a/crates/authkestra-engine/Cargo.toml
+++ b/crates/authkestra-engine/Cargo.toml
@@ -31,7 +31,7 @@ rand = { workspace = true }
 
 # From authkestra-flow
 serde_json = "1.0"
-uuid = { version = "1.0", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4", "v5"] }
 tracing = "0.1"
 
 # From authkestra-token

--- a/crates/authkestra-engine/src/auth/webauthn.rs
+++ b/crates/authkestra-engine/src/auth/webauthn.rs
@@ -3,6 +3,50 @@ use async_trait::async_trait;
 use std::sync::Arc;
 use webauthn_rs::prelude::*;
 
+/// Namespace for authkestra-derived WebAuthn user handles.
+///
+/// This is `uuid5(NAMESPACE_URL, "https://authkestra.dev/webauthn/user-handle")`,
+/// so the value is reproducible outside Rust and will never change.
+pub const USER_HANDLE_NAMESPACE: Uuid = Uuid::from_u128(0xef84b322_b2dd_5ab4_aea2_8221f829229e);
+
+/// Derive a stable WebAuthn user handle from an application user id.
+///
+/// The user handle (`user.id` in `PublicKeyCredentialCreationOptions`) is baked
+/// into the credential by the authenticator at registration time and returned as
+/// `response.userHandle` by discoverable ("usernameless") sign-in. It must
+/// therefore be stable for the lifetime of the account and resolvable back to
+/// exactly one user, which rules out generating a fresh value per registration.
+///
+/// The rule is deterministic and total:
+///
+/// * a `user_id` that already parses as a UUID is returned unchanged, so
+///   applications with UUID user ids keep byte-identical handles;
+/// * anything else (CUID, ULID, prefixed id, integer, email) is hashed into a
+///   version 5 UUID over [`USER_HANDLE_NAMESPACE`].
+///
+/// Because it is UUIDv5, an application can reproduce the same handle in any
+/// language to build its own handle-to-user index for discoverable login.
+///
+/// ```
+/// use authkestra_engine::auth::webauthn::derive_user_handle;
+///
+/// // A UUID user id is passed through untouched.
+/// let uuid_id = "67e55044-10b1-426f-9247-bb680e5fe0c8";
+/// assert_eq!(derive_user_handle(uuid_id).to_string(), uuid_id);
+///
+/// // A non-UUID id yields the same handle every time.
+/// let cuid = "clh3k2j1x0000qwer1234asdf";
+/// assert_eq!(derive_user_handle(cuid), derive_user_handle(cuid));
+///
+/// // Different ids yield different handles.
+/// assert_ne!(derive_user_handle("user-a"), derive_user_handle("user-b"));
+/// ```
+#[must_use]
+pub fn derive_user_handle(user_id: &str) -> Uuid {
+    Uuid::parse_str(user_id)
+        .unwrap_or_else(|_| Uuid::new_v5(&USER_HANDLE_NAMESPACE, user_id.as_bytes()))
+}
+
 /// WebAuthn Passkeys authentication method.
 #[non_exhaustive]
 pub struct WebAuthnAuthMethod<S: CredentialStore> {
@@ -17,16 +61,44 @@ impl<S: CredentialStore> WebAuthnAuthMethod<S> {
     }
 
     /// Helper to generate a registration challenge.
+    ///
+    /// The WebAuthn user handle is derived from `user_id` with
+    /// [`derive_user_handle`], which is stable across calls. Use
+    /// [`WebAuthnAuthMethod::start_register_with_handle`] when the application
+    /// allocates handles itself, or when the display name differs from the
+    /// username (this method passes `username` for both).
     pub fn start_register(
         &self,
         user_id: &str,
         username: &str,
     ) -> Result<(CreationChallengeResponse, PasskeyRegistration), AuthError> {
-        let user_unique_id = Uuid::parse_str(user_id).unwrap_or_else(|_| Uuid::new_v4());
+        self.start_register_with_handle(derive_user_handle(user_id), username, username)
+    }
+
+    /// Helper to generate a registration challenge for an explicit user handle.
+    ///
+    /// `handle` becomes `user.id` in the returned
+    /// `PublicKeyCredentialCreationOptions`. The authenticator stores it inside
+    /// the credential and returns it as `response.userHandle` on every later
+    /// assertion, so it MUST be stable for the lifetime of the account and MUST
+    /// map back to exactly one user. Prefer this method when the application
+    /// keeps its own handle-to-user index; otherwise use
+    /// [`WebAuthnAuthMethod::start_register`], which derives a stable handle
+    /// from the user id.
+    pub fn start_register_with_handle(
+        &self,
+        handle: Uuid,
+        username: &str,
+        display_name: &str,
+    ) -> Result<(CreationChallengeResponse, PasskeyRegistration), AuthError> {
+        tracing::debug!(user_handle = %handle, username, "starting WebAuthn registration");
 
         self.webauthn
-            .start_passkey_registration(user_unique_id, username, username, None)
-            .map_err(|e| AuthError::Internal(format!("WebAuthn registration failed to start: {e}")))
+            .start_passkey_registration(handle, username, display_name, None)
+            .map_err(|e| {
+                tracing::warn!(error = %e, user_handle = %handle, "WebAuthn registration failed to start");
+                AuthError::Internal(format!("WebAuthn registration failed to start: {e}"))
+            })
     }
 
     /// Helper to finalize passkey registration and return the serialized Passkey to store.
@@ -269,5 +341,109 @@ mod tests {
             })
             .await;
         assert!(matches!(invalid_input, Err(AuthError::InvalidInput)));
+    }
+
+    #[test]
+    fn derive_user_handle_is_stable_for_a_non_uuid_id() {
+        // A CUID, which is what many applications actually use for user ids.
+        let cuid = "clh3k2j1x0000qwer1234asdf";
+
+        let first = derive_user_handle(cuid);
+        let second = derive_user_handle(cuid);
+
+        assert_eq!(
+            first, second,
+            "the same non-UUID user id must always derive the same handle"
+        );
+        assert_eq!(first.get_version_num(), 5, "handle must be a UUIDv5");
+    }
+
+    #[test]
+    fn derive_user_handle_separates_distinct_ids() {
+        assert_ne!(
+            derive_user_handle("clh3k2j1x0000qwer1234asdf"),
+            derive_user_handle("clh3k2j1x0000qwer1234asdg"),
+            "distinct user ids must not collide onto one handle"
+        );
+    }
+
+    #[test]
+    fn derive_user_handle_passes_uuid_ids_through_unchanged() {
+        let id = "67e55044-10b1-426f-9247-bb680e5fe0c8";
+
+        assert_eq!(
+            derive_user_handle(id),
+            Uuid::parse_str(id).unwrap(),
+            "an id that is already a UUID must be used verbatim"
+        );
+    }
+
+    #[test]
+    fn derive_user_handle_matches_the_documented_namespace() {
+        // Pins the derivation rule: changing the namespace or the hash would
+        // orphan every passkey already registered under a derived handle.
+        assert_eq!(
+            USER_HANDLE_NAMESPACE.to_string(),
+            "ef84b322-b2dd-5ab4-aea2-8221f829229e"
+        );
+        assert_eq!(
+            derive_user_handle("clh3k2j1x0000qwer1234asdf").to_string(),
+            "ed6b6951-8a79-5ac9-a322-471f5427dc08"
+        );
+    }
+
+    #[test]
+    fn start_register_emits_a_stable_user_handle_for_a_non_uuid_id() {
+        let site_url = Url::parse("http://localhost").unwrap();
+        let webauthn = Arc::new(
+            WebauthnBuilder::new("localhost", &site_url)
+                .unwrap()
+                .build()
+                .unwrap(),
+        );
+        let method = WebAuthnAuthMethod::new(webauthn, DummyCredentialStore);
+
+        let cuid = "clh3k2j1x0000qwer1234asdf";
+        let (first, _) = method.start_register(cuid, "ada").unwrap();
+        let (second, _) = method.start_register(cuid, "ada").unwrap();
+
+        assert_eq!(
+            first.public_key.user.id, second.public_key.user.id,
+            "two registrations for one user must share a user handle"
+        );
+        assert_eq!(
+            first.public_key.user.id.as_ref(),
+            derive_user_handle(cuid).as_bytes(),
+            "the challenge must carry the derived handle"
+        );
+
+        let (other, _) = method
+            .start_register("clh3k2j1x0000qwer1234asdg", "grace")
+            .unwrap();
+        assert_ne!(
+            first.public_key.user.id, other.public_key.user.id,
+            "distinct users must not share a user handle"
+        );
+    }
+
+    #[test]
+    fn start_register_with_handle_uses_the_caller_handle_and_display_name() {
+        let site_url = Url::parse("http://localhost").unwrap();
+        let webauthn = Arc::new(
+            WebauthnBuilder::new("localhost", &site_url)
+                .unwrap()
+                .build()
+                .unwrap(),
+        );
+        let method = WebAuthnAuthMethod::new(webauthn, DummyCredentialStore);
+
+        let handle = Uuid::parse_str("67e55044-10b1-426f-9247-bb680e5fe0c8").unwrap();
+        let (challenge, _) = method
+            .start_register_with_handle(handle, "ada", "Ada Lovelace")
+            .unwrap();
+
+        assert_eq!(challenge.public_key.user.id.as_ref(), handle.as_bytes());
+        assert_eq!(challenge.public_key.user.name, "ada");
+        assert_eq!(challenge.public_key.user.display_name, "Ada Lovelace");
     }
 }

--- a/website/src/content/docs/providers/passkeys.md
+++ b/website/src/content/docs/providers/passkeys.md
@@ -47,6 +47,50 @@ A runnable example combining passkeys with TOTP lives in the repository:
 cargo run -p authkestra --example axum_mfa_server --all-features
 ```
 
+## Registration Ceremony
+
+Registration is also a two-step ceremony, driven directly on the `WebAuthnAuthMethod`:
+
+```rust
+use authkestra_engine::auth::webauthn::WebAuthnAuthMethod;
+
+let method = WebAuthnAuthMethod::new(Arc::new(webauthn), my_store);
+
+// 1. Start: return `challenge` to the browser for `navigator.credentials.create()`,
+//    and stash `reg_state` in the user's session.
+let (challenge, reg_state) = method.start_register("user_123", "ada")?;
+
+// 2. Finish: verify the attestation and persist the passkey via the CredentialStore.
+let passkey = method.finish_register("user_123", reg_response, reg_state).await?;
+```
+
+### User handles
+
+`user.id` in the creation options is the **user handle**. The authenticator stores it inside the
+credential and returns it as `response.userHandle` on every later assertion, which is what makes
+discoverable ("usernameless") sign-in able to resolve an account. It must be stable for the lifetime
+of the account and map back to exactly one user.
+
+`start_register` derives the handle from `user_id` with `derive_user_handle`:
+
+- a `user_id` that already parses as a UUID is used verbatim;
+- anything else (CUID, ULID, prefixed id, integer) is hashed into a **UUIDv5** over the documented
+  `USER_HANDLE_NAMESPACE` constant.
+
+Because the derivation is a plain UUIDv5, you can reproduce the same handle in any language to index
+your own users by handle.
+
+If your application allocates handles itself — or needs a display name distinct from the username,
+since `start_register` passes `username` for both — use `start_register_with_handle`:
+
+```rust
+use authkestra_engine::auth::webauthn::derive_user_handle;
+
+let handle = derive_user_handle("user_123"); // or your own stable handle
+let (challenge, reg_state) =
+    method.start_register_with_handle(handle, "ada", "Ada Lovelace")?;
+```
+
 ## Authentication Ceremony
 
 WebAuthn uses a two-step "ceremony":
@@ -54,7 +98,7 @@ WebAuthn uses a two-step "ceremony":
 2. **Finish**: The client (browser) signs the challenge with the authenticator and returns the signature to the server. The server verifies the signature and completes the authentication via the unified `Engine::authenticate` method.
 
 ### Starting Authentication
-When the user wants to sign in, call `start_authentication`. You must pass the user's previously registered `Passkey` objects (retrieved from your credential store):
+When the user wants to sign in, call `start_authentication`. You must pass the user's previously registered `Passkey` objects (retrieved from your credential store). `Engine::start_webauthn` is the usual entry point; to call it directly on a `WebAuthnAuthMethod` you must bring the `authkestra_engine::auth::WebAuthnStarter` trait into scope, since that is where the method lives:
 
 ```rust
 // `passkeys` is a `Vec<webauthn_rs::prelude::Passkey>` loaded from your store


### PR DESCRIPTION
## Summary

`WebAuthnAuthMethod::start_register` silently replaced a non-UUID `user_id` with a **freshly random UUID** for the WebAuthn user handle:

```rust
let user_unique_id = Uuid::parse_str(user_id).unwrap_or_else(|_| Uuid::new_v4());
```

That value goes straight into `PublicKeyCredentialCreationOptions.user.id`. The authenticator stores it inside the credential at registration time and returns it as `response.userHandle` on every later assertion, so it is the only thing discoverable ("usernameless") sign-in gives the server to resolve an account.

This PR replaces the random fallback with a deterministic derivation, and adds an explicit-handle entry point for applications that allocate handles themselves.

## Intent

Fixes #333.

Source of truth for the user-handle contract: [WebAuthn Level 3 §5.4.3, `PublicKeyCredentialUserEntity`](https://www.w3.org/TR/webauthn-3/#dictionary-user-credential-params) — `user.id` is an opaque, stable, non-PII account identifier that the authenticator persists in the credential.

The consequences of the random fallback, for any application whose user ids are not UUIDs (CUID/CUID2, ULID, prefixed ids, integers):

1. A user who registers two passkeys gets two unrelated handles for one account.
2. The handle maps back to no user, so discoverable-credential authentication cannot resolve the account.
3. The failure is silent and time-shifted — `start_register` reports success, the bad handle is baked into the authenticator, and it only surfaces later as an unexplained failed sign-in.

A parse failure must not be papered over with a random value in a security-relevant identifier.

## Scope

- `crates/authkestra-engine/src/auth/webauthn.rs`
  - **new** `pub const USER_HANDLE_NAMESPACE: Uuid` — `uuid5(NAMESPACE_URL, "https://authkestra.dev/webauthn/user-handle")` = `ef84b322-b2dd-5ab4-aea2-8221f829229e`, documented so it is reproducible outside Rust.
  - **new** `pub fn derive_user_handle(user_id: &str) -> Uuid` — a `user_id` that already parses as a UUID is returned unchanged; anything else is hashed into a UUIDv5 over the namespace above.
  - **new** `pub fn start_register_with_handle(&self, handle: Uuid, username: &str, display_name: &str)` — for callers that own handle allocation, or need a display name distinct from the username (`start_register` passes `username` for both `user_name` and `user_display_name`).
  - **changed** `start_register` now delegates to `start_register_with_handle(derive_user_handle(user_id), username, username)`. **Signature unchanged.**
  - Added `tracing` on the registration-start path per the repo's tracing DoD (`debug!` on entry, `warn!` on failure).
- `crates/authkestra-engine/Cargo.toml` — `uuid` gains the `v5` feature (pulls in `sha1_smol`; `cargo deny` is clean, see Verification).
- `crates/authkestra-engine/CHANGELOG.md` — `Fixed` + `Added` under `[Unreleased]`, explicitly stating the no-silent-re-map constraint.
- `website/src/content/docs/providers/passkeys.md` — the page documented the authentication ceremony but never registration, which is part of why this went unnoticed. Adds a **Registration Ceremony** section with a **User handles** subsection, and notes that calling `start_authentication` directly on a `WebAuthnAuthMethod` requires importing `WebAuthnStarter`.

### Public API after this change

```rust
pub const USER_HANDLE_NAMESPACE: Uuid;

#[must_use]
pub fn derive_user_handle(user_id: &str) -> Uuid;

impl<S: CredentialStore> WebAuthnAuthMethod<S> {
    // unchanged signature, new behaviour for non-UUID ids
    pub fn start_register(
        &self,
        user_id: &str,
        username: &str,
    ) -> Result<(CreationChallengeResponse, PasskeyRegistration), AuthError>;

    // new
    pub fn start_register_with_handle(
        &self,
        handle: Uuid,
        username: &str,
        display_name: &str,
    ) -> Result<(CreationChallengeResponse, PasskeyRegistration), AuthError>;
}
```

### Deliberately not changed

`start_authentication` is **not** missing, despite the type looking asymmetric — it is provided by the `WebAuthnStarter` trait impl (`auth/webauthn.rs`, trait in `auth/mod.rs`) and reached via `Engine::start_webauthn`. I did not add an inherent method: it would shadow the trait method for existing callers for no functional gain. The real friction was discoverability, so it is addressed in the docs instead.

I also grepped every `Uuid::new_v4()` in the workspace. This was the only *parse failure* falling back to a random value. The rest are legitimate fresh-identifier generation (session ids, `jti`, OAuth2 `state`/`nonce`, TOTP credential ids, refresh tokens, device user codes). `store/sql/credential.rs` falls back only for an *absent* credential id — a genuinely new identifier, not a failed parse — so it is left alone.

## Verification

All commands run on this branch, from the repo root.

```
$ cargo fmt --all -- --check
FMT_OK                      # (no output; echo confirms exit 0)

$ cargo clippy -p authkestra-engine --all-targets --all-features -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 50.91s
                            # no warnings

$ cargo test -p authkestra-engine --all-features
test auth::webauthn::tests::derive_user_handle_matches_the_documented_namespace ... ok
test auth::webauthn::tests::derive_user_handle_is_stable_for_a_non_uuid_id ... ok
test auth::webauthn::tests::derive_user_handle_passes_uuid_ids_through_unchanged ... ok
test auth::webauthn::tests::derive_user_handle_separates_distinct_ids ... ok
test auth::webauthn::tests::test_webauthn_auth_method ... ok
test auth::webauthn::tests::start_register_with_handle_uses_the_caller_handle_and_display_name ... ok
test auth::webauthn::tests::start_register_emits_a_stable_user_handle_for_a_non_uuid_id ... ok
test result: ok. 160 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.14s

   Doc-tests authkestra_engine
test crates/authkestra-engine/src/auth/webauthn.rs - auth::webauthn::derive_user_handle (line 30) ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.32s

$ cargo deny check
advisories ok, bans ok, licenses ok, sources ok
```

### Negative control

I reverted the one-line fix to `unwrap_or_else(|_| Uuid::new_v4())` on top of the new tests, to confirm they actually catch the bug rather than merely passing:

```
$ cargo test -p authkestra-engine --all-features --lib auth::webauthn   # with the fix reverted
test auth::webauthn::tests::derive_user_handle_is_stable_for_a_non_uuid_id ... FAILED
test auth::webauthn::tests::derive_user_handle_matches_the_documented_namespace ... FAILED
test auth::webauthn::tests::start_register_emits_a_stable_user_handle_for_a_non_uuid_id ... FAILED

panicked at crates/authkestra-engine/src/auth/webauthn.rs:353:9:
assertion `left == right` failed: the same non-UUID user id must always derive the same handle
panicked at crates/authkestra-engine/src/auth/webauthn.rs:409:9:
assertion `left == right` failed: two registrations for one user must share a user handle

test result: FAILED. 4 passed; 3 failed; 0 ignored; 0 measured; 153 filtered out
```

The fix was then restored; the final tree is the one all the green output above was produced from.

### Test coverage added

Six unit tests plus a doctest:

- `derive_user_handle_is_stable_for_a_non_uuid_id` — a CUID derives the same handle twice, and it is a v5 UUID.
- `derive_user_handle_separates_distinct_ids` — two ids differing in one character do not collide.
- `derive_user_handle_passes_uuid_ids_through_unchanged` — the backwards-compatibility guarantee.
- `derive_user_handle_matches_the_documented_namespace` — pins the namespace constant *and* a known derived value, so a future change to the derivation cannot land silently.
- `start_register_emits_a_stable_user_handle_for_a_non_uuid_id` — end-to-end through the real `Webauthn`, asserting on `challenge.public_key.user.id`.
- `start_register_with_handle_uses_the_caller_handle_and_display_name` — the explicit-handle path honours the handle, username and display name.

## Risk Assessment

**Trade-off, stated plainly: this change is additive and must not be read as a migration.** A user handle is written into the authenticator at registration and cannot be rewritten server-side. Any passkey already enrolled under a random handle keeps that random handle; it will not be silently re-mapped to the newly derived value, and it must be re-enrolled to gain a stable one. The changelog says this explicitly.

| Concern | Assessment |
|---|---|
| Existing UUID-user-id applications | **No change.** `derive_user_handle` returns a parseable UUID verbatim — byte-identical to the previous code path. |
| Existing non-UUID applications | Newly derived handles differ from the old random ones. There is nothing coherent to preserve: the old value was random per registration, so it was already unusable. New registrations become correct; old credentials are unaffected and keep working on the `user_id`-driven `authenticate` path. |
| Source compatibility | Additive only. No signature changed; `WebAuthnAuthMethod` is `#[non_exhaustive]`. |
| Namespace stability | `USER_HANDLE_NAMESPACE` is now part of the public API and pinned by a test. Changing it later would orphan every derived handle — the test makes that a deliberate, visible act. |
| New dependency surface | `uuid/v5` only, adding `sha1_smol`. SHA-1 here is a UUIDv5 namespace hash as mandated by RFC 9562 §5.5, not a security primitive; no collision-resistance claim rests on it. `cargo deny check` is clean. |
| Coverage gate (`--fail-under-lines 84`) | Net positive: six new tests over previously untested lines. |

## Reviewer Focus

1. **The namespace value.** `ef84b322-b2dd-5ab4-aea2-8221f829229e` is `uuid5(NAMESPACE_URL, "https://authkestra.dev/webauthn/user-handle")`. Reproduce with `python3 -c 'import uuid; print(uuid.uuid5(uuid.NAMESPACE_URL, "https://authkestra.dev/webauthn/user-handle"))'`. If you would rather own a different namespace string, now is the only cheap moment to change it.
2. **Is "pass UUIDs through verbatim" the right call?** It buys exact backwards compatibility for the majority case, at the cost of a derivation with two branches rather than one. The alternative — always UUIDv5, including over UUID inputs — is more uniform but would change handles for *every* existing user.
3. **Is additive the right posture, or should this reject non-UUID ids outright?** Returning an error would be the loudest fix, but it breaks compilation-clean applications at runtime and offers them no path forward. I chose derivation; if you would rather have a hard error, say so and I will reshape it.
4. **The docs section** (`website/src/content/docs/providers/passkeys.md`) is new prose describing behaviour, not generated — worth a read for accuracy.

## AI Usage Declaration

**What AI did:** Claude Opus 5 (via Claude Code) investigated the reported defect, verified it against the current `origin/main` tree and the `webauthn-rs` 0.5.5 source in the local cargo registry, grepped the workspace for equivalent silent fallbacks, wrote the fix, the tests, the changelog entry and the docs section, and ran every command in the Verification section.

**What was checked, not assumed:**
- The `start_passkey_registration` signature was read from `webauthn-rs-0.5.5/src/lib.rs:534` rather than recalled, confirming `user_unique_id: Uuid` lands in `user.id` and that the current code passes `username` for both name and display name.
- The claim that `start_authentication` was missing was **investigated and found to be false** — it exists via `WebAuthnStarter` and is used by `Engine::start_webauthn`. The PR reflects the code, not the initial hypothesis.
- The tests were run against a deliberately reverted fix (negative control above) to prove they fail without it.
- Every command's output pasted into Verification is real terminal output.

**Human accountability:**
- [x] A human has reviewed the diff and understands what it changes.
- [x] The behaviour change is intentional and its blast radius is stated in Risk Assessment and the changelog.
- [x] Verification commands were run and their real output is recorded, including a negative control.
- [x] No generated or scratch files are committed.
- [x] The author takes responsibility for this change as if they had written it by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
