### PR TITLE
feat(store): let callers compose their own transaction with the OpStore traits

### DIFF
--- a/crates/authkestra-example-diesel/src/lib.rs
+++ b/crates/authkestra-example-diesel/src/lib.rs
@@ -9,4 +9,4 @@ mod models;
 mod schema;
 mod store;
 
-pub use store::DieselOpStore;
+pub use store::{DieselOpStore, DieselOpStoreTx};

--- a/crates/authkestra-example-diesel/src/store.rs
+++ b/crates/authkestra-example-diesel/src/store.rs
@@ -630,7 +630,6 @@ mod queries {
 }
 
 #[async_trait]
-#[async_trait]
 impl ClientStore for DieselOpStore {
     async fn find_client(
         &mut self,
@@ -642,7 +641,6 @@ impl ClientStore for DieselOpStore {
     }
 }
 
-#[async_trait]
 #[async_trait]
 impl AuthorizationCodeStore for DieselOpStore {
     async fn store_code(&mut self, code: AuthorizationCode) -> Result<(), StoreError> {
@@ -656,7 +654,6 @@ impl AuthorizationCodeStore for DieselOpStore {
     }
 }
 
-#[async_trait]
 #[async_trait]
 impl RefreshTokenStore for DieselOpStore {
     async fn store_token(&mut self, token: RefreshToken) -> Result<(), StoreError> {
@@ -679,7 +676,6 @@ impl RefreshTokenStore for DieselOpStore {
     }
 }
 
-#[async_trait]
 #[async_trait]
 impl DeviceCodeStore for DieselOpStore {
     async fn store_device_code(&mut self, session: DeviceCodeSession) -> Result<(), StoreError> {

--- a/crates/authkestra-example-diesel/src/store.rs
+++ b/crates/authkestra-example-diesel/src/store.rs
@@ -8,8 +8,9 @@ use authkestra_op::code::{AuthorizationCode, AuthorizationCodeStore};
 use authkestra_op::device::{DeviceCodeSession, DeviceCodeStore};
 use authkestra_op::refresh::{RefreshToken, RefreshTokenStore};
 use authkestra_op::store::OpStore;
+use diesel::connection::{AnsiTransactionManager, TransactionManager};
 use diesel::prelude::*;
-use diesel::r2d2::{ConnectionManager, Pool};
+use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 use diesel::sqlite::SqliteConnection;
 
 type SqlitePool = Pool<ConnectionManager<SqliteConnection>>;
@@ -118,6 +119,58 @@ impl DieselOpStore {
         &self.pool
     }
 
+    /// Run one synchronous query on a pooled connection, off the async
+    /// runtime. The pool-backed counterpart to [`DieselOpStoreTx::run`],
+    /// which runs the same closure on the connection its transaction owns —
+    /// having both means every query in `queries` is written once and driven
+    /// two ways.
+    async fn run<T, F>(&self, f: F) -> Result<T, StoreError>
+    where
+        F: FnOnce(&mut SqliteConnection) -> Result<T, StoreError> + Send + 'static,
+        T: Send + 'static,
+    {
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut conn = pool.get().map_err(pool_err)?;
+            f(&mut conn)
+        })
+        .await
+        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))?
+    }
+
+    /// Begin a transaction and return a store scoped to it.
+    ///
+    /// Diesel is synchronous and has no owned transaction object, so this
+    /// holds the checked-out connection with a transaction open on it and
+    /// drives it through `spawn_blocking` per call. The connection is moved
+    /// into the blocking task and moved back out again, which is what lets a
+    /// `!Sync` `SqliteConnection` be held across await points at all.
+    ///
+    /// Note this takes the connection out of the pool for as long as the
+    /// transaction is open — the same cost any synchronous transaction has,
+    /// but worth stating, since a pool sized for request concurrency needs
+    /// headroom for however many of these a host application holds at once.
+    pub async fn begin_tx(&self) -> Result<DieselOpStoreTx, StoreError> {
+        let pool = self.pool.clone();
+        let conn = tokio::task::spawn_blocking(move || {
+            let mut conn = pool.get().map_err(pool_err)?;
+            // `BEGIN IMMEDIATE`, matching the `immediate_transaction` the
+            // consume paths use when they run on the pool: it takes the
+            // write lock up front rather than discovering a conflict at the
+            // first write and failing with SQLITE_BUSY halfway through a
+            // unit of work the caller believes it has already secured.
+            AnsiTransactionManager::begin_transaction_sql(&mut *conn, "BEGIN IMMEDIATE")
+                .map_err(diesel_err)?;
+            Ok::<_, StoreError>(conn)
+        })
+        .await
+        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))??;
+
+        Ok(DieselOpStoreTx {
+            conn: std::sync::Mutex::new(Some(conn)),
+        })
+    }
+
     /// Creates the four tables this store needs, if they don't already
     /// exist. Idempotent — safe to call on every startup, same contract as
     /// `authkestra-store-sqlx::SqlxOpStore::migrate`.
@@ -188,287 +241,580 @@ impl DieselOpStore {
     }
 }
 
+/// A [`DieselOpStore`] scoped to one open transaction — the synchronous
+/// counterpart to `authkestra-store-sqlx`'s `SqlxOpStoreTx`, and the case
+/// that most stresses the design: Diesel has no owned transaction handle and
+/// its connections are `!Sync`, so the transaction lives as an open
+/// transaction *on a connection this type owns*, moved in and out of
+/// `spawn_blocking` for each call.
+///
+/// That it works at all is the point: because the transaction lives in the
+/// store value rather than in the method signatures, a backend whose native
+/// API has no transaction object to pass around can still implement the
+/// trait unchanged.
+///
+/// Obtain one from [`DieselOpStore::begin_tx`]. [`run`](Self::run) is the
+/// escape hatch for the host application's own Diesel queries — it hands a
+/// `&mut SqliteConnection` inside the same transaction.
+#[non_exhaustive]
+pub struct DieselOpStoreTx {
+    /// `Option` so the connection can be moved into a blocking task and
+    /// moved back; it is `Some` at every await point except during a call.
+    ///
+    /// The `Mutex` is not for concurrency — every access below goes through
+    /// `get_mut`, and an open transaction is exclusively owned anyway. It is
+    /// here purely to satisfy the `Send + Sync` bound the store traits carry:
+    /// a `SqliteConnection` is `Send` but `!Sync`, so without the wrapper
+    /// this type cannot implement `OpStore` at all. Worth noting as a wart —
+    /// `Sync` buys those traits nothing now that every method takes
+    /// `&mut self` — but relaxing the bound is a breaking change to every
+    /// implementor, so it stays for now.
+    conn: std::sync::Mutex<Option<PooledConnection<ConnectionManager<SqliteConnection>>>>,
+}
+
+impl DieselOpStoreTx {
+    /// Run one synchronous closure on this transaction's connection, off the
+    /// async runtime.
+    ///
+    /// Public because it is also how a host application runs *its own*
+    /// Diesel queries inside this transaction — the equivalent of
+    /// `SqlxOpStoreTx::as_mut`, shaped as a closure rather than a borrow
+    /// because a `!Sync` connection cannot be lent across an await point.
+    pub async fn run<T, F>(&mut self, f: F) -> Result<T, StoreError>
+    where
+        F: FnOnce(&mut SqliteConnection) -> Result<T, StoreError> + Send + 'static,
+        T: Send + 'static,
+    {
+        let mut conn = self.take_conn()?;
+        let (conn, result) = tokio::task::spawn_blocking(move || {
+            let result = f(&mut conn);
+            (conn, result)
+        })
+        .await
+        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))?;
+        *self
+            .conn
+            .get_mut()
+            .expect("transaction mutex is never poisoned") = Some(conn);
+        result
+    }
+
+    fn take_conn(
+        &mut self,
+    ) -> Result<PooledConnection<ConnectionManager<SqliteConnection>>, StoreError> {
+        self.conn
+            .get_mut()
+            .expect("transaction mutex is never poisoned")
+            .take()
+            .ok_or_else(|| {
+                StoreError::Internal("diesel transaction connection is gone".to_string())
+            })
+    }
+
+    /// Commit, making every write in this transaction durable at once.
+    pub async fn commit(mut self) -> Result<(), StoreError> {
+        self.finish(true).await
+    }
+
+    /// Roll back, discarding every write in this transaction.
+    pub async fn rollback(mut self) -> Result<(), StoreError> {
+        self.finish(false).await
+    }
+
+    async fn finish(&mut self, commit: bool) -> Result<(), StoreError> {
+        let mut conn = self.take_conn()?;
+        tokio::task::spawn_blocking(move || {
+            if commit {
+                AnsiTransactionManager::commit_transaction(&mut *conn).map_err(diesel_err)
+            } else {
+                AnsiTransactionManager::rollback_transaction(&mut *conn).map_err(diesel_err)
+            }
+        })
+        .await
+        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))?
+    }
+}
+
+impl Drop for DieselOpStoreTx {
+    /// Roll back on drop, so an early `?` in a host application's unit of
+    /// work cannot leave the transaction open.
+    ///
+    /// This has to happen synchronously — `Drop` cannot await — which is
+    /// safe enough here (a local `ROLLBACK` on an already-checked-out
+    /// connection) but is a real reason to prefer calling
+    /// [`commit`](Self::commit) or [`rollback`](Self::rollback) explicitly.
+    ///
+    /// Doing nothing would not be a silent success: r2d2 asks Diesel whether
+    /// a returned connection is broken, and a connection still inside a
+    /// transaction answers yes, so the pool would discard it and dial a new
+    /// one. The data outcome is the same (nothing was committed), but the
+    /// pool pays for a reconnect on every dropped transaction — and against
+    /// an in-memory SQLite database, where the connection *is* the database,
+    /// the reconnect silently starts from an empty schema.
+    fn drop(&mut self) {
+        if let Ok(slot) = self.conn.get_mut() {
+            if let Some(mut conn) = slot.take() {
+                let _ = AnsiTransactionManager::rollback_transaction(&mut *conn);
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl authkestra_op::store::TransactionalOpStore for DieselOpStore {
+    async fn begin(
+        &self,
+    ) -> Result<Box<dyn authkestra_op::store::OpStoreTransaction + Send>, StoreError> {
+        Ok(Box::new(self.begin_tx().await?))
+    }
+}
+
+#[async_trait]
+impl authkestra_op::store::OpStoreTransaction for DieselOpStoreTx {
+    async fn commit(self: Box<Self>) -> Result<(), StoreError> {
+        DieselOpStoreTx::commit(*self).await
+    }
+
+    async fn rollback(self: Box<Self>) -> Result<(), StoreError> {
+        DieselOpStoreTx::rollback(*self).await
+    }
+}
+
+/// Every query this store runs, written once as plain synchronous Diesel
+/// against a borrowed connection — no pool checkout, no `spawn_blocking`.
+/// Both [`DieselOpStore`] (which checks a connection out per call) and
+/// [`DieselOpStoreTx`] (which owns one for the life of its transaction)
+/// drive these through their own `run` helper.
+mod queries {
+    use super::*;
+
+    /// True when `conn` already has a transaction (or savepoint) open.
+    fn in_transaction(conn: &mut SqliteConnection) -> bool {
+        AnsiTransactionManager::transaction_manager_status_mut(conn)
+            .transaction_depth()
+            .ok()
+            .flatten()
+            .is_some()
+    }
+
+    /// Run `f` atomically, whether or not a transaction is already open.
+    ///
+    /// The single-use consume paths need their own atomic scope, and on the
+    /// pool that means `BEGIN IMMEDIATE` — taking SQLite's write lock up
+    /// front rather than failing with `SQLITE_BUSY` at the first write. But
+    /// SQLite has no nested `BEGIN`: called inside a host application's
+    /// transaction (`DieselOpStoreTx`), the same statement errors with
+    /// "cannot start a transaction within a transaction". Diesel's plain
+    /// `transaction` issues a SAVEPOINT once the depth is non-zero, which is
+    /// the correct nested form — governed by the outer commit or rollback —
+    /// so pick between them by depth.
+    ///
+    /// The outer transaction was itself opened with `BEGIN IMMEDIATE` (see
+    /// [`DieselOpStore::begin_tx`]), so the write lock this would have taken
+    /// is already held by the time a savepoint is used instead. Nothing is
+    /// given up by the switch.
+    fn atomically<T>(
+        conn: &mut SqliteConnection,
+        f: impl FnOnce(&mut SqliteConnection) -> Result<T, diesel::result::Error>,
+    ) -> Result<T, diesel::result::Error> {
+        if in_transaction(conn) {
+            conn.transaction(f)
+        } else {
+            conn.immediate_transaction(f)
+        }
+    }
+
+    pub(crate) fn find_client(
+        conn: &mut SqliteConnection,
+        client_id: String,
+    ) -> Result<Option<ClientRegistration>, StoreError> {
+        let row: Option<ClientRow> = oauth_clients::table
+            .find(client_id)
+            .first(conn)
+            .optional()
+            .map_err(diesel_err)?;
+        row.map(ClientRow::into_domain).transpose()
+    }
+
+    pub(crate) fn store_code(conn: &mut SqliteConnection, row: CodeRow) -> Result<(), StoreError> {
+        diesel::insert_into(oauth_codes::table)
+            .values(&row)
+            .execute(conn)
+            .map_err(diesel_err)?;
+        Ok(())
+    }
+
+    pub(crate) fn consume_code(
+        conn: &mut SqliteConnection,
+        code: String,
+    ) -> Result<Option<AuthorizationCode>, StoreError> {
+        atomically(conn, |conn| {
+            let row: Option<CodeRow> = oauth_codes::table.find(&code).first(conn).optional()?;
+            let Some(mut row) = row else {
+                return Ok(None);
+            };
+            // Single-use, atomically: the `UPDATE ... WHERE used =
+            // false` below is the actual compare-and-swap — two
+            // concurrent consumers can both reach this point having
+            // read `used: false` above, but only the one whose UPDATE
+            // affects a row (still `used = false` at write time) may
+            // treat the code as consumed. Same shape, and the same
+            // reasoning, as authkestra-store-sqlx's own consume_code;
+            // the `find` above is a read for the fields to return, not
+            // the authority on whether this call wins the race.
+            let affected = diesel::update(
+                oauth_codes::table
+                    .filter(oauth_codes::code.eq(&code))
+                    .filter(oauth_codes::used.eq(false)),
+            )
+            .set(oauth_codes::used.eq(true))
+            .execute(conn)?;
+            if affected != 1 {
+                return Ok(None);
+            }
+            row.used = true;
+            Ok::<_, diesel::result::Error>(Some(row))
+        })
+        .map_err(diesel_err)?
+        .map(CodeRow::into_domain)
+        .transpose()
+    }
+
+    pub(crate) fn store_token(
+        conn: &mut SqliteConnection,
+        row: RefreshTokenRow,
+    ) -> Result<(), StoreError> {
+        diesel::insert_into(oauth_refresh_tokens::table)
+            .values(&row)
+            .execute(conn)
+            .map_err(diesel_err)?;
+        Ok(())
+    }
+
+    pub(crate) fn get_token(
+        conn: &mut SqliteConnection,
+        token: String,
+    ) -> Result<Option<RefreshToken>, StoreError> {
+        let row: Option<RefreshTokenRow> = oauth_refresh_tokens::table
+            .find(token)
+            .first(conn)
+            .optional()
+            .map_err(diesel_err)?;
+        row.map(RefreshTokenRow::into_domain).transpose()
+    }
+
+    pub(crate) fn revoke_token(
+        conn: &mut SqliteConnection,
+        token: String,
+    ) -> Result<(), StoreError> {
+        diesel::delete(oauth_refresh_tokens::table.find(token))
+            .execute(conn)
+            .map_err(diesel_err)?;
+        Ok(())
+    }
+
+    pub(crate) fn consume_token(
+        conn: &mut SqliteConnection,
+        token: String,
+    ) -> Result<Option<RefreshToken>, StoreError> {
+        atomically(conn, |conn| {
+            let row: Option<RefreshTokenRow> = oauth_refresh_tokens::table
+                .find(&token)
+                .first(conn)
+                .optional()?;
+            let Some(row) = row else {
+                return Ok(None);
+            };
+            // The DELETE, not the `find` above, is what's atomic: two
+            // concurrent consumers can both read the row present, but
+            // only the one whose DELETE actually removes it (checked
+            // via the affected-row count) may treat the token as
+            // consumed — same compare-and-swap reasoning as
+            // `consume_code`.
+            let affected =
+                diesel::delete(oauth_refresh_tokens::table.find(&token)).execute(conn)?;
+            if affected != 1 {
+                return Ok(None);
+            }
+            Ok::<_, diesel::result::Error>(Some(row))
+        })
+        .map_err(diesel_err)?
+        .map(RefreshTokenRow::into_domain)
+        .transpose()
+    }
+
+    pub(crate) fn store_device_code(
+        conn: &mut SqliteConnection,
+        row: DeviceCodeRow,
+    ) -> Result<(), StoreError> {
+        diesel::insert_into(oauth_device_codes::table)
+            .values(&row)
+            .execute(conn)
+            .map_err(diesel_err)?;
+        Ok(())
+    }
+
+    pub(crate) fn get_device_code(
+        conn: &mut SqliteConnection,
+        device_code: String,
+    ) -> Result<Option<DeviceCodeSession>, StoreError> {
+        let row: Option<DeviceCodeRow> = oauth_device_codes::table
+            .find(device_code)
+            .first(conn)
+            .optional()
+            .map_err(diesel_err)?;
+        row.map(DeviceCodeRow::into_domain).transpose()
+    }
+
+    pub(crate) fn get_by_user_code(
+        conn: &mut SqliteConnection,
+        user_code: String,
+    ) -> Result<Option<DeviceCodeSession>, StoreError> {
+        let row: Option<DeviceCodeRow> = oauth_device_codes::table
+            .filter(oauth_device_codes::user_code.eq(user_code))
+            .first(conn)
+            .optional()
+            .map_err(diesel_err)?;
+        row.map(DeviceCodeRow::into_domain).transpose()
+    }
+
+    pub(crate) fn update_device_code(
+        conn: &mut SqliteConnection,
+        row: DeviceCodeRow,
+        device_code: String,
+    ) -> Result<(), StoreError> {
+        diesel::update(oauth_device_codes::table.find(device_code))
+            .set(&row)
+            .execute(conn)
+            .map_err(diesel_err)?;
+        Ok(())
+    }
+
+    pub(crate) fn delete_device_code(
+        conn: &mut SqliteConnection,
+        device_code: String,
+    ) -> Result<(), StoreError> {
+        diesel::delete(oauth_device_codes::table.find(device_code))
+            .execute(conn)
+            .map_err(diesel_err)?;
+        Ok(())
+    }
+
+    pub(crate) fn consume_device_code(
+        conn: &mut SqliteConnection,
+        device_code: String,
+    ) -> Result<Option<DeviceCodeSession>, StoreError> {
+        atomically(conn, |conn| {
+            let row: Option<DeviceCodeRow> = oauth_device_codes::table
+                .find(&device_code)
+                .first(conn)
+                .optional()?;
+            let Some(row) = row else {
+                return Ok(None);
+            };
+            // Same compare-and-swap reasoning as `consume_token`: the
+            // DELETE's affected-row count, not the read above, decides
+            // whether this call wins the race against a concurrent
+            // consumer of the same device code.
+            let affected =
+                diesel::delete(oauth_device_codes::table.find(&device_code)).execute(conn)?;
+            if affected != 1 {
+                return Ok(None);
+            }
+            Ok::<_, diesel::result::Error>(Some(row))
+        })
+        .map_err(diesel_err)?
+        .map(DeviceCodeRow::into_domain)
+        .transpose()
+    }
+}
+
+#[async_trait]
 #[async_trait]
 impl ClientStore for DieselOpStore {
     async fn find_client(
         &mut self,
         client_id: &str,
     ) -> Result<Option<ClientRegistration>, StoreError> {
-        let pool = self.pool.clone();
         let client_id = client_id.to_string();
-        tokio::task::spawn_blocking(move || {
-            let mut conn = pool.get().map_err(pool_err)?;
-            let row: Option<ClientRow> = oauth_clients::table
-                .find(client_id)
-                .first(&mut conn)
-                .optional()
-                .map_err(diesel_err)?;
-            row.map(ClientRow::into_domain).transpose()
-        })
-        .await
-        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))?
+        self.run(move |conn| queries::find_client(conn, client_id))
+            .await
     }
 }
 
+#[async_trait]
 #[async_trait]
 impl AuthorizationCodeStore for DieselOpStore {
     async fn store_code(&mut self, code: AuthorizationCode) -> Result<(), StoreError> {
-        let pool = self.pool.clone();
         let row = CodeRow::from_domain(&code)?;
-        tokio::task::spawn_blocking(move || {
-            let mut conn = pool.get().map_err(pool_err)?;
-            diesel::insert_into(oauth_codes::table)
-                .values(&row)
-                .execute(&mut conn)
-                .map_err(diesel_err)?;
-            Ok(())
-        })
-        .await
-        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))?
+        self.run(move |conn| queries::store_code(conn, row)).await
     }
-
     async fn consume_code(&mut self, code: &str) -> Result<Option<AuthorizationCode>, StoreError> {
-        let pool = self.pool.clone();
         let code = code.to_string();
-        tokio::task::spawn_blocking(move || {
-            let mut conn = pool.get().map_err(pool_err)?;
-            conn.immediate_transaction(|conn| {
-                let row: Option<CodeRow> = oauth_codes::table.find(&code).first(conn).optional()?;
-                let Some(mut row) = row else {
-                    return Ok(None);
-                };
-                // Single-use, atomically: the `UPDATE ... WHERE used =
-                // false` below is the actual compare-and-swap — two
-                // concurrent consumers can both reach this point having
-                // read `used: false` above, but only the one whose UPDATE
-                // affects a row (still `used = false` at write time) may
-                // treat the code as consumed. Same shape, and the same
-                // reasoning, as authkestra-store-sqlx's own consume_code;
-                // the `find` above is a read for the fields to return, not
-                // the authority on whether this call wins the race.
-                let affected = diesel::update(
-                    oauth_codes::table
-                        .filter(oauth_codes::code.eq(&code))
-                        .filter(oauth_codes::used.eq(false)),
-                )
-                .set(oauth_codes::used.eq(true))
-                .execute(conn)?;
-                if affected != 1 {
-                    return Ok(None);
-                }
-                row.used = true;
-                Ok::<_, diesel::result::Error>(Some(row))
-            })
-            .map_err(diesel_err)?
-            .map(CodeRow::into_domain)
-            .transpose()
-        })
-        .await
-        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))?
+        self.run(move |conn| queries::consume_code(conn, code))
+            .await
     }
 }
 
+#[async_trait]
 #[async_trait]
 impl RefreshTokenStore for DieselOpStore {
     async fn store_token(&mut self, token: RefreshToken) -> Result<(), StoreError> {
-        let pool = self.pool.clone();
         let row = RefreshTokenRow::from_domain(&token)?;
-        tokio::task::spawn_blocking(move || {
-            let mut conn = pool.get().map_err(pool_err)?;
-            diesel::insert_into(oauth_refresh_tokens::table)
-                .values(&row)
-                .execute(&mut conn)
-                .map_err(diesel_err)?;
-            Ok(())
-        })
-        .await
-        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))?
+        self.run(move |conn| queries::store_token(conn, row)).await
     }
-
     async fn get_token(&mut self, token: &str) -> Result<Option<RefreshToken>, StoreError> {
-        let pool = self.pool.clone();
         let token = token.to_string();
-        tokio::task::spawn_blocking(move || {
-            let mut conn = pool.get().map_err(pool_err)?;
-            let row: Option<RefreshTokenRow> = oauth_refresh_tokens::table
-                .find(token)
-                .first(&mut conn)
-                .optional()
-                .map_err(diesel_err)?;
-            row.map(RefreshTokenRow::into_domain).transpose()
-        })
-        .await
-        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))?
+        self.run(move |conn| queries::get_token(conn, token)).await
     }
-
     async fn revoke_token(&mut self, token: &str) -> Result<(), StoreError> {
-        let pool = self.pool.clone();
         let token = token.to_string();
-        tokio::task::spawn_blocking(move || {
-            let mut conn = pool.get().map_err(pool_err)?;
-            diesel::delete(oauth_refresh_tokens::table.find(token))
-                .execute(&mut conn)
-                .map_err(diesel_err)?;
-            Ok(())
-        })
-        .await
-        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))?
+        self.run(move |conn| queries::revoke_token(conn, token))
+            .await
     }
-
     async fn consume_token(&mut self, token: &str) -> Result<Option<RefreshToken>, StoreError> {
-        let pool = self.pool.clone();
         let token = token.to_string();
-        tokio::task::spawn_blocking(move || {
-            let mut conn = pool.get().map_err(pool_err)?;
-            conn.immediate_transaction(|conn| {
-                let row: Option<RefreshTokenRow> = oauth_refresh_tokens::table
-                    .find(&token)
-                    .first(conn)
-                    .optional()?;
-                let Some(row) = row else {
-                    return Ok(None);
-                };
-                // The DELETE, not the `find` above, is what's atomic: two
-                // concurrent consumers can both read the row present, but
-                // only the one whose DELETE actually removes it (checked
-                // via the affected-row count) may treat the token as
-                // consumed — same compare-and-swap reasoning as
-                // `consume_code`.
-                let affected =
-                    diesel::delete(oauth_refresh_tokens::table.find(&token)).execute(conn)?;
-                if affected != 1 {
-                    return Ok(None);
-                }
-                Ok::<_, diesel::result::Error>(Some(row))
-            })
-            .map_err(diesel_err)?
-            .map(RefreshTokenRow::into_domain)
-            .transpose()
-        })
-        .await
-        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))?
+        self.run(move |conn| queries::consume_token(conn, token))
+            .await
     }
 }
 
 #[async_trait]
+#[async_trait]
 impl DeviceCodeStore for DieselOpStore {
     async fn store_device_code(&mut self, session: DeviceCodeSession) -> Result<(), StoreError> {
-        let pool = self.pool.clone();
         let row = DeviceCodeRow::from_domain(&session)?;
-        tokio::task::spawn_blocking(move || {
-            let mut conn = pool.get().map_err(pool_err)?;
-            diesel::insert_into(oauth_device_codes::table)
-                .values(&row)
-                .execute(&mut conn)
-                .map_err(diesel_err)?;
-            Ok(())
-        })
-        .await
-        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))?
+        self.run(move |conn| queries::store_device_code(conn, row))
+            .await
     }
-
     async fn get_device_code(
         &mut self,
         device_code: &str,
     ) -> Result<Option<DeviceCodeSession>, StoreError> {
-        let pool = self.pool.clone();
         let device_code = device_code.to_string();
-        tokio::task::spawn_blocking(move || {
-            let mut conn = pool.get().map_err(pool_err)?;
-            let row: Option<DeviceCodeRow> = oauth_device_codes::table
-                .find(device_code)
-                .first(&mut conn)
-                .optional()
-                .map_err(diesel_err)?;
-            row.map(DeviceCodeRow::into_domain).transpose()
-        })
-        .await
-        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))?
+        self.run(move |conn| queries::get_device_code(conn, device_code))
+            .await
     }
-
     async fn get_by_user_code(
         &mut self,
         user_code: &str,
     ) -> Result<Option<DeviceCodeSession>, StoreError> {
-        let pool = self.pool.clone();
         let user_code = user_code.to_string();
-        tokio::task::spawn_blocking(move || {
-            let mut conn = pool.get().map_err(pool_err)?;
-            let row: Option<DeviceCodeRow> = oauth_device_codes::table
-                .filter(oauth_device_codes::user_code.eq(user_code))
-                .first(&mut conn)
-                .optional()
-                .map_err(diesel_err)?;
-            row.map(DeviceCodeRow::into_domain).transpose()
-        })
-        .await
-        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))?
+        self.run(move |conn| queries::get_by_user_code(conn, user_code))
+            .await
     }
-
     async fn update_device_code(&mut self, session: DeviceCodeSession) -> Result<(), StoreError> {
-        let pool = self.pool.clone();
         let row = DeviceCodeRow::from_domain(&session)?;
         let device_code = session.device_code.clone();
-        tokio::task::spawn_blocking(move || {
-            let mut conn = pool.get().map_err(pool_err)?;
-            diesel::update(oauth_device_codes::table.find(device_code))
-                .set(&row)
-                .execute(&mut conn)
-                .map_err(diesel_err)?;
-            Ok(())
-        })
-        .await
-        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))?
+        self.run(move |conn| queries::update_device_code(conn, row, device_code))
+            .await
     }
-
     async fn delete_device_code(&mut self, device_code: &str) -> Result<(), StoreError> {
-        let pool = self.pool.clone();
         let device_code = device_code.to_string();
-        tokio::task::spawn_blocking(move || {
-            let mut conn = pool.get().map_err(pool_err)?;
-            diesel::delete(oauth_device_codes::table.find(device_code))
-                .execute(&mut conn)
-                .map_err(diesel_err)?;
-            Ok(())
-        })
-        .await
-        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))?
+        self.run(move |conn| queries::delete_device_code(conn, device_code))
+            .await
     }
-
     async fn consume_device_code(
         &mut self,
         device_code: &str,
     ) -> Result<Option<DeviceCodeSession>, StoreError> {
-        let pool = self.pool.clone();
         let device_code = device_code.to_string();
-        tokio::task::spawn_blocking(move || {
-            let mut conn = pool.get().map_err(pool_err)?;
-            conn.immediate_transaction(|conn| {
-                let row: Option<DeviceCodeRow> = oauth_device_codes::table
-                    .find(&device_code)
-                    .first(conn)
-                    .optional()?;
-                let Some(row) = row else {
-                    return Ok(None);
-                };
-                // Same compare-and-swap reasoning as `consume_token`: the
-                // DELETE's affected-row count, not the read above, decides
-                // whether this call wins the race against a concurrent
-                // consumer of the same device code.
-                let affected =
-                    diesel::delete(oauth_device_codes::table.find(&device_code)).execute(conn)?;
-                if affected != 1 {
-                    return Ok(None);
-                }
-                Ok::<_, diesel::result::Error>(Some(row))
-            })
-            .map_err(diesel_err)?
-            .map(DeviceCodeRow::into_domain)
-            .transpose()
-        })
-        .await
-        .map_err(|e| StoreError::Internal(format!("diesel worker task failed: {e}")))?
+        self.run(move |conn| queries::consume_device_code(conn, device_code))
+            .await
     }
 }
 
 impl OpStore for DieselOpStore {}
+
+#[async_trait]
+impl ClientStore for DieselOpStoreTx {
+    async fn find_client(
+        &mut self,
+        client_id: &str,
+    ) -> Result<Option<ClientRegistration>, StoreError> {
+        let client_id = client_id.to_string();
+        self.run(move |conn| queries::find_client(conn, client_id))
+            .await
+    }
+}
+
+#[async_trait]
+impl AuthorizationCodeStore for DieselOpStoreTx {
+    async fn store_code(&mut self, code: AuthorizationCode) -> Result<(), StoreError> {
+        let row = CodeRow::from_domain(&code)?;
+        self.run(move |conn| queries::store_code(conn, row)).await
+    }
+    async fn consume_code(&mut self, code: &str) -> Result<Option<AuthorizationCode>, StoreError> {
+        let code = code.to_string();
+        self.run(move |conn| queries::consume_code(conn, code))
+            .await
+    }
+}
+
+#[async_trait]
+impl RefreshTokenStore for DieselOpStoreTx {
+    async fn store_token(&mut self, token: RefreshToken) -> Result<(), StoreError> {
+        let row = RefreshTokenRow::from_domain(&token)?;
+        self.run(move |conn| queries::store_token(conn, row)).await
+    }
+    async fn get_token(&mut self, token: &str) -> Result<Option<RefreshToken>, StoreError> {
+        let token = token.to_string();
+        self.run(move |conn| queries::get_token(conn, token)).await
+    }
+    async fn revoke_token(&mut self, token: &str) -> Result<(), StoreError> {
+        let token = token.to_string();
+        self.run(move |conn| queries::revoke_token(conn, token))
+            .await
+    }
+    async fn consume_token(&mut self, token: &str) -> Result<Option<RefreshToken>, StoreError> {
+        let token = token.to_string();
+        self.run(move |conn| queries::consume_token(conn, token))
+            .await
+    }
+}
+
+#[async_trait]
+impl DeviceCodeStore for DieselOpStoreTx {
+    async fn store_device_code(&mut self, session: DeviceCodeSession) -> Result<(), StoreError> {
+        let row = DeviceCodeRow::from_domain(&session)?;
+        self.run(move |conn| queries::store_device_code(conn, row))
+            .await
+    }
+    async fn get_device_code(
+        &mut self,
+        device_code: &str,
+    ) -> Result<Option<DeviceCodeSession>, StoreError> {
+        let device_code = device_code.to_string();
+        self.run(move |conn| queries::get_device_code(conn, device_code))
+            .await
+    }
+    async fn get_by_user_code(
+        &mut self,
+        user_code: &str,
+    ) -> Result<Option<DeviceCodeSession>, StoreError> {
+        let user_code = user_code.to_string();
+        self.run(move |conn| queries::get_by_user_code(conn, user_code))
+            .await
+    }
+    async fn update_device_code(&mut self, session: DeviceCodeSession) -> Result<(), StoreError> {
+        let row = DeviceCodeRow::from_domain(&session)?;
+        let device_code = session.device_code.clone();
+        self.run(move |conn| queries::update_device_code(conn, row, device_code))
+            .await
+    }
+    async fn delete_device_code(&mut self, device_code: &str) -> Result<(), StoreError> {
+        let device_code = device_code.to_string();
+        self.run(move |conn| queries::delete_device_code(conn, device_code))
+            .await
+    }
+    async fn consume_device_code(
+        &mut self,
+        device_code: &str,
+    ) -> Result<Option<DeviceCodeSession>, StoreError> {
+        let device_code = device_code.to_string();
+        self.run(move |conn| queries::consume_device_code(conn, device_code))
+            .await
+    }
+}
+
+impl OpStore for DieselOpStoreTx {}

--- a/crates/authkestra-example-diesel/tests/conformance.rs
+++ b/crates/authkestra-example-diesel/tests/conformance.rs
@@ -1,5 +1,10 @@
+use authkestra_engine::auth::state::Identity;
+use authkestra_engine::chrono::{Duration, Utc};
+use authkestra_engine::store::StoreError;
 use authkestra_example_diesel::DieselOpStore;
+use authkestra_op::refresh::{RefreshToken, RefreshTokenStore};
 use authkestra_store_testsuite::op::run_op_store_tests;
+use authkestra_store_testsuite::tx::run_transactional_op_store_tests;
 use diesel::prelude::*;
 
 /// Runs the shared `OpStore` conformance suite (authkestra-store-testsuite)
@@ -26,6 +31,7 @@ async fn test_diesel_op_store_sqlite() {
 
     let mut store = store;
     run_op_store_tests(&mut store).await;
+    run_transactional_op_store_tests(&mut store).await;
 }
 
 fn seed_fixture_client(store: &DieselOpStore) {
@@ -37,4 +43,127 @@ fn seed_fixture_client(store: &DieselOpStore) {
     )
     .execute(&mut conn)
     .expect("seeding the fixture client must succeed");
+}
+
+/// The composed unit of work (authkestra#336) against Diesel — the awkward
+/// case, and the one worth having a test for: a synchronous ORM with no owned
+/// transaction handle, driven through `spawn_blocking`, where the host's own
+/// query arrives as a closure rather than a borrow.
+#[tokio::test]
+async fn test_host_write_and_store_write_commit_as_one_unit() {
+    let store = DieselOpStore::connect(":memory:").expect("in-memory sqlite pool must build");
+    store.migrate().await.expect("migrating must succeed");
+    seed_fixture_client(&store);
+
+    {
+        let mut conn = store
+            .pool()
+            .get()
+            .expect("checking out a connection must succeed");
+        diesel::sql_query("CREATE TABLE app_users (id TEXT PRIMARY KEY, email TEXT NOT NULL)")
+            .execute(&mut conn)
+            .expect("creating the host application's own table must succeed");
+    }
+
+    let mut store = store;
+
+    // Rolled back as one unit.
+    let mut tx = store
+        .begin_tx()
+        .await
+        .expect("beginning a transaction must succeed");
+    tx.run(|conn| {
+        diesel::sql_query("INSERT INTO app_users (id, email) VALUES ('u-rb', 'rb@example.com')")
+            .execute(conn)
+            .map(|_| ())
+            .map_err(|e| StoreError::Internal(format!("diesel error: {e}")))
+    })
+    .await
+    .expect("the host's own insert must succeed inside the transaction");
+    tx.store_token(refresh_token("diesel-tx-rolled-back"))
+        .await
+        .expect("the store's write must succeed in the same transaction");
+    tx.rollback().await.expect("rolling back must succeed");
+
+    assert_eq!(
+        count_app_users(&store, "u-rb"),
+        0,
+        "the host's row must roll back with the store's"
+    );
+    assert!(
+        store
+            .get_token("diesel-tx-rolled-back")
+            .await
+            .expect("reading must not error")
+            .is_none(),
+        "the store's row must roll back with the host application's"
+    );
+
+    // Committed as one unit.
+    let mut tx = store
+        .begin_tx()
+        .await
+        .expect("beginning a transaction must succeed");
+    tx.run(|conn| {
+        diesel::sql_query("INSERT INTO app_users (id, email) VALUES ('u-ok', 'ok@example.com')")
+            .execute(conn)
+            .map(|_| ())
+            .map_err(|e| StoreError::Internal(format!("diesel error: {e}")))
+    })
+    .await
+    .expect("the host's own insert must succeed inside the transaction");
+    tx.store_token(refresh_token("diesel-tx-committed"))
+        .await
+        .expect("the store's write must succeed in the same transaction");
+    tx.commit().await.expect("committing must succeed");
+
+    assert_eq!(
+        count_app_users(&store, "u-ok"),
+        1,
+        "the host's row must be durable after the commit"
+    );
+    assert!(
+        store
+            .get_token("diesel-tx-committed")
+            .await
+            .expect("reading must not error")
+            .is_some(),
+        "the store's row must be durable after the same commit"
+    );
+}
+
+#[derive(diesel::QueryableByName)]
+struct Count {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    n: i64,
+}
+
+fn count_app_users(store: &DieselOpStore, id: &str) -> i64 {
+    let mut conn = store
+        .pool()
+        .get()
+        .expect("checking out a connection must succeed");
+    diesel::sql_query(format!(
+        "SELECT COUNT(*) AS n FROM app_users WHERE id = '{id}'"
+    ))
+    .get_result::<Count>(&mut conn)
+    .expect("counting host rows must succeed")
+    .n
+}
+
+fn refresh_token(token: &str) -> RefreshToken {
+    RefreshToken::new(
+        token.to_string(),
+        "client-1".to_string(),
+        Identity {
+            provider_id: "test".to_string(),
+            external_id: "user-1".to_string(),
+            email: None,
+            username: None,
+            attributes: std::collections::HashMap::new(),
+        },
+        "openid".to_string(),
+        Utc::now() + Duration::days(1),
+        None,
+    )
 }

--- a/crates/authkestra-example-seaorm/src/lib.rs
+++ b/crates/authkestra-example-seaorm/src/lib.rs
@@ -8,4 +8,4 @@ mod entities;
 mod store;
 
 pub use entities::{client, code, device_code, refresh_token};
-pub use store::SeaOrmOpStore;
+pub use store::{SeaOrmOpStore, SeaOrmOpStoreTx};

--- a/crates/authkestra-example-seaorm/src/store.rs
+++ b/crates/authkestra-example-seaorm/src/store.rs
@@ -9,7 +9,8 @@ use authkestra_op::refresh::{RefreshToken, RefreshTokenStore};
 use authkestra_op::store::OpStore;
 use sea_orm::{
     sea_query::Expr, ActiveModelTrait, ActiveValue, ColumnTrait, ConnectionTrait, Database,
-    DatabaseConnection, DbErr, EntityTrait, QueryFilter, Schema, TransactionTrait,
+    DatabaseConnection, DatabaseTransaction, DbErr, EntityTrait, QueryFilter, Schema,
+    TransactionTrait,
 };
 
 fn db_err(e: DbErr) -> StoreError {
@@ -77,6 +78,17 @@ impl SeaOrmOpStore {
         &self.db
     }
 
+    /// Begin a transaction and return a store scoped to it.
+    ///
+    /// The concrete counterpart to
+    /// [`TransactionalOpStore::begin`](authkestra_op::store::TransactionalOpStore::begin):
+    /// it returns [`SeaOrmOpStoreTx`] rather than a trait object, which is
+    /// what a host application needs in order to interleave its own writes.
+    pub async fn begin_tx(&self) -> Result<SeaOrmOpStoreTx, StoreError> {
+        let txn = self.db.begin().await.map_err(db_err)?;
+        Ok(SeaOrmOpStoreTx { txn })
+    }
+
     /// Creates the four tables this store needs, if they don't already
     /// exist. Idempotent — safe to call on every startup, same contract as
     /// `authkestra-store-sqlx::SqlxOpStore::migrate`.
@@ -133,41 +145,91 @@ fn client_from_model(model: client::Model) -> Result<ClientRegistration, StoreEr
     })
 }
 
+/// A [`SeaOrmOpStore`] scoped to one open SeaORM transaction — the same
+/// capability `authkestra-store-sqlx` offers, implemented here against a
+/// third-party ORM to check the design isn't shaped around `sqlx`.
+///
+/// Obtain one from [`SeaOrmOpStore::begin_tx`]. [`transaction`](Self::transaction)
+/// hands back the live [`DatabaseTransaction`] so a host application's own
+/// entities and queries run in the same unit of work as the store's, and
+/// commit or roll back with them.
+///
+/// Note this accessor returns `&DatabaseTransaction` where the `sqlx`
+/// counterpart's returns `&mut Connection`: SeaORM's `ConnectionTrait` takes
+/// `&self`, sqlx's `Executor` takes `&mut`. That difference is exactly why
+/// reaching the native handle stays an inherent method per backend rather
+/// than something the shared, dyn-compatible trait tries to abstract over.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct SeaOrmOpStoreTx {
+    txn: DatabaseTransaction,
+}
+
+impl SeaOrmOpStoreTx {
+    /// The live transaction, for the host application's own statements.
+    pub fn transaction(&self) -> &DatabaseTransaction {
+        &self.txn
+    }
+
+    /// Commit, making every write in this transaction durable at once.
+    pub async fn commit(self) -> Result<(), StoreError> {
+        self.txn.commit().await.map_err(db_err)
+    }
+
+    /// Roll back, discarding every write in this transaction.
+    pub async fn rollback(self) -> Result<(), StoreError> {
+        self.txn.rollback().await.map_err(db_err)
+    }
+}
+
 #[async_trait]
-impl ClientStore for SeaOrmOpStore {
-    async fn find_client(
-        &mut self,
+impl authkestra_op::store::TransactionalOpStore for SeaOrmOpStore {
+    async fn begin(
+        &self,
+    ) -> Result<Box<dyn authkestra_op::store::OpStoreTransaction + Send>, StoreError> {
+        Ok(Box::new(self.begin_tx().await?))
+    }
+}
+
+#[async_trait]
+impl authkestra_op::store::OpStoreTransaction for SeaOrmOpStoreTx {
+    async fn commit(self: Box<Self>) -> Result<(), StoreError> {
+        SeaOrmOpStoreTx::commit(*self).await
+    }
+
+    async fn rollback(self: Box<Self>) -> Result<(), StoreError> {
+        SeaOrmOpStoreTx::rollback(*self).await
+    }
+}
+
+/// Every query this store runs, written once against any SeaORM
+/// [`ConnectionTrait`] rather than against the pooled `DatabaseConnection`,
+/// so [`SeaOrmOpStore`] and [`SeaOrmOpStoreTx`] share them verbatim instead
+/// of keeping two copies of the same logic in sync.
+///
+/// The [`TransactionTrait`] bound is what makes the composed case correct:
+/// the single-use consume paths open a transaction of their own, and SeaORM
+/// turns `begin()` on a `DatabaseTransaction` into a nested savepoint — so
+/// called inside a caller's transaction they are governed by the caller's
+/// rollback rather than committing independently of it.
+mod queries {
+    use super::*;
+
+    pub(crate) async fn find_client<C: ConnectionTrait + TransactionTrait>(
+        conn: &C,
         client_id: &str,
     ) -> Result<Option<ClientRegistration>, StoreError> {
         let model = client::Entity::find_by_id(client_id)
-            .one(&self.db)
+            .one(conn)
             .await
             .map_err(db_err)?;
         model.map(client_from_model).transpose()
     }
-}
 
-fn code_from_model(model: code::Model) -> Result<AuthorizationCode, StoreError> {
-    Ok({
-        let mut code = AuthorizationCode::new(
-            model.code,
-            model.client_id,
-            model.redirect_uri,
-            model.scope,
-            decode_json(model.identity)?,
-            model.expires_at,
-            model.used,
-        );
-        code.code_challenge = model.code_challenge;
-        code.code_challenge_method = model.code_challenge_method;
-        code.nonce = model.nonce;
-        code
-    })
-}
-
-#[async_trait]
-impl AuthorizationCodeStore for SeaOrmOpStore {
-    async fn store_code(&mut self, code: AuthorizationCode) -> Result<(), StoreError> {
+    pub(crate) async fn store_code<C: ConnectionTrait + TransactionTrait>(
+        conn: &C,
+        code: AuthorizationCode,
+    ) -> Result<(), StoreError> {
         let identity = serde_json::to_value(&code.identity)
             .map_err(|e| StoreError::Internal(format!("failed to encode value as JSON: {e}")))?;
         let active = code::ActiveModel {
@@ -182,12 +244,15 @@ impl AuthorizationCodeStore for SeaOrmOpStore {
             expires_at: ActiveValue::Set(code.expires_at),
             used: ActiveValue::Set(code.used),
         };
-        active.insert(&self.db).await.map_err(db_err)?;
+        active.insert(conn).await.map_err(db_err)?;
         Ok(())
     }
 
-    async fn consume_code(&mut self, code: &str) -> Result<Option<AuthorizationCode>, StoreError> {
-        let txn = self.db.begin().await.map_err(db_err)?;
+    pub(crate) async fn consume_code<C: ConnectionTrait + TransactionTrait>(
+        conn: &C,
+        code: &str,
+    ) -> Result<Option<AuthorizationCode>, StoreError> {
+        let txn = conn.begin().await.map_err(db_err)?;
         let model = code::Entity::find_by_id(code)
             .one(&txn)
             .await
@@ -219,22 +284,11 @@ impl AuthorizationCodeStore for SeaOrmOpStore {
         model.used = true;
         code_from_model(model).map(Some)
     }
-}
 
-fn refresh_token_from_model(model: refresh_token::Model) -> Result<RefreshToken, StoreError> {
-    Ok(RefreshToken::new(
-        model.token,
-        model.client_id,
-        decode_json(model.identity)?,
-        model.scope,
-        model.expires_at,
-        model.jkt,
-    ))
-}
-
-#[async_trait]
-impl RefreshTokenStore for SeaOrmOpStore {
-    async fn store_token(&mut self, token: RefreshToken) -> Result<(), StoreError> {
+    pub(crate) async fn store_token<C: ConnectionTrait + TransactionTrait>(
+        conn: &C,
+        token: RefreshToken,
+    ) -> Result<(), StoreError> {
         let identity = serde_json::to_value(&token.identity)
             .map_err(|e| StoreError::Internal(format!("failed to encode value as JSON: {e}")))?;
         let active = refresh_token::ActiveModel {
@@ -245,28 +299,37 @@ impl RefreshTokenStore for SeaOrmOpStore {
             expires_at: ActiveValue::Set(token.expires_at),
             jkt: ActiveValue::Set(token.jkt),
         };
-        active.insert(&self.db).await.map_err(db_err)?;
+        active.insert(conn).await.map_err(db_err)?;
         Ok(())
     }
 
-    async fn get_token(&mut self, token: &str) -> Result<Option<RefreshToken>, StoreError> {
+    pub(crate) async fn get_token<C: ConnectionTrait + TransactionTrait>(
+        conn: &C,
+        token: &str,
+    ) -> Result<Option<RefreshToken>, StoreError> {
         let model = refresh_token::Entity::find_by_id(token)
-            .one(&self.db)
+            .one(conn)
             .await
             .map_err(db_err)?;
         model.map(refresh_token_from_model).transpose()
     }
 
-    async fn revoke_token(&mut self, token: &str) -> Result<(), StoreError> {
+    pub(crate) async fn revoke_token<C: ConnectionTrait + TransactionTrait>(
+        conn: &C,
+        token: &str,
+    ) -> Result<(), StoreError> {
         refresh_token::Entity::delete_by_id(token)
-            .exec(&self.db)
+            .exec(conn)
             .await
             .map_err(db_err)?;
         Ok(())
     }
 
-    async fn consume_token(&mut self, token: &str) -> Result<Option<RefreshToken>, StoreError> {
-        let txn = self.db.begin().await.map_err(db_err)?;
+    pub(crate) async fn consume_token<C: ConnectionTrait + TransactionTrait>(
+        conn: &C,
+        token: &str,
+    ) -> Result<Option<RefreshToken>, StoreError> {
+        let txn = conn.begin().await.map_err(db_err)?;
         let model = refresh_token::Entity::find_by_id(token)
             .one(&txn)
             .await
@@ -290,6 +353,157 @@ impl RefreshTokenStore for SeaOrmOpStore {
         }
         txn.commit().await.map_err(db_err)?;
         refresh_token_from_model(model).map(Some)
+    }
+
+    pub(crate) async fn store_device_code<C: ConnectionTrait + TransactionTrait>(
+        conn: &C,
+        session: DeviceCodeSession,
+    ) -> Result<(), StoreError> {
+        device_code_active_model(&session)?
+            .insert(conn)
+            .await
+            .map_err(db_err)?;
+        Ok(())
+    }
+
+    pub(crate) async fn get_device_code<C: ConnectionTrait + TransactionTrait>(
+        conn: &C,
+        device_code: &str,
+    ) -> Result<Option<DeviceCodeSession>, StoreError> {
+        let model = device_code::Entity::find_by_id(device_code)
+            .one(conn)
+            .await
+            .map_err(db_err)?;
+        model.map(device_code_from_model).transpose()
+    }
+
+    pub(crate) async fn get_by_user_code<C: ConnectionTrait + TransactionTrait>(
+        conn: &C,
+        user_code: &str,
+    ) -> Result<Option<DeviceCodeSession>, StoreError> {
+        use sea_orm::{ColumnTrait, QueryFilter};
+        let model = device_code::Entity::find()
+            .filter(device_code::Column::UserCode.eq(user_code))
+            .one(conn)
+            .await
+            .map_err(db_err)?;
+        model.map(device_code_from_model).transpose()
+    }
+
+    pub(crate) async fn update_device_code<C: ConnectionTrait + TransactionTrait>(
+        conn: &C,
+        session: DeviceCodeSession,
+    ) -> Result<(), StoreError> {
+        device_code_active_model(&session)?
+            .update(conn)
+            .await
+            .map_err(db_err)?;
+        Ok(())
+    }
+
+    pub(crate) async fn delete_device_code<C: ConnectionTrait + TransactionTrait>(
+        conn: &C,
+        device_code: &str,
+    ) -> Result<(), StoreError> {
+        device_code::Entity::delete_by_id(device_code)
+            .exec(conn)
+            .await
+            .map_err(db_err)?;
+        Ok(())
+    }
+
+    pub(crate) async fn consume_device_code<C: ConnectionTrait + TransactionTrait>(
+        conn: &C,
+        device_code: &str,
+    ) -> Result<Option<DeviceCodeSession>, StoreError> {
+        let txn = conn.begin().await.map_err(db_err)?;
+        let model = device_code::Entity::find_by_id(device_code)
+            .one(&txn)
+            .await
+            .map_err(db_err)?;
+        let Some(model) = model else {
+            txn.rollback().await.map_err(db_err)?;
+            return Ok(None);
+        };
+        // Same compare-and-swap reasoning as `consume_token`: the DELETE's
+        // `rows_affected`, not the read above, decides whether this call
+        // wins the race against a concurrent consumer of the same device
+        // code.
+        let result = device_code::Entity::delete_by_id(device_code)
+            .exec(&txn)
+            .await
+            .map_err(db_err)?;
+        if result.rows_affected != 1 {
+            txn.rollback().await.map_err(db_err)?;
+            return Ok(None);
+        }
+        txn.commit().await.map_err(db_err)?;
+        device_code_from_model(model).map(Some)
+    }
+}
+
+#[async_trait]
+impl ClientStore for SeaOrmOpStore {
+    async fn find_client(
+        &mut self,
+        client_id: &str,
+    ) -> Result<Option<ClientRegistration>, StoreError> {
+        queries::find_client(&self.db, client_id).await
+    }
+}
+
+fn code_from_model(model: code::Model) -> Result<AuthorizationCode, StoreError> {
+    Ok({
+        let mut code = AuthorizationCode::new(
+            model.code,
+            model.client_id,
+            model.redirect_uri,
+            model.scope,
+            decode_json(model.identity)?,
+            model.expires_at,
+            model.used,
+        );
+        code.code_challenge = model.code_challenge;
+        code.code_challenge_method = model.code_challenge_method;
+        code.nonce = model.nonce;
+        code
+    })
+}
+
+#[async_trait]
+impl AuthorizationCodeStore for SeaOrmOpStore {
+    async fn store_code(&mut self, code: AuthorizationCode) -> Result<(), StoreError> {
+        queries::store_code(&self.db, code).await
+    }
+    async fn consume_code(&mut self, code: &str) -> Result<Option<AuthorizationCode>, StoreError> {
+        queries::consume_code(&self.db, code).await
+    }
+}
+
+fn refresh_token_from_model(model: refresh_token::Model) -> Result<RefreshToken, StoreError> {
+    Ok(RefreshToken::new(
+        model.token,
+        model.client_id,
+        decode_json(model.identity)?,
+        model.scope,
+        model.expires_at,
+        model.jkt,
+    ))
+}
+
+#[async_trait]
+impl RefreshTokenStore for SeaOrmOpStore {
+    async fn store_token(&mut self, token: RefreshToken) -> Result<(), StoreError> {
+        queries::store_token(&self.db, token).await
+    }
+    async fn get_token(&mut self, token: &str) -> Result<Option<RefreshToken>, StoreError> {
+        queries::get_token(&self.db, token).await
+    }
+    async fn revoke_token(&mut self, token: &str) -> Result<(), StoreError> {
+        queries::revoke_token(&self.db, token).await
+    }
+    async fn consume_token(&mut self, token: &str) -> Result<Option<RefreshToken>, StoreError> {
+        queries::consume_token(&self.db, token).await
     }
 }
 
@@ -328,81 +542,101 @@ fn device_code_active_model(
 #[async_trait]
 impl DeviceCodeStore for SeaOrmOpStore {
     async fn store_device_code(&mut self, session: DeviceCodeSession) -> Result<(), StoreError> {
-        device_code_active_model(&session)?
-            .insert(&self.db)
-            .await
-            .map_err(db_err)?;
-        Ok(())
+        queries::store_device_code(&self.db, session).await
     }
-
     async fn get_device_code(
         &mut self,
         device_code: &str,
     ) -> Result<Option<DeviceCodeSession>, StoreError> {
-        let model = device_code::Entity::find_by_id(device_code)
-            .one(&self.db)
-            .await
-            .map_err(db_err)?;
-        model.map(device_code_from_model).transpose()
+        queries::get_device_code(&self.db, device_code).await
     }
-
     async fn get_by_user_code(
         &mut self,
         user_code: &str,
     ) -> Result<Option<DeviceCodeSession>, StoreError> {
-        use sea_orm::{ColumnTrait, QueryFilter};
-        let model = device_code::Entity::find()
-            .filter(device_code::Column::UserCode.eq(user_code))
-            .one(&self.db)
-            .await
-            .map_err(db_err)?;
-        model.map(device_code_from_model).transpose()
+        queries::get_by_user_code(&self.db, user_code).await
     }
-
     async fn update_device_code(&mut self, session: DeviceCodeSession) -> Result<(), StoreError> {
-        device_code_active_model(&session)?
-            .update(&self.db)
-            .await
-            .map_err(db_err)?;
-        Ok(())
+        queries::update_device_code(&self.db, session).await
     }
-
     async fn delete_device_code(&mut self, device_code: &str) -> Result<(), StoreError> {
-        device_code::Entity::delete_by_id(device_code)
-            .exec(&self.db)
-            .await
-            .map_err(db_err)?;
-        Ok(())
+        queries::delete_device_code(&self.db, device_code).await
     }
-
     async fn consume_device_code(
         &mut self,
         device_code: &str,
     ) -> Result<Option<DeviceCodeSession>, StoreError> {
-        let txn = self.db.begin().await.map_err(db_err)?;
-        let model = device_code::Entity::find_by_id(device_code)
-            .one(&txn)
-            .await
-            .map_err(db_err)?;
-        let Some(model) = model else {
-            txn.rollback().await.map_err(db_err)?;
-            return Ok(None);
-        };
-        // Same compare-and-swap reasoning as `consume_token`: the DELETE's
-        // `rows_affected`, not the read above, decides whether this call
-        // wins the race against a concurrent consumer of the same device
-        // code.
-        let result = device_code::Entity::delete_by_id(device_code)
-            .exec(&txn)
-            .await
-            .map_err(db_err)?;
-        if result.rows_affected != 1 {
-            txn.rollback().await.map_err(db_err)?;
-            return Ok(None);
-        }
-        txn.commit().await.map_err(db_err)?;
-        device_code_from_model(model).map(Some)
+        queries::consume_device_code(&self.db, device_code).await
     }
 }
 
 impl OpStore for SeaOrmOpStore {}
+
+#[async_trait]
+impl ClientStore for SeaOrmOpStoreTx {
+    async fn find_client(
+        &mut self,
+        client_id: &str,
+    ) -> Result<Option<ClientRegistration>, StoreError> {
+        queries::find_client(&self.txn, client_id).await
+    }
+}
+
+#[async_trait]
+impl AuthorizationCodeStore for SeaOrmOpStoreTx {
+    async fn store_code(&mut self, code: AuthorizationCode) -> Result<(), StoreError> {
+        queries::store_code(&self.txn, code).await
+    }
+    async fn consume_code(&mut self, code: &str) -> Result<Option<AuthorizationCode>, StoreError> {
+        queries::consume_code(&self.txn, code).await
+    }
+}
+
+#[async_trait]
+impl RefreshTokenStore for SeaOrmOpStoreTx {
+    async fn store_token(&mut self, token: RefreshToken) -> Result<(), StoreError> {
+        queries::store_token(&self.txn, token).await
+    }
+    async fn get_token(&mut self, token: &str) -> Result<Option<RefreshToken>, StoreError> {
+        queries::get_token(&self.txn, token).await
+    }
+    async fn revoke_token(&mut self, token: &str) -> Result<(), StoreError> {
+        queries::revoke_token(&self.txn, token).await
+    }
+    async fn consume_token(&mut self, token: &str) -> Result<Option<RefreshToken>, StoreError> {
+        queries::consume_token(&self.txn, token).await
+    }
+}
+
+#[async_trait]
+impl DeviceCodeStore for SeaOrmOpStoreTx {
+    async fn store_device_code(&mut self, session: DeviceCodeSession) -> Result<(), StoreError> {
+        queries::store_device_code(&self.txn, session).await
+    }
+    async fn get_device_code(
+        &mut self,
+        device_code: &str,
+    ) -> Result<Option<DeviceCodeSession>, StoreError> {
+        queries::get_device_code(&self.txn, device_code).await
+    }
+    async fn get_by_user_code(
+        &mut self,
+        user_code: &str,
+    ) -> Result<Option<DeviceCodeSession>, StoreError> {
+        queries::get_by_user_code(&self.txn, user_code).await
+    }
+    async fn update_device_code(&mut self, session: DeviceCodeSession) -> Result<(), StoreError> {
+        queries::update_device_code(&self.txn, session).await
+    }
+    async fn delete_device_code(&mut self, device_code: &str) -> Result<(), StoreError> {
+        queries::delete_device_code(&self.txn, device_code).await
+    }
+    async fn consume_device_code(
+        &mut self,
+        device_code: &str,
+    ) -> Result<Option<DeviceCodeSession>, StoreError> {
+        queries::consume_device_code(&self.txn, device_code).await
+    }
+}
+
+impl OpStore for SeaOrmOpStoreTx {}

--- a/crates/authkestra-example-seaorm/tests/conformance.rs
+++ b/crates/authkestra-example-seaorm/tests/conformance.rs
@@ -1,6 +1,11 @@
+use authkestra_engine::auth::state::Identity;
+use authkestra_engine::chrono::{Duration, Utc};
 use authkestra_example_seaorm::{client, SeaOrmOpStore};
+use authkestra_op::refresh::{RefreshToken, RefreshTokenStore};
 use authkestra_store_testsuite::op::run_op_store_tests;
+use authkestra_store_testsuite::tx::run_transactional_op_store_tests;
 use sea_orm::{ActiveValue, EntityTrait};
+use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
 
 /// Runs the shared `OpStore` conformance suite (authkestra-store-testsuite)
 /// against the SeaORM example store — the actual proof this example is
@@ -26,6 +31,7 @@ async fn test_seaorm_op_store_sqlite() {
 
     let mut store = store;
     run_op_store_tests(&mut store).await;
+    run_transactional_op_store_tests(&mut store).await;
 }
 
 async fn seed_fixture_client(store: &SeaOrmOpStore) {
@@ -44,4 +50,117 @@ async fn seed_fixture_client(store: &SeaOrmOpStore) {
         .exec(store.connection())
         .await
         .expect("seeding the fixture client must succeed");
+}
+
+/// The composed unit of work (authkestra#336) against SeaORM: a host
+/// application's own entity write and an `OpStore` write in one transaction.
+///
+/// The point of running this on a second backend is that nothing in the
+/// shared trait had to bend to accommodate it — only the accessor that hands
+/// back the native handle differs (`&DatabaseTransaction` here,
+/// `&mut Connection` in `authkestra-store-sqlx`).
+#[tokio::test]
+async fn test_host_write_and_store_write_commit_as_one_unit() {
+    let store = SeaOrmOpStore::connect("sqlite::memory:")
+        .await
+        .expect("in-memory sqlite connection must succeed");
+    store.migrate().await.expect("migrating must succeed");
+    seed_fixture_client(&store).await;
+
+    // A table the host application owns; authkestra knows nothing about it.
+    store
+        .connection()
+        .execute_unprepared("CREATE TABLE app_users (id TEXT PRIMARY KEY, email TEXT NOT NULL)")
+        .await
+        .expect("creating the host application's own table must succeed");
+
+    let mut store = store;
+
+    // Rolled back as one unit.
+    let mut tx = store
+        .begin_tx()
+        .await
+        .expect("beginning a transaction must succeed");
+    tx.transaction()
+        .execute_unprepared("INSERT INTO app_users (id, email) VALUES ('u-rb', 'rb@example.com')")
+        .await
+        .expect("the host's own insert must succeed inside the transaction");
+    tx.store_token(refresh_token("seaorm-tx-rolled-back"))
+        .await
+        .expect("the store's write must succeed in the same transaction");
+    tx.rollback().await.expect("rolling back must succeed");
+
+    let rows = store
+        .connection()
+        .query_all(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            "SELECT id FROM app_users WHERE id = 'u-rb'",
+        ))
+        .await
+        .expect("querying host rows must succeed");
+    assert!(
+        rows.is_empty(),
+        "the host application's row must roll back with the store's"
+    );
+    assert!(
+        store
+            .get_token("seaorm-tx-rolled-back")
+            .await
+            .expect("reading must not error")
+            .is_none(),
+        "the store's row must roll back with the host application's"
+    );
+
+    // Committed as one unit.
+    let mut tx = store
+        .begin_tx()
+        .await
+        .expect("beginning a transaction must succeed");
+    tx.transaction()
+        .execute_unprepared("INSERT INTO app_users (id, email) VALUES ('u-ok', 'ok@example.com')")
+        .await
+        .expect("the host's own insert must succeed inside the transaction");
+    tx.store_token(refresh_token("seaorm-tx-committed"))
+        .await
+        .expect("the store's write must succeed in the same transaction");
+    tx.commit().await.expect("committing must succeed");
+
+    let rows = store
+        .connection()
+        .query_all(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            "SELECT id FROM app_users WHERE id = 'u-ok'",
+        ))
+        .await
+        .expect("querying host rows must succeed");
+    assert_eq!(
+        rows.len(),
+        1,
+        "the host application's row must be durable after the commit"
+    );
+    assert!(
+        store
+            .get_token("seaorm-tx-committed")
+            .await
+            .expect("reading must not error")
+            .is_some(),
+        "the store's row must be durable after the same commit"
+    );
+}
+
+fn refresh_token(token: &str) -> RefreshToken {
+    RefreshToken::new(
+        token.to_string(),
+        "client-1".to_string(),
+        Identity {
+            provider_id: "test".to_string(),
+            external_id: "user-1".to_string(),
+            email: None,
+            username: None,
+            attributes: std::collections::HashMap::new(),
+        },
+        "openid".to_string(),
+        Utc::now() + Duration::days(1),
+        None,
+    )
 }

--- a/crates/authkestra-op/src/store.rs
+++ b/crates/authkestra-op/src/store.rs
@@ -227,6 +227,69 @@ where
     }
 }
 
+/// An [`OpStore`] scoped to a single open database transaction.
+///
+/// Every `OpStore` method called on one of these runs inside that
+/// transaction, so nothing it writes is visible to anyone else — and
+/// nothing is durable — until [`commit`](OpStoreTransaction::commit).
+/// Dropping it without committing rolls the transaction back, which is what
+/// makes `?` in the middle of a composed unit of work safe.
+///
+/// This is what the `&mut self` receiver on the store traits is *for*: the
+/// transaction lives in the store value rather than being threaded through
+/// every method as an extra argument. That choice is what keeps the traits
+/// dyn-compatible — `authkestra-axum` and `authkestra-actix` hand route
+/// handlers an `Arc<Mutex<dyn OpStore>>`, which a generic executor
+/// parameter on each method would have made impossible to express.
+///
+/// Obtain one from [`TransactionalOpStore::begin`]. To interleave a host
+/// application's *own* statements in the same transaction, use the
+/// concrete store's inherent `begin_tx` instead, which returns the backend
+/// type rather than a trait object — see that type's docs (e.g.
+/// `authkestra_store_sqlx::SqlxOpStoreTx`) for the escape hatch that hands
+/// you the native connection.
+#[async_trait::async_trait]
+pub trait OpStoreTransaction: OpStore {
+    /// Commit the transaction, making every write durable at once.
+    ///
+    /// Takes `self: Box<Self>` rather than `self` so the trait stays
+    /// dyn-compatible: a by-value `self` on a `?Sized` receiver is not
+    /// expressible, and this trait is meant to be usable as
+    /// `Box<dyn OpStoreTransaction>`.
+    async fn commit(self: Box<Self>) -> Result<(), authkestra_engine::store::StoreError>;
+
+    /// Roll the transaction back, discarding every write.
+    ///
+    /// Dropping without committing does this too; the explicit form exists
+    /// so a caller can observe a rollback failure rather than have it
+    /// swallowed by `Drop`.
+    async fn rollback(self: Box<Self>) -> Result<(), authkestra_engine::store::StoreError>;
+}
+
+/// An [`OpStore`] whose backend can hand out transaction-scoped stores.
+///
+/// Deliberately a separate, opt-in trait rather than defaulted methods on
+/// `OpStore`: a backend with no transactions (the in-memory store, Redis)
+/// must not be able to accidentally claim this. There is no useful default
+/// — one that committed each write immediately and made `rollback` a no-op
+/// would hand callers a unit of work that silently isn't one, which is
+/// worse than not offering the capability at all.
+///
+/// See [`OpStoreTransaction`] for why the transaction lives in the store
+/// value instead of in the method signatures.
+#[async_trait::async_trait]
+pub trait TransactionalOpStore: OpStore {
+    /// Begin a transaction and return a store scoped to it.
+    ///
+    /// Takes `&self`, not `&mut self`: beginning a transaction borrows the
+    /// pool, not the store's own state, so a host application can start one
+    /// from behind an `Arc` while request handlers keep using the
+    /// non-transactional store.
+    async fn begin(
+        &self,
+    ) -> Result<Box<dyn OpStoreTransaction + Send>, authkestra_engine::store::StoreError>;
+}
+
 /// A helper struct that implements `OpStore` by delegating to individual stores.
 /// Useful if you want to use different backends for different types of data (e.g., config for clients, Redis for codes).
 ///

--- a/crates/authkestra-op/src/store.rs
+++ b/crates/authkestra-op/src/store.rs
@@ -238,9 +238,11 @@ where
 /// This is what the `&mut self` receiver on the store traits is *for*: the
 /// transaction lives in the store value rather than being threaded through
 /// every method as an extra argument. That choice is what keeps the traits
-/// dyn-compatible — `authkestra-axum` and `authkestra-actix` hand route
-/// handlers an `Arc<Mutex<dyn OpStore>>`, which a generic executor
-/// parameter on each method would have made impossible to express.
+/// dyn-compatible, which the adapters depend on — `authkestra-axum` and
+/// `authkestra-actix` hold an [`Arc<dyn CloneableOpStore>`](CloneableOpStore)
+/// and clone a `Box<dyn OpStore>` per request. Neither trait object can be
+/// named if `OpStore` stops being dyn-compatible, and a generic executor
+/// parameter on each method would do exactly that.
 ///
 /// Obtain one from [`TransactionalOpStore::begin`]. To interleave a host
 /// application's *own* statements in the same transaction, use the

--- a/crates/authkestra-store-sqlx/src/lib.rs
+++ b/crates/authkestra-store-sqlx/src/lib.rs
@@ -31,11 +31,97 @@ pub struct SqlxOpStore<DB: sqlx::Database> {
 // already cheaply cloneable (it's a handle around a shared connection pool)
 // regardless of whether the `Database` marker type itself implements
 // `Clone` — Postgres/MySql/Sqlite don't.
+impl<DB: sqlx::Database> SqlxOpStore<DB> {
+    /// Check a connection out of the pool for one query.
+    ///
+    /// Every `OpStore` method on the pool-backed store goes through here,
+    /// which is the only thing that distinguishes it from `SqlxOpStoreTx` —
+    /// that one already owns a connection with a transaction open on it.
+    async fn conn(
+        &self,
+    ) -> Result<sqlx::pool::PoolConnection<DB>, authkestra_engine::store::StoreError> {
+        self.pool.acquire().await.map_err(|e| {
+            tracing::error!(error = %e, "sqlx pool acquire error");
+            authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
+        })
+    }
+}
+
 impl<DB: sqlx::Database> Clone for SqlxOpStore<DB> {
     fn clone(&self) -> Self {
         Self {
             pool: self.pool.clone(),
         }
+    }
+}
+
+/// A [`SqlxOpStore`] scoped to one open `sqlx` transaction — every store
+/// method called on it runs inside that transaction, and nothing lands until
+/// [`commit`](Self::commit).
+///
+/// Obtain one from [`SqlxOpStore::begin_tx`]. Dropping it without committing
+/// rolls back, so an early `?` in the middle of a composed unit of work
+/// cannot leave a half-written state behind.
+///
+/// # Composing with the host application's own writes
+///
+/// This is the point of the type. [`as_mut`](AsMut::as_mut) hands back the
+/// live connection, so the application's own statements and the store's run
+/// in the same transaction and commit or roll back together:
+///
+/// ```ignore
+/// let mut tx = store.begin_tx().await?;
+///
+/// sqlx::query("INSERT INTO app_users (id, email) VALUES (?1, ?2)")
+///     .bind(&user_id)
+///     .bind(&email)
+///     .execute(tx.as_mut())
+///     .await?;
+///
+/// tx.store_token(refresh_token).await?;   // same transaction
+///
+/// tx.commit().await?;                     // both, or neither
+/// ```
+///
+/// Reaching the native connection is deliberately an inherent method rather
+/// than something on the [`OpStoreTransaction`](authkestra_op::store::OpStoreTransaction)
+/// trait: the host's own queries are written against a concrete driver, so
+/// there is nothing for a backend-agnostic trait to usefully return here.
+/// Keeping it off the trait is what lets the trait stay dyn-compatible.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct SqlxOpStoreTx<DB: sqlx::Database> {
+    tx: sqlx::Transaction<'static, DB>,
+}
+
+/// The live connection inside this transaction, for the host application's own
+/// statements — `tx.as_mut()`, exactly as it reads on a bare
+/// [`sqlx::Transaction`], so a caller's queries look the way they would
+/// anywhere else in their code.
+impl<DB: sqlx::Database> AsMut<DB::Connection> for SqlxOpStoreTx<DB> {
+    fn as_mut(&mut self) -> &mut DB::Connection {
+        &mut self.tx
+    }
+}
+
+impl<DB: sqlx::Database> SqlxOpStoreTx<DB> {
+    /// Commit, making every write in this transaction durable at once.
+    pub async fn commit(self) -> Result<(), authkestra_engine::store::StoreError> {
+        self.tx.commit().await.map_err(|e| {
+            tracing::error!(error = %e, "sqlx commit error");
+            authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
+        })
+    }
+
+    /// Roll back, discarding every write in this transaction.
+    ///
+    /// Dropping does this too; calling it explicitly is how a caller gets to
+    /// see a rollback failure rather than have `Drop` swallow it.
+    pub async fn rollback(self) -> Result<(), authkestra_engine::store::StoreError> {
+        self.tx.rollback().await.map_err(|e| {
+            tracing::error!(error = %e, "sqlx rollback error");
+            authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
+        })
     }
 }
 
@@ -187,14 +273,430 @@ macro_rules! impl_opstore_sql {
     (
         $backend:path,
         $feature:literal,
+        $queries:ident,
         $placeholder_fmt:expr,
         $schema_prefix:literal,
         $migrate_impl:item,
-        $consume_code_impl:item,
-        $consume_token_impl:item,
-        $consume_device_impl:item,
-        $dpop_jti_impl:item
+        $consume_code_fn:item,
+        $consume_token_fn:item,
+        $consume_device_fn:item,
+        $dpop_jti_fn:item
     ) => {
+        /// Every query this backend runs, written once against a plain
+        /// connection rather than against a pool, so the pool-backed store
+        /// and the transaction-scoped store below can share them verbatim
+        /// instead of keeping two copies of the same SQL in sync.
+        ///
+        /// Taking `&mut Conn` (not a generic `sqlx::Executor`) is what makes
+        /// the composed case correct: a `Connection` can `begin()`, and sqlx
+        /// turns a `begin()` on a connection that is already inside a
+        /// transaction into a SAVEPOINT. So the consume paths that need their
+        /// own transaction (MySQL's `SELECT ... FOR UPDATE`) get a real one
+        /// when called on the pool, and a nested savepoint — governed by the
+        /// caller's commit — when called inside a host transaction.
+        #[cfg(feature = $feature)]
+        pub(crate) mod $queries {
+            use super::*;
+            #[allow(unused_imports)]
+            use sqlx::Connection as _;
+
+            /// The raw connection type this backend's queries run against.
+            pub(crate) type Conn = <$backend as sqlx::Database>::Connection;
+
+            #[allow(deprecated)] // `require_pkce` (authkestra#273) — still round-tripped for wire/storage compatibility
+            pub(crate) async fn find_client(
+                conn: &mut Conn,
+                client_id: &str,
+            ) -> Result<Option<ClientRegistration>, authkestra_engine::store::StoreError> {
+            let query = format!(
+                "SELECT
+                    client_id,
+                    client_secret_hash,
+                    require_pkce,
+                    redirect_uris,
+                    grant_types,
+                    scopes,
+                    allowed_audiences,
+                    token_endpoint_auth_method,
+                    jwks
+                FROM {schema}oauth_clients
+                WHERE client_id = {p1}",
+                schema = $schema_prefix,
+                p1 = $placeholder_fmt(1)
+            );
+
+            let row = sqlx::query(&query)
+                .bind(client_id)
+                .fetch_optional(&mut *conn)
+                .await
+                .map_err(|e| {
+                    tracing::error!(error = %e, "sqlx find_client error");
+                    authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
+                })?;
+
+            if let Some(row) = row {
+                use sqlx::Row;
+                let client_id: String = row.try_get("client_id").unwrap_or_default();
+                let client_secret_hash: Option<String> = row.try_get("client_secret_hash").unwrap_or_default();
+                let require_pkce: bool = row.try_get("require_pkce").unwrap_or(true);
+
+                // SQLite might return these as Strings (from TEXT) while Postgres might return JsonValue (from JSONB)
+                // The safest way across all drivers is to deserialize from whatever String they provide, or handle types cleanly.
+                // For now, we'll assume we can get it as a string or fallback. We will use `try_get` as string.
+                // Since sqlx::types::Json is cross-platform, we can use that!
+
+                let redirect_uris: sqlx::types::Json<Vec<String>> = row.try_get("redirect_uris").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
+                let grant_types: sqlx::types::Json<Vec<authkestra_op::client::GrantType>> = row.try_get("grant_types").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
+                let scopes: sqlx::types::Json<Vec<String>> = row.try_get("scopes").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
+                let allowed_audiences: sqlx::types::Json<Vec<String>> = row.try_get("allowed_audiences").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
+                // Nullable: a client registered before authkestra#287's
+                // migration added these columns simply has no value in
+                // them yet, same as any other pre-existing row and a
+                // newly-added nullable column. That's a genuine SQL
+                // NULL, which `try_get::<Option<Json<T>>, _>` already
+                // reports as `Ok(None)` — distinct from a non-NULL value
+                // that fails to decode, which it reports as `Err`.
+                // Collapsing both cases with `.ok()` would silently turn
+                // an operator-written value this enum doesn't model
+                // (e.g. `client_secret_jwt`) into `None`, and
+                // `authenticate_client` treats `None` as "no auth method
+                // configured" — fail-open into an unauthenticated
+                // client. Propagate the decode error instead.
+                let token_endpoint_auth_method: Option<TokenEndpointAuthMethod> = row
+                    .try_get::<Option<sqlx::types::Json<TokenEndpointAuthMethod>>, _>("token_endpoint_auth_method")
+                    .map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?
+                    .map(|j| j.0);
+                let jwks: Option<serde_json::Value> = row
+                    .try_get::<Option<sqlx::types::Json<serde_json::Value>>, _>("jwks")
+                    .map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?
+                    .map(|j| j.0);
+
+                Ok(Some(ClientRegistration {
+                    client_id,
+                    client_secret_hash,
+                    require_pkce,
+                    redirect_uris: redirect_uris.0,
+                    grant_types: grant_types.0,
+                    scopes: scopes.0,
+                    allowed_audiences: allowed_audiences.0,
+                    token_endpoint_auth_method,
+                    jwks,
+                }))
+            } else {
+                Ok(None)
+            }
+            }
+
+            pub(crate) async fn store_code(
+                conn: &mut Conn,
+                code: AuthorizationCode,
+            ) -> Result<(), authkestra_engine::store::StoreError> {
+            let query = format!(
+                "INSERT INTO {schema}oauth_codes 
+                (code, client_id, redirect_uri, scope, code_challenge, code_challenge_method, nonce, identity, expires_at, used) 
+                VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7}, {p8}, {p9}, {p10})",
+                schema = $schema_prefix,
+                p1 = $placeholder_fmt(1), p2 = $placeholder_fmt(2), p3 = $placeholder_fmt(3),
+                p4 = $placeholder_fmt(4), p5 = $placeholder_fmt(5), p6 = $placeholder_fmt(6),
+                p7 = $placeholder_fmt(7), p8 = $placeholder_fmt(8), p9 = $placeholder_fmt(9),
+                p10 = $placeholder_fmt(10)
+            );
+
+            let identity_json = sqlx::types::Json(code.identity);
+
+            sqlx::query(&query)
+                .bind(code.code)
+                .bind(code.client_id)
+                .bind(code.redirect_uri)
+                .bind(code.scope)
+                .bind(code.code_challenge)
+                .bind(code.code_challenge_method)
+                .bind(code.nonce)
+                .bind(identity_json)
+                .bind(code.expires_at)
+                .bind(code.used)
+                .execute(&mut *conn)
+                .await
+                .map_err(|e| {
+                    tracing::error!(error = %e, "sqlx store_code error");
+                    authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
+                })?;
+            Ok(())
+            }
+
+            pub(crate) async fn store_token(
+                conn: &mut Conn,
+                token: RefreshToken,
+            ) -> Result<(), authkestra_engine::store::StoreError> {
+            let query = format!(
+                "INSERT INTO {schema}oauth_refresh_tokens
+                (token, client_id, identity, scope, expires_at, jkt)
+                VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6})",
+                schema = $schema_prefix,
+                p1 = $placeholder_fmt(1), p2 = $placeholder_fmt(2), p3 = $placeholder_fmt(3),
+                p4 = $placeholder_fmt(4), p5 = $placeholder_fmt(5), p6 = $placeholder_fmt(6)
+            );
+
+            let identity_json = sqlx::types::Json(token.identity);
+
+            sqlx::query(&query)
+                .bind(token.token)
+                .bind(token.client_id)
+                .bind(identity_json)
+                .bind(token.scope)
+                .bind(token.expires_at)
+                .bind(token.jkt)
+                .execute(&mut *conn)
+                .await
+                .map_err(|e| {
+                    tracing::error!(error = %e, "sqlx store_token error");
+                    authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
+                })?;
+            Ok(())
+            }
+
+            pub(crate) async fn get_token(
+                conn: &mut Conn,
+                token: &str,
+            ) -> Result<Option<RefreshToken>, authkestra_engine::store::StoreError> {
+            let query = format!(
+                "SELECT token, client_id, identity, scope, expires_at, jkt
+                FROM {schema}oauth_refresh_tokens
+                WHERE token = {p1} AND revoked_at IS NULL AND expires_at > {p2}",
+                schema = $schema_prefix,
+                p1 = $placeholder_fmt(1),
+                p2 = $placeholder_fmt(2)
+            );
+
+            let row = sqlx::query(&query)
+                .bind(token)
+                .bind(chrono::Utc::now())
+                .fetch_optional(&mut *conn)
+                .await
+                .map_err(|e| {
+                    tracing::error!(error = %e, "sqlx get_token error");
+                    authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
+                })?;
+
+            if let Some(row) = row {
+                use sqlx::Row;
+                let identity: sqlx::types::Json<authkestra_engine::auth::state::Identity> = row.try_get("identity").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
+
+                // NULL (a pre-authkestra#287 row, or a token never bound
+                // to a DPoP proof) is a legitimate `None`; a decode error
+                // on a non-NULL value is propagated rather than silently
+                // discarded, since that would undo the RFC 9449 §5
+                // continuity check this column exists to enforce.
+                Ok(Some(RefreshToken::new(
+                    row.try_get("token").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
+                    row.try_get("client_id").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
+                    identity.0,
+                    row.try_get("scope").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
+                    row.try_get("expires_at").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
+                    row.try_get("jkt").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
+                )))
+            } else {
+                Ok(None)
+            }
+            }
+
+            pub(crate) async fn revoke_token(
+                conn: &mut Conn,
+                token: &str,
+            ) -> Result<(), authkestra_engine::store::StoreError> {
+            let query = format!(
+                "UPDATE {schema}oauth_refresh_tokens SET revoked_at = {p1} WHERE token = {p2}",
+                schema = $schema_prefix,
+                p1 = $placeholder_fmt(1),
+                p2 = $placeholder_fmt(2)
+            );
+
+            sqlx::query(&query)
+                .bind(chrono::Utc::now())
+                .bind(token)
+                .execute(&mut *conn)
+                .await
+                .map_err(|e| {
+                    tracing::error!(error = %e, "sqlx revoke_token error");
+                    authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
+                })?;
+            Ok(())
+            }
+
+            pub(crate) async fn store_device_code(
+                conn: &mut Conn,
+                session: DeviceCodeSession,
+            ) -> Result<(), authkestra_engine::store::StoreError> {
+            let query = format!(
+                "INSERT INTO {schema}oauth_device_codes 
+                (device_code, user_code, client_id, scope, expires_at, status, last_polled_at) 
+                VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7})",
+                schema = $schema_prefix,
+                p1 = $placeholder_fmt(1), p2 = $placeholder_fmt(2), p3 = $placeholder_fmt(3),
+                p4 = $placeholder_fmt(4), p5 = $placeholder_fmt(5), p6 = $placeholder_fmt(6),
+                p7 = $placeholder_fmt(7)
+            );
+
+            let status_json = sqlx::types::Json(session.status);
+
+            sqlx::query(&query)
+                .bind(session.device_code)
+                .bind(session.user_code)
+                .bind(session.client_id)
+                .bind(session.scope)
+                .bind(session.expires_at)
+                .bind(status_json)
+                .bind(session.last_polled_at)
+                .execute(&mut *conn)
+                .await
+                .map_err(|e| {
+                    tracing::error!(error = %e, "sqlx store_device_code error");
+                    authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
+                })?;
+            Ok(())
+            }
+
+            pub(crate) async fn get_device_code(
+                conn: &mut Conn,
+                device_code: &str,
+            ) -> Result<Option<DeviceCodeSession>, authkestra_engine::store::StoreError> {
+            let query = format!(
+                "SELECT device_code, user_code, client_id, scope, expires_at, status, last_polled_at 
+                FROM {schema}oauth_device_codes 
+                WHERE device_code = {p1}",
+                schema = $schema_prefix,
+                p1 = $placeholder_fmt(1)
+            );
+
+            let row = sqlx::query(&query)
+                .bind(device_code)
+                .fetch_optional(&mut *conn)
+                .await
+                .map_err(|e| {
+                    tracing::error!(error = %e, "sqlx get_device_code error");
+                    authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
+                })?;
+
+            if let Some(row) = row {
+                use sqlx::Row;
+                let status: sqlx::types::Json<authkestra_op::device::DeviceCodeStatus> = row.try_get("status").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
+
+                Ok(Some({
+                    let mut session = DeviceCodeSession::new(
+                    row.try_get("device_code").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
+                    row.try_get("user_code").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
+                    row.try_get("client_id").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
+                    row.try_get("scope").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
+                    row.try_get("expires_at").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
+                    status.0,
+                );
+                    session.last_polled_at = row.try_get("last_polled_at").ok();
+                    session
+                }))
+            } else {
+                Ok(None)
+            }
+            }
+
+            pub(crate) async fn get_by_user_code(
+                conn: &mut Conn,
+                user_code: &str,
+            ) -> Result<Option<DeviceCodeSession>, authkestra_engine::store::StoreError> {
+            let query = format!(
+                "SELECT device_code, user_code, client_id, scope, expires_at, status, last_polled_at 
+                FROM {schema}oauth_device_codes 
+                WHERE user_code = {p1}",
+                schema = $schema_prefix,
+                p1 = $placeholder_fmt(1)
+            );
+
+            let row = sqlx::query(&query)
+                .bind(user_code)
+                .fetch_optional(&mut *conn)
+                .await
+                .map_err(|e| {
+                    tracing::error!(error = %e, "sqlx get_by_user_code error");
+                    authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
+                })?;
+
+            if let Some(row) = row {
+                use sqlx::Row;
+                let status: sqlx::types::Json<authkestra_op::device::DeviceCodeStatus> = row.try_get("status").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
+
+                Ok(Some({
+                    let mut session = DeviceCodeSession::new(
+                    row.try_get("device_code").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
+                    row.try_get("user_code").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
+                    row.try_get("client_id").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
+                    row.try_get("scope").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
+                    row.try_get("expires_at").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
+                    status.0,
+                );
+                    session.last_polled_at = row.try_get("last_polled_at").ok();
+                    session
+                }))
+            } else {
+                Ok(None)
+            }
+            }
+
+            pub(crate) async fn update_device_code(
+                conn: &mut Conn,
+                session: DeviceCodeSession,
+            ) -> Result<(), authkestra_engine::store::StoreError> {
+            let query = format!(
+                "UPDATE {schema}oauth_device_codes 
+                SET status = {p1}, last_polled_at = {p2} 
+                WHERE device_code = {p3}",
+                schema = $schema_prefix,
+                p1 = $placeholder_fmt(1), p2 = $placeholder_fmt(2), p3 = $placeholder_fmt(3)
+            );
+
+            let status_json = sqlx::types::Json(session.status);
+
+            sqlx::query(&query)
+                .bind(status_json)
+                .bind(session.last_polled_at)
+                .bind(session.device_code)
+                .execute(&mut *conn)
+                .await
+                .map_err(|e| {
+                    tracing::error!(error = %e, "sqlx update_device_code error");
+                    authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
+                })?;
+            Ok(())
+            }
+
+            pub(crate) async fn delete_device_code(
+                conn: &mut Conn,
+                device_code: &str,
+            ) -> Result<(), authkestra_engine::store::StoreError> {
+            let query = format!(
+                "DELETE FROM {schema}oauth_device_codes WHERE device_code = {p1}",
+                schema = $schema_prefix,
+                p1 = $placeholder_fmt(1)
+            );
+
+            sqlx::query(&query)
+                .bind(device_code)
+                .execute(&mut *conn)
+                .await
+                .map_err(|e| {
+                    tracing::error!(error = %e, "sqlx delete_device_code error");
+                    authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
+                })?;
+            Ok(())
+            }
+
+            $consume_code_fn
+
+            $consume_token_fn
+
+            $consume_device_fn
+
+            $dpop_jti_fn
+        }
+
         #[cfg(feature = $feature)]
         impl SqlxOpStore<$backend> {
             /// Create a new SqlxOpStore from a sqlx connection pool.
@@ -203,96 +705,63 @@ macro_rules! impl_opstore_sql {
             }
 
             $migrate_impl
+
+            /// Begin a transaction and return a store scoped to it.
+            ///
+            /// The concrete counterpart to
+            /// [`TransactionalOpStore::begin`](authkestra_op::store::TransactionalOpStore::begin):
+            /// it returns [`SqlxOpStoreTx`] rather than a trait object, which is
+            /// what a host application needs — `SqlxOpStoreTx`'s `AsMut` impl hands
+            /// back the live `sqlx` connection so the application's own
+            /// statements run in the same transaction as the store's.
+            pub async fn begin_tx(&self) -> Result<SqlxOpStoreTx<$backend>, authkestra_engine::store::StoreError> {
+                let tx = self.pool.begin().await.map_err(|e| {
+                    tracing::error!(error = %e, "sqlx begin transaction error");
+                    authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
+                })?;
+                Ok(SqlxOpStoreTx { tx })
+            }
+        }
+
+        #[cfg(feature = $feature)]
+        #[async_trait]
+        impl authkestra_op::store::TransactionalOpStore for SqlxOpStore<$backend> {
+            async fn begin(
+                &self,
+            ) -> Result<Box<dyn authkestra_op::store::OpStoreTransaction + Send>, authkestra_engine::store::StoreError> {
+                Ok(Box::new(self.begin_tx().await?))
+            }
+        }
+
+        #[cfg(feature = $feature)]
+        #[async_trait]
+        impl authkestra_op::store::OpStoreTransaction for SqlxOpStoreTx<$backend> {
+            async fn commit(self: Box<Self>) -> Result<(), authkestra_engine::store::StoreError> {
+                SqlxOpStoreTx::commit(*self).await
+            }
+
+            async fn rollback(self: Box<Self>) -> Result<(), authkestra_engine::store::StoreError> {
+                SqlxOpStoreTx::rollback(*self).await
+            }
         }
 
         #[cfg(feature = $feature)]
         #[async_trait]
         impl authkestra_op::store::OpStore for SqlxOpStore<$backend> {
-            $dpop_jti_impl
+            async fn check_and_record_dpop_jti(&mut self, jti: &str, expires_at: chrono::DateTime<chrono::Utc>) -> Result<bool, authkestra_engine::store::StoreError> {
+                let mut c = self.conn().await?;
+                let conn = &mut *c;
+                $queries::check_and_record_dpop_jti(conn, jti, expires_at).await
+            }
         }
 
         #[cfg(feature = $feature)]
         #[async_trait]
         impl ClientStore for SqlxOpStore<$backend> {
-            #[allow(deprecated)] // `require_pkce` (authkestra#273) — still round-tripped for wire/storage compatibility
             async fn find_client(&mut self, client_id: &str) -> Result<Option<ClientRegistration>, authkestra_engine::store::StoreError> {
-                let query = format!(
-                    "SELECT
-                        client_id,
-                        client_secret_hash,
-                        require_pkce,
-                        redirect_uris,
-                        grant_types,
-                        scopes,
-                        allowed_audiences,
-                        token_endpoint_auth_method,
-                        jwks
-                    FROM {schema}oauth_clients
-                    WHERE client_id = {p1}",
-                    schema = $schema_prefix,
-                    p1 = $placeholder_fmt(1)
-                );
-
-                let row = sqlx::query(&query)
-                    .bind(client_id)
-                    .fetch_optional(&self.pool)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!(error = %e, "sqlx find_client error");
-                        authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
-                    })?;
-
-                if let Some(row) = row {
-                    use sqlx::Row;
-                    let client_id: String = row.try_get("client_id").unwrap_or_default();
-                    let client_secret_hash: Option<String> = row.try_get("client_secret_hash").unwrap_or_default();
-                    let require_pkce: bool = row.try_get("require_pkce").unwrap_or(true);
-
-                    // SQLite might return these as Strings (from TEXT) while Postgres might return JsonValue (from JSONB)
-                    // The safest way across all drivers is to deserialize from whatever String they provide, or handle types cleanly.
-                    // For now, we'll assume we can get it as a string or fallback. We will use `try_get` as string.
-                    // Since sqlx::types::Json is cross-platform, we can use that!
-
-                    let redirect_uris: sqlx::types::Json<Vec<String>> = row.try_get("redirect_uris").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
-                    let grant_types: sqlx::types::Json<Vec<authkestra_op::client::GrantType>> = row.try_get("grant_types").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
-                    let scopes: sqlx::types::Json<Vec<String>> = row.try_get("scopes").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
-                    let allowed_audiences: sqlx::types::Json<Vec<String>> = row.try_get("allowed_audiences").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
-                    // Nullable: a client registered before authkestra#287's
-                    // migration added these columns simply has no value in
-                    // them yet, same as any other pre-existing row and a
-                    // newly-added nullable column. That's a genuine SQL
-                    // NULL, which `try_get::<Option<Json<T>>, _>` already
-                    // reports as `Ok(None)` — distinct from a non-NULL value
-                    // that fails to decode, which it reports as `Err`.
-                    // Collapsing both cases with `.ok()` would silently turn
-                    // an operator-written value this enum doesn't model
-                    // (e.g. `client_secret_jwt`) into `None`, and
-                    // `authenticate_client` treats `None` as "no auth method
-                    // configured" — fail-open into an unauthenticated
-                    // client. Propagate the decode error instead.
-                    let token_endpoint_auth_method: Option<TokenEndpointAuthMethod> = row
-                        .try_get::<Option<sqlx::types::Json<TokenEndpointAuthMethod>>, _>("token_endpoint_auth_method")
-                        .map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?
-                        .map(|j| j.0);
-                    let jwks: Option<serde_json::Value> = row
-                        .try_get::<Option<sqlx::types::Json<serde_json::Value>>, _>("jwks")
-                        .map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?
-                        .map(|j| j.0);
-
-                    Ok(Some(ClientRegistration {
-                        client_id,
-                        client_secret_hash,
-                        require_pkce,
-                        redirect_uris: redirect_uris.0,
-                        grant_types: grant_types.0,
-                        scopes: scopes.0,
-                        allowed_audiences: allowed_audiences.0,
-                        token_endpoint_auth_method,
-                        jwks,
-                    }))
-                } else {
-                    Ok(None)
-                }
+                let mut c = self.conn().await?;
+                let conn = &mut *c;
+                $queries::find_client(conn, client_id).await
             }
         }
 
@@ -300,293 +769,144 @@ macro_rules! impl_opstore_sql {
         #[async_trait]
         impl AuthorizationCodeStore for SqlxOpStore<$backend> {
             async fn store_code(&mut self, code: AuthorizationCode) -> Result<(), authkestra_engine::store::StoreError> {
-                let query = format!(
-                    "INSERT INTO {schema}oauth_codes 
-                    (code, client_id, redirect_uri, scope, code_challenge, code_challenge_method, nonce, identity, expires_at, used) 
-                    VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7}, {p8}, {p9}, {p10})",
-                    schema = $schema_prefix,
-                    p1 = $placeholder_fmt(1), p2 = $placeholder_fmt(2), p3 = $placeholder_fmt(3),
-                    p4 = $placeholder_fmt(4), p5 = $placeholder_fmt(5), p6 = $placeholder_fmt(6),
-                    p7 = $placeholder_fmt(7), p8 = $placeholder_fmt(8), p9 = $placeholder_fmt(9),
-                    p10 = $placeholder_fmt(10)
-                );
-
-                let identity_json = sqlx::types::Json(code.identity);
-
-                sqlx::query(&query)
-                    .bind(code.code)
-                    .bind(code.client_id)
-                    .bind(code.redirect_uri)
-                    .bind(code.scope)
-                    .bind(code.code_challenge)
-                    .bind(code.code_challenge_method)
-                    .bind(code.nonce)
-                    .bind(identity_json)
-                    .bind(code.expires_at)
-                    .bind(code.used)
-                    .execute(&self.pool)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!(error = %e, "sqlx store_code error");
-                        authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
-                    })?;
-                Ok(())
+                let mut c = self.conn().await?;
+                let conn = &mut *c;
+                $queries::store_code(conn, code).await
             }
-
-            $consume_code_impl
+            async fn consume_code(&mut self, code: &str) -> Result<Option<AuthorizationCode>, authkestra_engine::store::StoreError> {
+                let mut c = self.conn().await?;
+                let conn = &mut *c;
+                $queries::consume_code(conn, code).await
+            }
         }
 
         #[cfg(feature = $feature)]
         #[async_trait]
         impl RefreshTokenStore for SqlxOpStore<$backend> {
             async fn store_token(&mut self, token: RefreshToken) -> Result<(), authkestra_engine::store::StoreError> {
-                let query = format!(
-                    "INSERT INTO {schema}oauth_refresh_tokens
-                    (token, client_id, identity, scope, expires_at, jkt)
-                    VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6})",
-                    schema = $schema_prefix,
-                    p1 = $placeholder_fmt(1), p2 = $placeholder_fmt(2), p3 = $placeholder_fmt(3),
-                    p4 = $placeholder_fmt(4), p5 = $placeholder_fmt(5), p6 = $placeholder_fmt(6)
-                );
-
-                let identity_json = sqlx::types::Json(token.identity);
-
-                sqlx::query(&query)
-                    .bind(token.token)
-                    .bind(token.client_id)
-                    .bind(identity_json)
-                    .bind(token.scope)
-                    .bind(token.expires_at)
-                    .bind(token.jkt)
-                    .execute(&self.pool)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!(error = %e, "sqlx store_token error");
-                        authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
-                    })?;
-                Ok(())
+                let mut c = self.conn().await?;
+                let conn = &mut *c;
+                $queries::store_token(conn, token).await
             }
-
             async fn get_token(&mut self, token: &str) -> Result<Option<RefreshToken>, authkestra_engine::store::StoreError> {
-                let query = format!(
-                    "SELECT token, client_id, identity, scope, expires_at, jkt
-                    FROM {schema}oauth_refresh_tokens
-                    WHERE token = {p1} AND revoked_at IS NULL AND expires_at > {p2}",
-                    schema = $schema_prefix,
-                    p1 = $placeholder_fmt(1),
-                    p2 = $placeholder_fmt(2)
-                );
-
-                let row = sqlx::query(&query)
-                    .bind(token)
-                    .bind(chrono::Utc::now())
-                    .fetch_optional(&self.pool)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!(error = %e, "sqlx get_token error");
-                        authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
-                    })?;
-
-                if let Some(row) = row {
-                    use sqlx::Row;
-                    let identity: sqlx::types::Json<authkestra_engine::auth::state::Identity> = row.try_get("identity").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
-
-                    // NULL (a pre-authkestra#287 row, or a token never bound
-                    // to a DPoP proof) is a legitimate `None`; a decode error
-                    // on a non-NULL value is propagated rather than silently
-                    // discarded, since that would undo the RFC 9449 §5
-                    // continuity check this column exists to enforce.
-                    Ok(Some(RefreshToken::new(
-                        row.try_get("token").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
-                        row.try_get("client_id").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
-                        identity.0,
-                        row.try_get("scope").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
-                        row.try_get("expires_at").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
-                        row.try_get("jkt").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
-                    )))
-                } else {
-                    Ok(None)
-                }
+                let mut c = self.conn().await?;
+                let conn = &mut *c;
+                $queries::get_token(conn, token).await
             }
-
             async fn revoke_token(&mut self, token: &str) -> Result<(), authkestra_engine::store::StoreError> {
-                let query = format!(
-                    "UPDATE {schema}oauth_refresh_tokens SET revoked_at = {p1} WHERE token = {p2}",
-                    schema = $schema_prefix,
-                    p1 = $placeholder_fmt(1),
-                    p2 = $placeholder_fmt(2)
-                );
-
-                sqlx::query(&query)
-                    .bind(chrono::Utc::now())
-                    .bind(token)
-                    .execute(&self.pool)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!(error = %e, "sqlx revoke_token error");
-                        authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
-                    })?;
-                Ok(())
+                let mut c = self.conn().await?;
+                let conn = &mut *c;
+                $queries::revoke_token(conn, token).await
             }
-
-            $consume_token_impl
+            async fn consume_token(&mut self, token: &str) -> Result<Option<RefreshToken>, authkestra_engine::store::StoreError> {
+                let mut c = self.conn().await?;
+                let conn = &mut *c;
+                $queries::consume_token(conn, token).await
+            }
         }
 
         #[cfg(feature = $feature)]
         #[async_trait]
         impl DeviceCodeStore for SqlxOpStore<$backend> {
             async fn store_device_code(&mut self, session: DeviceCodeSession) -> Result<(), authkestra_engine::store::StoreError> {
-                let query = format!(
-                    "INSERT INTO {schema}oauth_device_codes 
-                    (device_code, user_code, client_id, scope, expires_at, status, last_polled_at) 
-                    VALUES ({p1}, {p2}, {p3}, {p4}, {p5}, {p6}, {p7})",
-                    schema = $schema_prefix,
-                    p1 = $placeholder_fmt(1), p2 = $placeholder_fmt(2), p3 = $placeholder_fmt(3),
-                    p4 = $placeholder_fmt(4), p5 = $placeholder_fmt(5), p6 = $placeholder_fmt(6),
-                    p7 = $placeholder_fmt(7)
-                );
-
-                let status_json = sqlx::types::Json(session.status);
-
-                sqlx::query(&query)
-                    .bind(session.device_code)
-                    .bind(session.user_code)
-                    .bind(session.client_id)
-                    .bind(session.scope)
-                    .bind(session.expires_at)
-                    .bind(status_json)
-                    .bind(session.last_polled_at)
-                    .execute(&self.pool)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!(error = %e, "sqlx store_device_code error");
-                        authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
-                    })?;
-                Ok(())
+                let mut c = self.conn().await?;
+                let conn = &mut *c;
+                $queries::store_device_code(conn, session).await
             }
-
             async fn get_device_code(&mut self, device_code: &str) -> Result<Option<DeviceCodeSession>, authkestra_engine::store::StoreError> {
-                let query = format!(
-                    "SELECT device_code, user_code, client_id, scope, expires_at, status, last_polled_at 
-                    FROM {schema}oauth_device_codes 
-                    WHERE device_code = {p1}",
-                    schema = $schema_prefix,
-                    p1 = $placeholder_fmt(1)
-                );
-
-                let row = sqlx::query(&query)
-                    .bind(device_code)
-                    .fetch_optional(&self.pool)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!(error = %e, "sqlx get_device_code error");
-                        authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
-                    })?;
-
-                if let Some(row) = row {
-                    use sqlx::Row;
-                    let status: sqlx::types::Json<authkestra_op::device::DeviceCodeStatus> = row.try_get("status").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
-
-                    Ok(Some({
-                        let mut session = DeviceCodeSession::new(
-                        row.try_get("device_code").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
-                        row.try_get("user_code").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
-                        row.try_get("client_id").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
-                        row.try_get("scope").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
-                        row.try_get("expires_at").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
-                        status.0,
-                    );
-                        session.last_polled_at = row.try_get("last_polled_at").ok();
-                        session
-                    }))
-                } else {
-                    Ok(None)
-                }
+                let mut c = self.conn().await?;
+                let conn = &mut *c;
+                $queries::get_device_code(conn, device_code).await
             }
-
             async fn get_by_user_code(&mut self, user_code: &str) -> Result<Option<DeviceCodeSession>, authkestra_engine::store::StoreError> {
-                let query = format!(
-                    "SELECT device_code, user_code, client_id, scope, expires_at, status, last_polled_at 
-                    FROM {schema}oauth_device_codes 
-                    WHERE user_code = {p1}",
-                    schema = $schema_prefix,
-                    p1 = $placeholder_fmt(1)
-                );
-
-                let row = sqlx::query(&query)
-                    .bind(user_code)
-                    .fetch_optional(&self.pool)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!(error = %e, "sqlx get_by_user_code error");
-                        authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
-                    })?;
-
-                if let Some(row) = row {
-                    use sqlx::Row;
-                    let status: sqlx::types::Json<authkestra_op::device::DeviceCodeStatus> = row.try_get("status").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
-
-                    Ok(Some({
-                        let mut session = DeviceCodeSession::new(
-                        row.try_get("device_code").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
-                        row.try_get("user_code").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
-                        row.try_get("client_id").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
-                        row.try_get("scope").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
-                        row.try_get("expires_at").map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?,
-                        status.0,
-                    );
-                        session.last_polled_at = row.try_get("last_polled_at").ok();
-                        session
-                    }))
-                } else {
-                    Ok(None)
-                }
+                let mut c = self.conn().await?;
+                let conn = &mut *c;
+                $queries::get_by_user_code(conn, user_code).await
             }
-
             async fn update_device_code(&mut self, session: DeviceCodeSession) -> Result<(), authkestra_engine::store::StoreError> {
-                let query = format!(
-                    "UPDATE {schema}oauth_device_codes 
-                    SET status = {p1}, last_polled_at = {p2} 
-                    WHERE device_code = {p3}",
-                    schema = $schema_prefix,
-                    p1 = $placeholder_fmt(1), p2 = $placeholder_fmt(2), p3 = $placeholder_fmt(3)
-                );
-
-                let status_json = sqlx::types::Json(session.status);
-
-                sqlx::query(&query)
-                    .bind(status_json)
-                    .bind(session.last_polled_at)
-                    .bind(session.device_code)
-                    .execute(&self.pool)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!(error = %e, "sqlx update_device_code error");
-                        authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
-                    })?;
-                Ok(())
+                let mut c = self.conn().await?;
+                let conn = &mut *c;
+                $queries::update_device_code(conn, session).await
             }
-
             async fn delete_device_code(&mut self, device_code: &str) -> Result<(), authkestra_engine::store::StoreError> {
-                let query = format!(
-                    "DELETE FROM {schema}oauth_device_codes WHERE device_code = {p1}",
-                    schema = $schema_prefix,
-                    p1 = $placeholder_fmt(1)
-                );
-
-                sqlx::query(&query)
-                    .bind(device_code)
-                    .execute(&self.pool)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!(error = %e, "sqlx delete_device_code error");
-                        authkestra_engine::store::StoreError::Internal(format!("db error: {e}"))
-                    })?;
-                Ok(())
+                let mut c = self.conn().await?;
+                let conn = &mut *c;
+                $queries::delete_device_code(conn, device_code).await
             }
-
-            $consume_device_impl
+            async fn consume_device_code(&mut self, device_code: &str) -> Result<Option<DeviceCodeSession>, authkestra_engine::store::StoreError> {
+                let mut c = self.conn().await?;
+                let conn = &mut *c;
+                $queries::consume_device_code(conn, device_code).await
+            }
         }
+
+        #[cfg(feature = $feature)]
+        #[async_trait]
+        impl authkestra_op::store::OpStore for SqlxOpStoreTx<$backend> {
+            async fn check_and_record_dpop_jti(&mut self, jti: &str, expires_at: chrono::DateTime<chrono::Utc>) -> Result<bool, authkestra_engine::store::StoreError> {
+                $queries::check_and_record_dpop_jti(&mut *self.tx, jti, expires_at).await
+            }
+        }
+
+        #[cfg(feature = $feature)]
+        #[async_trait]
+        impl ClientStore for SqlxOpStoreTx<$backend> {
+            async fn find_client(&mut self, client_id: &str) -> Result<Option<ClientRegistration>, authkestra_engine::store::StoreError> {
+                $queries::find_client(&mut *self.tx, client_id).await
+            }
+        }
+
+        #[cfg(feature = $feature)]
+        #[async_trait]
+        impl AuthorizationCodeStore for SqlxOpStoreTx<$backend> {
+            async fn store_code(&mut self, code: AuthorizationCode) -> Result<(), authkestra_engine::store::StoreError> {
+                $queries::store_code(&mut *self.tx, code).await
+            }
+            async fn consume_code(&mut self, code: &str) -> Result<Option<AuthorizationCode>, authkestra_engine::store::StoreError> {
+                $queries::consume_code(&mut *self.tx, code).await
+            }
+        }
+
+        #[cfg(feature = $feature)]
+        #[async_trait]
+        impl RefreshTokenStore for SqlxOpStoreTx<$backend> {
+            async fn store_token(&mut self, token: RefreshToken) -> Result<(), authkestra_engine::store::StoreError> {
+                $queries::store_token(&mut *self.tx, token).await
+            }
+            async fn get_token(&mut self, token: &str) -> Result<Option<RefreshToken>, authkestra_engine::store::StoreError> {
+                $queries::get_token(&mut *self.tx, token).await
+            }
+            async fn revoke_token(&mut self, token: &str) -> Result<(), authkestra_engine::store::StoreError> {
+                $queries::revoke_token(&mut *self.tx, token).await
+            }
+            async fn consume_token(&mut self, token: &str) -> Result<Option<RefreshToken>, authkestra_engine::store::StoreError> {
+                $queries::consume_token(&mut *self.tx, token).await
+            }
+        }
+
+        #[cfg(feature = $feature)]
+        #[async_trait]
+        impl DeviceCodeStore for SqlxOpStoreTx<$backend> {
+            async fn store_device_code(&mut self, session: DeviceCodeSession) -> Result<(), authkestra_engine::store::StoreError> {
+                $queries::store_device_code(&mut *self.tx, session).await
+            }
+            async fn get_device_code(&mut self, device_code: &str) -> Result<Option<DeviceCodeSession>, authkestra_engine::store::StoreError> {
+                $queries::get_device_code(&mut *self.tx, device_code).await
+            }
+            async fn get_by_user_code(&mut self, user_code: &str) -> Result<Option<DeviceCodeSession>, authkestra_engine::store::StoreError> {
+                $queries::get_by_user_code(&mut *self.tx, user_code).await
+            }
+            async fn update_device_code(&mut self, session: DeviceCodeSession) -> Result<(), authkestra_engine::store::StoreError> {
+                $queries::update_device_code(&mut *self.tx, session).await
+            }
+            async fn delete_device_code(&mut self, device_code: &str) -> Result<(), authkestra_engine::store::StoreError> {
+                $queries::delete_device_code(&mut *self.tx, device_code).await
+            }
+            async fn consume_device_code(&mut self, device_code: &str) -> Result<Option<DeviceCodeSession>, authkestra_engine::store::StoreError> {
+                $queries::consume_device_code(&mut *self.tx, device_code).await
+            }
+        }
+
     };
 }
 
@@ -594,6 +914,7 @@ macro_rules! impl_opstore_sql {
 impl_opstore_sql! {
     sqlx::Postgres,
     "postgres",
+    pg_queries,
     |i| format!("${}", i),
     "authkestra.",
     /// Run necessary database migrations to set up schema and tables.
@@ -685,11 +1006,11 @@ impl_opstore_sql! {
         Ok(())
     },
     // consume_code (Postgres specific)
-    async fn consume_code(&mut self, code: &str) -> Result<Option<AuthorizationCode>, authkestra_engine::store::StoreError> {
+    pub(crate) async fn consume_code(conn: &mut Conn, code: &str) -> Result<Option<AuthorizationCode>, authkestra_engine::store::StoreError> {
         let query = "UPDATE authkestra.oauth_codes SET used = TRUE WHERE code = $1 AND used = FALSE RETURNING *";
         let row = sqlx::query(query)
             .bind(code)
-            .fetch_optional(&self.pool)
+            .fetch_optional(&mut *conn)
             .await
             .map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
 
@@ -716,11 +1037,11 @@ impl_opstore_sql! {
         }
     },
     // consume_token (Postgres specific)
-    async fn consume_token(&mut self, token: &str) -> Result<Option<RefreshToken>, authkestra_engine::store::StoreError> {
+    pub(crate) async fn consume_token(conn: &mut Conn, token: &str) -> Result<Option<RefreshToken>, authkestra_engine::store::StoreError> {
         let query = "DELETE FROM authkestra.oauth_refresh_tokens WHERE token = $1 AND revoked_at IS NULL RETURNING *";
         let row = sqlx::query(query)
             .bind(token)
-            .fetch_optional(&self.pool)
+            .fetch_optional(&mut *conn)
             .await
             .map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
 
@@ -740,11 +1061,11 @@ impl_opstore_sql! {
         }
     },
     // consume_device_impl (Postgres specific)
-    async fn consume_device_code(&mut self, device_code: &str) -> Result<Option<DeviceCodeSession>, authkestra_engine::store::StoreError> {
+    pub(crate) async fn consume_device_code(conn: &mut Conn, device_code: &str) -> Result<Option<DeviceCodeSession>, authkestra_engine::store::StoreError> {
         let query = "DELETE FROM authkestra.oauth_device_codes WHERE device_code = $1 RETURNING *";
         let row = sqlx::query(query)
             .bind(device_code)
-            .fetch_optional(&self.pool)
+            .fetch_optional(&mut *conn)
             .await
             .map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
 
@@ -783,8 +1104,8 @@ impl_opstore_sql! {
     /// An already-expired row is *reclaimable*: a `jti` past its window can
     /// no longer be usefully replayed, because `verify_dpop_proof` fails it
     /// on freshness first.
-    async fn check_and_record_dpop_jti(
-        &mut self,
+    pub(crate) async fn check_and_record_dpop_jti(
+        conn: &mut Conn,
         jti: &str,
         expires_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<bool, authkestra_engine::store::StoreError> {
@@ -799,7 +1120,7 @@ impl_opstore_sql! {
         .bind(jti)
         .bind(expires_at)
         .bind(chrono::Utc::now())
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await
         .map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
 
@@ -811,6 +1132,7 @@ impl_opstore_sql! {
 impl_opstore_sql! {
     sqlx::Sqlite,
     "sqlite",
+    sqlite_queries,
     |_| "?".to_string(),
     "authkestra_",
     /// Run necessary database migrations to set up schema and tables.
@@ -885,11 +1207,11 @@ impl_opstore_sql! {
         Ok(())
     },
     // consume_code (SQLite specific)
-    async fn consume_code(&mut self, code: &str) -> Result<Option<AuthorizationCode>, authkestra_engine::store::StoreError> {
+    pub(crate) async fn consume_code(conn: &mut Conn, code: &str) -> Result<Option<AuthorizationCode>, authkestra_engine::store::StoreError> {
         let query = "UPDATE authkestra_oauth_codes SET used = TRUE WHERE code = ? AND used = FALSE RETURNING *";
         let row = sqlx::query(query)
             .bind(code)
-            .fetch_optional(&self.pool)
+            .fetch_optional(&mut *conn)
             .await
             .map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
 
@@ -916,11 +1238,11 @@ impl_opstore_sql! {
         }
     },
     // consume_token (SQLite specific)
-    async fn consume_token(&mut self, token: &str) -> Result<Option<RefreshToken>, authkestra_engine::store::StoreError> {
+    pub(crate) async fn consume_token(conn: &mut Conn, token: &str) -> Result<Option<RefreshToken>, authkestra_engine::store::StoreError> {
         let query = "DELETE FROM authkestra_oauth_refresh_tokens WHERE token = ? AND revoked_at IS NULL RETURNING *";
         let row = sqlx::query(query)
             .bind(token)
-            .fetch_optional(&self.pool)
+            .fetch_optional(&mut *conn)
             .await
             .map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
 
@@ -940,11 +1262,11 @@ impl_opstore_sql! {
         }
     },
     // consume_device_impl (SQLite specific)
-    async fn consume_device_code(&mut self, device_code: &str) -> Result<Option<DeviceCodeSession>, authkestra_engine::store::StoreError> {
+    pub(crate) async fn consume_device_code(conn: &mut Conn, device_code: &str) -> Result<Option<DeviceCodeSession>, authkestra_engine::store::StoreError> {
         let query = "DELETE FROM authkestra_oauth_device_codes WHERE device_code = ? RETURNING *";
         let row = sqlx::query(query)
             .bind(device_code)
-            .fetch_optional(&self.pool)
+            .fetch_optional(&mut *conn)
             .await
             .map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
 
@@ -983,8 +1305,8 @@ impl_opstore_sql! {
     /// An already-expired row is *reclaimable*: a `jti` past its window can
     /// no longer be usefully replayed, because `verify_dpop_proof` fails it
     /// on freshness first.
-    async fn check_and_record_dpop_jti(
-        &mut self,
+    pub(crate) async fn check_and_record_dpop_jti(
+        conn: &mut Conn,
         jti: &str,
         expires_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<bool, authkestra_engine::store::StoreError> {
@@ -998,7 +1320,7 @@ impl_opstore_sql! {
         .bind(jti)
         .bind(expires_at)
         .bind(chrono::Utc::now())
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await
         .map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
 
@@ -1010,6 +1332,7 @@ impl_opstore_sql! {
 impl_opstore_sql! {
     sqlx::MySql,
     "mysql",
+    mysql_queries,
     |_| "?".to_string(),
     "authkestra_",
     /// Run necessary database migrations to set up schema and tables.
@@ -1092,8 +1415,8 @@ impl_opstore_sql! {
         Ok(())
     },
     // consume_code (MySQL specific - needs transaction and FOR UPDATE since no RETURNING)
-    async fn consume_code(&mut self, code: &str) -> Result<Option<AuthorizationCode>, authkestra_engine::store::StoreError> {
-        let mut tx = self.pool.begin().await.map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
+    pub(crate) async fn consume_code(conn: &mut Conn, code: &str) -> Result<Option<AuthorizationCode>, authkestra_engine::store::StoreError> {
+        let mut tx = conn.begin().await.map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
 
         let select_query = "SELECT * FROM authkestra_oauth_codes WHERE code = ? AND used = FALSE FOR UPDATE";
         let row = sqlx::query(select_query)
@@ -1135,8 +1458,8 @@ impl_opstore_sql! {
         }
     },
     // consume_token (MySQL specific)
-    async fn consume_token(&mut self, token: &str) -> Result<Option<RefreshToken>, authkestra_engine::store::StoreError> {
-        let mut tx = self.pool.begin().await.map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
+    pub(crate) async fn consume_token(conn: &mut Conn, token: &str) -> Result<Option<RefreshToken>, authkestra_engine::store::StoreError> {
+        let mut tx = conn.begin().await.map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
 
         let select_query = "SELECT * FROM authkestra_oauth_refresh_tokens WHERE token = ? AND revoked_at IS NULL FOR UPDATE";
         let row = sqlx::query(select_query)
@@ -1171,8 +1494,8 @@ impl_opstore_sql! {
         }
     },
     // consume_device_impl (MySQL specific)
-    async fn consume_device_code(&mut self, device_code: &str) -> Result<Option<DeviceCodeSession>, authkestra_engine::store::StoreError> {
-        let mut tx = self.pool.begin().await.map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
+    pub(crate) async fn consume_device_code(conn: &mut Conn, device_code: &str) -> Result<Option<DeviceCodeSession>, authkestra_engine::store::StoreError> {
+        let mut tx = conn.begin().await.map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
 
         let select_query = "SELECT * FROM authkestra_oauth_device_codes WHERE device_code = ? FOR UPDATE";
         let row = sqlx::query(select_query)
@@ -1233,8 +1556,8 @@ impl_opstore_sql! {
     /// same `jti` then deadlock under MySQL's default REPEATABLE READ
     /// (authkestra#277 hit exactly this). Each statement below is
     /// individually atomic, so no transaction is needed.
-    async fn check_and_record_dpop_jti(
-        &mut self,
+    pub(crate) async fn check_and_record_dpop_jti(
+        conn: &mut Conn,
         jti: &str,
         expires_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<bool, authkestra_engine::store::StoreError> {
@@ -1243,7 +1566,7 @@ impl_opstore_sql! {
         )
         .bind(jti)
         .bind(expires_at)
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await
         .map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
 
@@ -1263,7 +1586,7 @@ impl_opstore_sql! {
         .bind(expires_at)
         .bind(jti)
         .bind(chrono::Utc::now())
-        .execute(&self.pool)
+        .execute(&mut *conn)
         .await
         .map_err(|e| authkestra_engine::store::StoreError::Internal(format!("db error: {e}")))?;
 
@@ -2410,6 +2733,62 @@ mod mysql_tests {
         .unwrap();
 
         assert_eq!(count.0, 0);
+    }
+
+    /// MySQL is the one backend whose `consume_code` opens a transaction of
+    /// its own (no `UPDATE ... RETURNING`, so it needs
+    /// `SELECT ... FOR UPDATE`). Called inside a caller's transaction that
+    /// has to degrade to a nested savepoint governed by the outer rollback —
+    /// otherwise the consume commits independently and the caller's unit of
+    /// work silently isn't one. authkestra#336.
+    #[tokio::test]
+    async fn test_mysql_consume_inside_a_caller_transaction_rolls_back_with_it() {
+        let (mut store, _c) = setup_db().await;
+
+        sqlx::query(
+            "INSERT INTO authkestra_oauth_clients (client_id, client_secret_hash, require_pkce, redirect_uris, grant_types, scopes, allowed_audiences)
+             VALUES (?, ?, ?, ?, ?, ?, ?)"
+        )
+        .bind("tx_client")
+        .bind("hash")
+        .bind(true)
+        .bind(sqlx::types::Json(vec!["http://localhost/cb"]))
+        .bind(sqlx::types::Json(vec!["authorization_code"]))
+        .bind(sqlx::types::Json(vec!["openid"]))
+        .bind(sqlx::types::Json(vec!["aud"]))
+        .execute(&store.pool)
+        .await
+        .unwrap();
+
+        let code = AuthorizationCode::new(
+            "tx_code_1".to_string(),
+            "tx_client".to_string(),
+            "http://localhost/cb".to_string(),
+            "openid".to_string(),
+            authkestra_engine::auth::state::Identity {
+                provider_id: "local".to_string(),
+                external_id: "user_1".to_string(),
+                email: None,
+                username: None,
+                attributes: std::collections::HashMap::new(),
+            },
+            Utc::now() + Duration::try_minutes(10).unwrap(),
+            false,
+        );
+
+        let mut tx = store.begin_tx().await.unwrap();
+        tx.store_code(code.clone()).await.unwrap();
+        let consumed = tx.consume_code(&code.code).await.unwrap();
+        assert!(
+            consumed.is_some(),
+            "the FOR UPDATE consume must work inside a caller's transaction, as a savepoint"
+        );
+        tx.rollback().await.unwrap();
+
+        assert!(
+            store.consume_code(&code.code).await.unwrap().is_none(),
+            "store-then-consume rolled back as a unit must leave nothing behind"
+        );
     }
 
     #[tokio::test]

--- a/crates/authkestra-store-testsuite/src/lib.rs
+++ b/crates/authkestra-store-testsuite/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod atomic;
 pub mod kv;
 pub mod op;
+pub mod tx;

--- a/crates/authkestra-store-testsuite/src/tx.rs
+++ b/crates/authkestra-store-testsuite/src/tx.rs
@@ -1,0 +1,194 @@
+//! Conformance suite for [`TransactionalOpStore`] — proves a backend's
+//! transaction-scoped store is a real unit of work, not a store that
+//! commits as it goes and calls `rollback` a no-op.
+//!
+//! Only backends that opt into [`TransactionalOpStore`] run this. A store
+//! with no transactions (the in-memory store, Redis) must not implement the
+//! trait at all rather than implement it weakly, which is exactly what these
+//! assertions are here to catch.
+
+use authkestra_engine::auth::state::Identity;
+use authkestra_engine::chrono::{Duration, Utc};
+use authkestra_op::code::AuthorizationCode;
+use authkestra_op::refresh::RefreshToken;
+// `store_token`/`consume_code`/... arrive through the `OpStore` supertrait that
+// `TransactionalOpStore` and `OpStoreTransaction` both require, so the individual
+// store traits need no separate import here.
+use authkestra_op::store::TransactionalOpStore;
+use std::collections::HashMap;
+
+fn test_identity() -> Identity {
+    Identity {
+        provider_id: "test".to_string(),
+        external_id: "user-1".to_string(),
+        email: None,
+        username: None,
+        attributes: HashMap::new(),
+    }
+}
+
+fn token(name: &str) -> RefreshToken {
+    RefreshToken::new(
+        name.to_string(),
+        "client-1".to_string(),
+        test_identity(),
+        "openid".to_string(),
+        Utc::now() + Duration::days(1),
+        None,
+    )
+}
+
+/// Generic conformance suite for [`TransactionalOpStore`].
+///
+/// Like [`crate::op::run_op_store_tests`], this expects a client with
+/// `client_id: "client-1"` to already exist — `ClientStore` has no generic
+/// write method, so a backend with a foreign key from tokens to clients
+/// needs it seeded out of band first.
+///
+/// What this deliberately does **not** assert: that an uncommitted write is
+/// invisible to a *different* connection. That is the other half of what a
+/// transaction means, but checking it requires holding the transaction open
+/// while reading through the pool — and a backend under test may legitimately
+/// be running on a single-connection pool (in-memory SQLite is, necessarily),
+/// where that deadlocks rather than fails. Every assertion below therefore
+/// finishes with the transaction before touching the store again.
+pub async fn run_transactional_op_store_tests<S: TransactionalOpStore>(store: &mut S) {
+    rollback_discards_writes(store).await;
+    commit_persists_writes(store).await;
+    drop_without_commit_rolls_back(store).await;
+    reads_its_own_uncommitted_writes(store).await;
+    rollback_undoes_a_consume(store).await;
+}
+
+async fn rollback_discards_writes<S: TransactionalOpStore>(store: &mut S) {
+    let t = token("tx-rolled-back");
+
+    let mut tx = store
+        .begin()
+        .await
+        .expect("beginning a transaction must succeed");
+    tx.store_token(t.clone())
+        .await
+        .expect("storing inside a transaction must succeed");
+    tx.rollback().await.expect("rolling back must succeed");
+
+    assert!(
+        store
+            .get_token(&t.token)
+            .await
+            .expect("reading after a rollback must not error")
+            .is_none(),
+        "a write made inside a rolled-back transaction must not be durable — if this fails, \
+         the store is committing as it goes and `rollback` is not undoing anything"
+    );
+}
+
+async fn commit_persists_writes<S: TransactionalOpStore>(store: &mut S) {
+    let t = token("tx-committed");
+
+    let mut tx = store
+        .begin()
+        .await
+        .expect("beginning a transaction must succeed");
+    tx.store_token(t.clone())
+        .await
+        .expect("storing inside a transaction must succeed");
+    tx.commit().await.expect("committing must succeed");
+
+    let found = store
+        .get_token(&t.token)
+        .await
+        .expect("reading after a commit must not error")
+        .expect("a committed write must be durable");
+    assert_eq!(found.token, t.token);
+    assert_eq!(found.client_id, t.client_id);
+}
+
+async fn drop_without_commit_rolls_back<S: TransactionalOpStore>(store: &mut S) {
+    let t = token("tx-dropped");
+
+    {
+        let mut tx = store
+            .begin()
+            .await
+            .expect("beginning a transaction must succeed");
+        tx.store_token(t.clone())
+            .await
+            .expect("storing inside a transaction must succeed");
+        // Dropped without committing — the case an early `?` in a host
+        // application's composed unit of work hits.
+    }
+
+    assert!(
+        store
+            .get_token(&t.token)
+            .await
+            .expect("reading after a dropped transaction must not error")
+            .is_none(),
+        "dropping a transaction without committing must roll it back, or every `?` in a \
+         caller's unit of work leaves a partial write behind"
+    );
+}
+
+async fn reads_its_own_uncommitted_writes<S: TransactionalOpStore>(store: &mut S) {
+    let t = token("tx-read-your-writes");
+
+    let mut tx = store
+        .begin()
+        .await
+        .expect("beginning a transaction must succeed");
+    tx.store_token(t.clone())
+        .await
+        .expect("storing inside a transaction must succeed");
+
+    let found = tx
+        .get_token(&t.token)
+        .await
+        .expect("reading inside the same transaction must not error")
+        .expect("a transaction must see its own uncommitted writes");
+    assert_eq!(found.token, t.token);
+
+    tx.rollback().await.expect("rolling back must succeed");
+}
+
+/// The single-use consume paths are the ones most likely to break when
+/// composed: a backend without `DELETE ... RETURNING` (MySQL) implements
+/// them by opening its *own* transaction. Called inside a caller's
+/// transaction that has to become a nested savepoint, governed by the outer
+/// rollback — not an independent transaction that commits on its own.
+async fn rollback_undoes_a_consume<S: TransactionalOpStore>(store: &mut S) {
+    let code = AuthorizationCode::new(
+        "tx-consume-rolled-back".to_string(),
+        "client-1".to_string(),
+        "https://cb.example.com".to_string(),
+        "openid".to_string(),
+        test_identity(),
+        Utc::now() + Duration::minutes(5),
+        false,
+    );
+
+    let mut tx = store
+        .begin()
+        .await
+        .expect("beginning a transaction must succeed");
+    tx.store_code(code.clone())
+        .await
+        .expect("storing a code inside a transaction must succeed");
+    let consumed = tx
+        .consume_code(&code.code)
+        .await
+        .expect("consuming inside a transaction must not error")
+        .expect("consuming a code stored in the same transaction must return it");
+    assert_eq!(consumed.code, code.code);
+    tx.rollback().await.expect("rolling back must succeed");
+
+    assert!(
+        store
+            .consume_code(&code.code)
+            .await
+            .expect("reading after a rollback must not error")
+            .is_none(),
+        "a store-and-consume rolled back as a unit must leave nothing behind — if this fails, \
+         the consume path opened its own transaction and committed independently of the caller's"
+    );
+}

--- a/crates/authkestra-store-testsuite/tests/sqlx_store.rs
+++ b/crates/authkestra-store-testsuite/tests/sqlx_store.rs
@@ -1,5 +1,9 @@
+use authkestra_engine::auth::state::Identity;
+use authkestra_engine::chrono::{Duration, Utc};
+use authkestra_op::refresh::{RefreshToken, RefreshTokenStore};
 use authkestra_store_sqlx::SqlxOpStore;
 use authkestra_store_testsuite::op::run_op_store_tests;
+use authkestra_store_testsuite::tx::run_transactional_op_store_tests;
 use sqlx::sqlite::SqlitePoolOptions;
 
 /// Runs the shared `OpStore` conformance suite against `SqlxOpStore` — the
@@ -32,6 +36,122 @@ async fn test_sqlx_op_store_sqlite() {
     // `client_id: "client-1"` — `ClientStore` has no generic write method (by
     // design), so a store with a foreign key from codes/tokens to clients
     // (like this one) needs it seeded directly before the suite can run.
+    seed_fixture_client(&pool).await;
+
+    run_op_store_tests(&mut store).await;
+    run_transactional_op_store_tests(&mut store).await;
+}
+
+/// The composition this whole capability exists for (authkestra#336): a host
+/// application's own write and an `OpStore` write, in one transaction, that
+/// commit or roll back together.
+///
+/// Backend-specific by nature — the application's statement is written
+/// against `sqlx`, not against any trait — which is exactly why reaching the
+/// native connection is an inherent method on `SqlxOpStoreTx` rather than
+/// something the dyn-compatible `OpStoreTransaction` trait tries to express.
+#[tokio::test]
+async fn test_host_write_and_store_write_commit_as_one_unit() {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("in-memory sqlite pool must connect");
+
+    let mut store = SqlxOpStore::<sqlx::Sqlite>::new(pool.clone());
+    store.migrate().await.expect("migrating must succeed");
+    seed_fixture_client(&pool).await;
+
+    // A table the *host application* owns — authkestra knows nothing about it.
+    sqlx::query("CREATE TABLE app_users (id TEXT PRIMARY KEY, email TEXT NOT NULL)")
+        .execute(&pool)
+        .await
+        .expect("creating the host application's own table must succeed");
+
+    // 1. The failing case: host row + store row, rolled back together.
+    let mut tx = store
+        .begin_tx()
+        .await
+        .expect("beginning a transaction must succeed");
+    sqlx::query("INSERT INTO app_users (id, email) VALUES (?1, ?2)")
+        .bind("user-rolled-back")
+        .bind("rolled-back@example.com")
+        .execute(tx.as_mut())
+        .await
+        .expect("the host's own insert must succeed inside the transaction");
+    tx.store_token(refresh_token("host-tx-rolled-back"))
+        .await
+        .expect("the store's write must succeed in the same transaction");
+    tx.rollback().await.expect("rolling back must succeed");
+
+    let host_rows: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM app_users WHERE id = 'user-rolled-back'")
+            .fetch_one(&pool)
+            .await
+            .expect("counting host rows must succeed");
+    assert_eq!(
+        host_rows, 0,
+        "the host application's row must roll back with the store's"
+    );
+    assert!(
+        store
+            .get_token("host-tx-rolled-back")
+            .await
+            .expect("reading must not error")
+            .is_none(),
+        "the store's row must roll back with the host application's"
+    );
+
+    // 2. The succeeding case: both durable after one commit.
+    let mut tx = store
+        .begin_tx()
+        .await
+        .expect("beginning a transaction must succeed");
+    sqlx::query("INSERT INTO app_users (id, email) VALUES (?1, ?2)")
+        .bind("user-committed")
+        .bind("committed@example.com")
+        .execute(tx.as_mut())
+        .await
+        .expect("the host's own insert must succeed inside the transaction");
+    tx.store_token(refresh_token("host-tx-committed"))
+        .await
+        .expect("the store's write must succeed in the same transaction");
+    tx.commit().await.expect("committing must succeed");
+
+    let email: String =
+        sqlx::query_scalar("SELECT email FROM app_users WHERE id = 'user-committed'")
+            .fetch_one(&pool)
+            .await
+            .expect("the host application's row must be durable after the commit");
+    assert_eq!(email, "committed@example.com");
+    assert!(
+        store
+            .get_token("host-tx-committed")
+            .await
+            .expect("reading must not error")
+            .is_some(),
+        "the store's row must be durable after the same commit"
+    );
+}
+
+fn refresh_token(token: &str) -> RefreshToken {
+    RefreshToken::new(
+        token.to_string(),
+        "client-1".to_string(),
+        Identity {
+            provider_id: "test".to_string(),
+            external_id: "user-1".to_string(),
+            email: None,
+            username: None,
+            attributes: std::collections::HashMap::new(),
+        },
+        "openid".to_string(),
+        Utc::now() + Duration::days(1),
+        None,
+    )
+}
+
+async fn seed_fixture_client(pool: &sqlx::SqlitePool) {
     sqlx::query(
         "INSERT INTO authkestra_oauth_clients \
          (client_id, client_secret_hash, require_pkce, redirect_uris, grant_types, scopes, allowed_audiences) \
@@ -44,9 +164,7 @@ async fn test_sqlx_op_store_sqlite() {
     .bind(sqlx::types::Json(vec!["authorization_code"]))
     .bind(sqlx::types::Json(vec!["openid", "offline_access"]))
     .bind(sqlx::types::Json(Vec::<String>::new()))
-    .execute(&pool)
+    .execute(pool)
     .await
     .expect("seeding the fixture client must succeed");
-
-    run_op_store_tests(&mut store).await;
 }

--- a/docs/rfc-005-executor-composable-stores.md
+++ b/docs/rfc-005-executor-composable-stores.md
@@ -24,12 +24,13 @@ The obvious design — an executor parameter on each method —
 async fn store_token<E: Executor>(&mut self, ex: &mut E, token: RefreshToken) -> ...;
 ```
 
-is not available. `authkestra-axum` and `authkestra-actix` hand route handlers
-an `Arc<tokio::sync::Mutex<dyn OpStore>>`, locked once per request. A generic
-method parameter makes the trait non-dyn-compatible, so that type stops
-existing. An associated `type Executor` has the same effect by a different
-route: `dyn OpStore` becomes `dyn OpStore<Executor = ...>`, which no longer
-names one type across backends.
+is not available. `authkestra-axum` and `authkestra-actix` hold an
+`Arc<dyn CloneableOpStore>` and clone a `Box<dyn OpStore>` out of it per
+request. A generic method parameter makes `OpStore` non-dyn-compatible, and
+neither of those trait objects can be named any more. An associated
+`type Executor` has the same effect by a different route: `dyn OpStore`
+becomes `dyn OpStore<Executor = ...>`, which no longer names one type across
+backends.
 
 The second constraint is that backends disagree about what an executor even is.
 sqlx wants `&mut Connection`, SeaORM wants `&impl ConnectionTrait`, Diesel wants
@@ -59,7 +60,7 @@ pub trait TransactionalOpStore: OpStore {
 
 Both stay dyn-compatible: `self: Box<Self>` is an object-safe receiver, and
 every inherited method already takes `&mut self`. Nothing about the existing
-traits, the adapters, or `Arc<Mutex<dyn OpStore>>` changes. This is a purely
+traits, the adapters, or `Arc<dyn CloneableOpStore>` changes. This is a purely
 additive, non-breaking capability.
 
 ### Where the host's own queries go

--- a/docs/rfc-005-executor-composable-stores.md
+++ b/docs/rfc-005-executor-composable-stores.md
@@ -1,0 +1,183 @@
+# RFC-005 — Executor/transaction-composable stores
+
+Status: implemented (prototype), authkestra#336
+Supersedes the deferred half of proposed direction (1) in authkestra#289.
+
+## Problem
+
+A host application that wants "create user + create org + issue refresh token"
+as one atomic operation cannot get it. Every `OpStore`-family method takes
+`&mut self` and manages its own storage call internally, so an authkestra write
+commits independently of whatever transaction the application already has open
+for its own schema. If the application's write then fails, the refresh token is
+already durable.
+
+Epic #289's Phase B reworked the traits from `&self` to `&mut self` and called
+that "the prerequisite; actual executor/transaction plumbing is not yet built."
+This RFC builds it.
+
+## The constraint that shapes everything
+
+The obvious design — an executor parameter on each method —
+
+```rust
+async fn store_token<E: Executor>(&mut self, ex: &mut E, token: RefreshToken) -> ...;
+```
+
+is not available. `authkestra-axum` and `authkestra-actix` hand route handlers
+an `Arc<tokio::sync::Mutex<dyn OpStore>>`, locked once per request. A generic
+method parameter makes the trait non-dyn-compatible, so that type stops
+existing. An associated `type Executor` has the same effect by a different
+route: `dyn OpStore` becomes `dyn OpStore<Executor = ...>`, which no longer
+names one type across backends.
+
+The second constraint is that backends disagree about what an executor even is.
+sqlx wants `&mut Connection`, SeaORM wants `&impl ConnectionTrait`, Diesel wants
+a `&mut SqliteConnection` inside a blocking closure and has no owned transaction
+handle at all. There is no shared shape to make generic over.
+
+## Design
+
+**Put the transaction in the store value, not in the method signatures.** This
+is what `&mut self` was always for: a store that owns an open transaction runs
+every one of its methods inside it, with no change to any existing signature.
+
+Two new traits, in `authkestra-op::store`:
+
+```rust
+#[async_trait]
+pub trait OpStoreTransaction: OpStore {
+    async fn commit(self: Box<Self>) -> Result<(), StoreError>;
+    async fn rollback(self: Box<Self>) -> Result<(), StoreError>;
+}
+
+#[async_trait]
+pub trait TransactionalOpStore: OpStore {
+    async fn begin(&self) -> Result<Box<dyn OpStoreTransaction + Send>, StoreError>;
+}
+```
+
+Both stay dyn-compatible: `self: Box<Self>` is an object-safe receiver, and
+every inherited method already takes `&mut self`. Nothing about the existing
+traits, the adapters, or `Arc<Mutex<dyn OpStore>>` changes. This is a purely
+additive, non-breaking capability.
+
+### Where the host's own queries go
+
+The trait deliberately does **not** try to hand back an executor. The host's own
+statements are written against a concrete driver, so there is nothing useful a
+backend-agnostic trait could return. Each backend exposes its native handle on
+its own concrete transaction type instead, in whatever shape is idiomatic there:
+
+| backend | begin | native handle |
+|---|---|---|
+| `authkestra-store-sqlx` | `SqlxOpStore::begin_tx` | `AsMut<DB::Connection>` — `tx.as_mut()`, as on a bare `sqlx::Transaction` |
+| `authkestra-example-seaorm` | `SeaOrmOpStore::begin_tx` | `SeaOrmOpStoreTx::transaction() -> &DatabaseTransaction` |
+| `authkestra-example-diesel` | `DieselOpStore::begin_tx` | `DieselOpStoreTx::run(closure)` |
+
+```rust
+let mut tx = store.begin_tx().await?;
+
+sqlx::query("INSERT INTO app_users (id, email) VALUES (?1, ?2)")
+    .bind(&user_id).bind(&email)
+    .execute(tx.as_mut()).await?;      // the application's own write
+
+tx.store_token(refresh_token).await?;  // authkestra's write, same transaction
+
+tx.commit().await?;                    // both, or neither
+```
+
+Note the three handle shapes differ (`&mut`, `&`, and a closure). That is the
+proof the split is in the right place: everything genuinely shared lives on the
+trait, everything genuinely driver-specific stays inherent, and neither has to
+compromise for the other.
+
+### Why not defaulted methods on `OpStore`
+
+`TransactionalOpStore` is opt-in so a backend with no transactions — the
+in-memory store, Redis — cannot accidentally claim it. There is no honest
+default: one that committed each write immediately and made `rollback` a no-op
+would hand callers a unit of work that silently isn't one. Those backends do not
+implement the trait, and the conformance suite skips them by construction.
+
+## What implementing it surfaced
+
+Three things that a design document alone would not have caught.
+
+**1. Sharing the query bodies is most of the work.** A transaction-scoped store
+has to run the same SQL as the pool-backed one. In all three backends the
+queries were written inline against the pool (`.execute(&self.pool)`,
+`.one(&self.db)`, `pool.get()` inside `spawn_blocking`). Each is now a `queries`
+module written once against a *connection*, with two thin impls that differ only
+in where the connection comes from. Without that, every backend would carry two
+copies of the same SQL.
+
+**2. The single-use consume paths must nest, and one of them couldn't.** The
+consume operations open their own transaction where the dialect lacks
+`DELETE ... RETURNING`. Called inside a caller's transaction, that has to become
+a nested savepoint governed by the outer commit — not an independent transaction
+that commits on its own.
+
+- sqlx: free. `Connection::begin()` on a connection already in a transaction
+  issues a `SAVEPOINT`. Taking `&mut Connection` rather than a generic
+  `Executor` in the `queries` module is what makes this work, since an
+  `Executor` cannot `begin()`.
+- SeaORM: free, same way, via `TransactionTrait` on `DatabaseTransaction`.
+- Diesel: **not** free. The consume paths used `immediate_transaction`
+  (`BEGIN IMMEDIATE`, which takes SQLite's write lock up front instead of
+  failing at the first write). SQLite has no nested `BEGIN`, so inside a host
+  transaction that errors with "cannot start a transaction within a
+  transaction". Fixed by choosing on depth: `immediate_transaction` at depth 0,
+  Diesel's plain `transaction` (which emits `SAVEPOINT`) when already nested.
+  Nothing is lost, because `begin_tx` opens the outer transaction with
+  `BEGIN IMMEDIATE` itself, so the write lock is already held.
+
+**3. Two Diesel-specific frictions worth recording.**
+
+- `SqliteConnection` is `Send` but `!Sync`, and the store traits require
+  `Send + Sync`. A transaction-scoped store holding a connection therefore
+  cannot implement `OpStore` without a `Mutex` whose only job is to satisfy the
+  bound — it is never contended, and every access goes through `get_mut`. The
+  `Sync` bound buys those traits nothing now that every method takes
+  `&mut self`; dropping it would be a breaking change to every implementor, so
+  it stays for now. Worth revisiting.
+- r2d2 asks Diesel whether a returned connection is broken, and one still inside
+  a transaction answers yes — so a dropped transaction would make the pool
+  discard the connection and dial a new one. `DieselOpStoreTx` therefore rolls
+  back in `Drop`. Synchronously, since `Drop` cannot await, which is a real
+  reason to prefer calling `commit`/`rollback` explicitly.
+
+## Conformance
+
+`authkestra-store-testsuite::tx::run_transactional_op_store_tests` is the
+generic proof, run by all three backends:
+
+- a write inside a rolled-back transaction is not durable
+- a write inside a committed transaction is
+- dropping without committing rolls back
+- a transaction reads its own uncommitted writes
+- **store-then-consume, rolled back as a unit, leaves nothing behind** — the
+  assertion that catches a consume path which opened its own transaction and
+  committed independently of the caller's
+
+It deliberately does not assert that an uncommitted write is invisible to a
+*different* connection. That is the other half of what a transaction means, but
+checking it requires holding the transaction open while reading through the
+pool, and a backend under test may be on a single-connection pool (in-memory
+SQLite necessarily is), where that deadlocks rather than fails.
+
+Each backend additionally has a `test_host_write_and_store_write_commit_as_one_unit`
+test covering the actual goal — an application-owned table written alongside an
+`OpStore` write, committed and rolled back as one — since that part is
+driver-specific and cannot live in the generic suite.
+
+## Not done
+
+- **Composing across two different backends.** A deployment with clients in
+  Postgres and codes in Redis gets no atomicity between them; `CompositeOpStore`
+  does not implement `TransactionalOpStore`. Distributed transactions are out of
+  scope, and probably permanently.
+- **Relaxing the `Send + Sync` bound** on the store traits (see friction 3).
+- **`authkestra-engine`'s `SqlxCredentialStore`** (WebAuthn/TOTP) has the same
+  shape and the same latent problem — see the ordering tradeoff documented in
+  `register_totp` (authkestra#326/#330) — but was out of scope here.


### PR DESCRIPTION
## Summary

Builds the executor/transaction plumbing deferred from #289's proposed direction (1), so a host application can compose its own writes and authkestra's into one atomic unit of work. Design write-up: `docs/rfc-005-executor-composable-stores.md`.

**The constraint that shapes the design.** An executor parameter on each method is not available — `authkestra-axum` and `authkestra-actix` hand route handlers an `Arc<Mutex<dyn OpStore>>`, and a generic method parameter (or an associated `Executor` type) makes the traits non-dyn-compatible, so that type stops existing. Backends also disagree about what an executor even is: `&mut Connection` for sqlx, `&impl ConnectionTrait` for SeaORM, a closure over `&mut SqliteConnection` for Diesel, which has no owned transaction handle at all.

**The design.** Put the transaction in the store *value*, not in the method signatures — which is what `&mut self` was always for. A store that owns an open transaction runs every method inside it with no signature change, so this is **purely additive**: no existing trait, adapter, or implementor changes.

```rust
#[async_trait]
pub trait OpStoreTransaction: OpStore {
    async fn commit(self: Box<Self>) -> Result<(), StoreError>;
    async fn rollback(self: Box<Self>) -> Result<(), StoreError>;
}

#[async_trait]
pub trait TransactionalOpStore: OpStore {
    async fn begin(&self) -> Result<Box<dyn OpStoreTransaction + Send>, StoreError>;
}
```

Both stay dyn-compatible (`self: Box<Self>` is an object-safe receiver). The host's own statements reach the transaction through each backend's *concrete* type — `AsMut` for sqlx, `transaction()` for SeaORM, `run(closure)` for Diesel — because those queries are written against a concrete driver, and there is nothing useful a backend-agnostic trait could return. That split is what keeps the shared trait dyn-compatible while each backend stays idiomatic.

```rust
let mut tx = store.begin_tx().await?;
sqlx::query("INSERT INTO app_users (id, email) VALUES (?1, ?2)")
    .bind(&user_id).bind(&email)
    .execute(tx.as_mut()).await?;      // the application's own write
tx.store_token(refresh_token).await?;  // authkestra's write, same transaction
tx.commit().await?;                    // both, or neither
```

Backends with no transactions (memory, Redis) deliberately do **not** implement the trait. There is no honest default — one that committed each write and made `rollback` a no-op would hand callers a unit of work that silently isn't one.

## What implementing it surfaced

Worth reading even if you skip the rest; none of it was visible from the design alone.

1. **The consume paths must nest, and one couldn't.** Single-use consume opens its own transaction where the dialect lacks `RETURNING`. Inside a caller's transaction that has to become a nested savepoint governed by the outer rollback. Free on sqlx (`Connection::begin()` emits `SAVEPOINT`) and SeaORM. **Not** free on Diesel: its `immediate_transaction` (`BEGIN IMMEDIATE`) cannot nest in SQLite, so it now picks by transaction depth. Verified against a real MySQL container, which is the one dialect that takes the `SELECT … FOR UPDATE` path.
2. **`SqliteConnection` is `!Sync`** while the store traits require `Send + Sync`, so the Diesel transaction store needs a `Mutex` purely to satisfy the bound (never contended; every access goes through `get_mut`). The `Sync` bound buys those traits nothing now that every method takes `&mut self` — worth revisiting, but relaxing it is breaking, so it stays.
3. **r2d2 treats a connection returned with an open transaction as broken** and discards it, so `DieselOpStoreTx` rolls back in `Drop`. Against in-memory SQLite the reconnect silently starts from an empty schema, which is how this was found.

Sharing the SQL turned out to be most of the work: each backend now has a `queries` module written once against a *connection*, with two thin impls that differ only in where the connection comes from. Without it every backend would carry two copies of the same SQL.

## Conformance

`authkestra-store-testsuite::tx::run_transactional_op_store_tests`, run by all three backends: rollback discards, commit persists, drop rolls back, a transaction reads its own uncommitted writes, and — the load-bearing one — **store-then-consume rolled back as a unit leaves nothing behind**, which catches a consume path that committed independently of its caller.

It deliberately does not assert that an uncommitted write is invisible to a *different* connection: that needs the transaction held open while reading through the pool, and a backend under test may be on a single-connection pool (in-memory SQLite necessarily is), where that deadlocks rather than fails.

Each backend additionally has a `test_host_write_and_store_write_commit_as_one_unit` covering the real goal — an application-owned table written alongside an `OpStore` write, committed and rolled back as one — since that part is driver-specific.

## Not done

- Composing across two *different* backends (`CompositeOpStore` does not implement the trait). Distributed transactions are out of scope, probably permanently.
- Relaxing the `Send + Sync` bound (friction 2 above).
- `authkestra-engine`'s `SqlxCredentialStore` has the same shape and the same latent problem — see the ordering tradeoff in `register_totp` from #326/#330 — but was out of scope here.

Closes #336

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features` — 40 test binaries, 0 failures, including the Postgres and MySQL testcontainers suites
- [x] `cargo test -p authkestra-store-sqlx --features mysql --lib mysql_consume_inside` — the nested-savepoint path against real MySQL