### PR TITLE
fix(resource): verify tokens under a multi-family algorithm policy

### DIFF
--- a/crates/authkestra-oidc/tests/provider_tests.rs
+++ b/crates/authkestra-oidc/tests/provider_tests.rs
@@ -388,9 +388,50 @@ async fn algorithms_come_from_discovery_not_the_rs256_fallback() {
         .await
         .expect_err("an RS256 token must be rejected when discovery advertises only ES256");
     assert!(
-        err.to_string().contains("InvalidAlgorithm"),
-        "expected an InvalidAlgorithm rejection, got: {err}"
+        err.to_string().contains("RS256") && err.to_string().contains("ES256"),
+        "expected a rejection naming both the token's algorithm and the accepted set, got: {err}"
     );
+}
+
+/// Issue #335: Keycloak advertises every algorithm it knows in
+/// `id_token_signing_alg_values_supported` — twelve of them, spanning the
+/// HMAC, RSA, EC and Ed key families — and signs with RS256. Because
+/// `jsonwebtoken` requires the *whole* accepted list to match the verifying
+/// key's family, the discovery-derived policy rejected every one of those ID
+/// tokens with a bare `InvalidAlgorithm`, making the provider unusable against
+/// a stock Keycloak realm.
+#[tokio::test]
+async fn keycloak_shaped_multi_family_discovery_list_verifies_an_rs256_id_token() {
+    let mock_server = MockServer::start().await;
+    let (provider, key) = setup_provider_advertising(
+        &mock_server,
+        "test_client",
+        Some(json!([
+            "PS384", "RS384", "EdDSA", "ES384", "HS256", "HS512", "ES256", "RS256", "HS384",
+            "PS256", "PS512", "RS512"
+        ])),
+    )
+    .await;
+
+    let claims = TestClaims {
+        sub: "user-123".to_string(),
+        iss: mock_server.uri(),
+        aud: "test_client".into(),
+        exp: future_exp(),
+        azp: None,
+        email: None,
+        name: None,
+        picture: None,
+        nonce: None,
+    };
+    let id_token = sign_claims(&key.encoding_key, "kid-1", &claims);
+    mount_token_response(&mock_server, &id_token).await;
+
+    let (identity, _token) = provider
+        .exchange_code_for_identity("code123", None, None)
+        .await
+        .expect("an RS256 ID token must verify against a Keycloak-shaped algorithm list");
+    assert_eq!(identity.external_id, "user-123");
 }
 
 /// A discovery document that omits `id_token_signing_alg_values_supported`

--- a/crates/authkestra-resource/src/jwt.rs
+++ b/crates/authkestra-resource/src/jwt.rs
@@ -1313,9 +1313,65 @@ where
         .ok_or(ValidationError::KeyNotFound)?;
 
     let decoding_key = jwk.to_decoding_key()?;
-    let token_data = decode::<T>(token, &decoding_key, validation)?;
+    let validation = narrow_to_header_family(validation, header.alg)?;
+    let token_data = decode::<T>(token, &decoding_key, &validation)?;
 
     Ok(token_data.claims)
+}
+
+/// Restricts `validation` to the algorithms that share a key family with the
+/// token header's own `alg`.
+///
+/// `jsonwebtoken` does not merely require that the header's `alg` be *among*
+/// `validation.algorithms`; it requires that **every** entry of that list
+/// belong to the same key family as the verifying key
+/// (`decoding::verify_signature_body`). A policy naming more than one family
+/// is therefore unverifiable by construction: whatever the token is signed
+/// with, the first entry from another family fails the loop and the whole
+/// decode returns `InvalidAlgorithm`.
+///
+/// That is exactly the policy an OIDC discovery document produces. Keycloak
+/// advertises all twelve algorithms across the HMAC/RSA/EC/Ed families in
+/// `id_token_signing_alg_values_supported`, so `authkestra-oidc`'s
+/// discovery-derived default rejected *every* ID token from *every* Keycloak
+/// deployment with a bare `InvalidAlgorithm` (#335). The same applied to a
+/// `ValidationConfig` whose `algorithms` deliberately spans families, which
+/// is the natural way to write "this resource server accepts RS256 or ES256".
+///
+/// # Why this does not weaken the policy
+///
+/// The set is only ever *narrowed*, and only to algorithms the caller already
+/// listed — a token signed with an algorithm outside the caller's policy is
+/// still rejected, by the explicit check below. What narrowing removes is
+/// `jsonwebtoken`'s use of the list as a proxy for "which family is this key",
+/// and that proxy is not what protects against algorithm confusion: each
+/// verifier re-checks the key's own family when it is constructed
+/// (`DecodingKey::family` → `ErrorKind::InvalidKeyFormat`), so an RSA JWK
+/// presented for an `HS256` header still fails there, with the public key
+/// never reaching the HMAC verifier.
+fn narrow_to_header_family(
+    validation: &Validation,
+    header_alg: Algorithm,
+) -> Result<Validation, ValidationError> {
+    if !validation.algorithms.contains(&header_alg) {
+        return Err(ValidationError::InvalidToken(format!(
+            "token is signed with {header_alg:?}, which this validation policy does not accept \
+             (accepted: {:?})",
+            validation.algorithms
+        )));
+    }
+
+    let mut narrowed = validation.clone();
+    narrowed
+        .algorithms
+        .retain(|alg| alg.family() == header_alg.family());
+    tracing::debug!(
+        header_alg = ?header_alg,
+        accepted = ?validation.algorithms,
+        narrowed = ?narrowed.algorithms,
+        "narrowed the accepted algorithm set to the token header's key family"
+    );
+    Ok(narrowed)
 }
 
 /// Validates a PASETO V4 Local/Public token.

--- a/crates/authkestra-resource/tests/jwt_test.rs
+++ b/crates/authkestra-resource/tests/jwt_test.rs
@@ -1400,3 +1400,126 @@ async fn default_client_does_not_carry_the_injected_configuration() {
          passes, the header is not actually discriminating and the sibling test proves nothing"
     );
 }
+
+/// The twelve algorithms Keycloak advertises in
+/// `id_token_signing_alg_values_supported`, in the order a realm returns them —
+/// four key families in one list.
+fn keycloak_signing_algs() -> Vec<Algorithm> {
+    vec![
+        Algorithm::PS384,
+        Algorithm::RS384,
+        Algorithm::EdDSA,
+        Algorithm::ES384,
+        Algorithm::HS256,
+        Algorithm::HS512,
+        Algorithm::ES256,
+        Algorithm::RS256,
+        Algorithm::HS384,
+        Algorithm::PS256,
+        Algorithm::PS512,
+        Algorithm::RS512,
+    ]
+}
+
+/// Issue #335: a validation policy naming more than one key family — which is
+/// exactly what an OIDC discovery document yields — must still verify a token
+/// signed with one of the algorithms it lists.
+///
+/// `jsonwebtoken` requires every entry of `Validation::algorithms` to match the
+/// verifying key's family, not just the header's `alg`, so before the fix this
+/// list rejected every token from every Keycloak deployment with a bare
+/// `InvalidAlgorithm`.
+#[tokio::test]
+async fn multi_family_algorithm_policy_verifies_a_token_from_one_of_its_families() {
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+    let cache = JwksCache::new(jwks_url(&server), Duration::from_secs(300));
+
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.algorithms = keycloak_signing_algs();
+    validation.validate_aud = false;
+
+    let claims = TestClaims {
+        sub: "user-1".to_string(),
+        exp: future_exp(),
+        aud: None,
+    };
+    let token = sign_token(&key.encoding_key, Some("kid-1"), &claims);
+
+    let validated: TestClaims = validate_jwt_generic(&token, &cache, &validation)
+        .await
+        .expect("an RS256 token must verify against the RS256 key that signed it");
+    assert_eq!(validated.sub, "user-1");
+}
+
+/// Narrowing the policy to the header's family must not turn it into "any
+/// algorithm goes": an algorithm the caller never listed is still refused.
+#[tokio::test]
+async fn rejects_an_algorithm_the_policy_does_not_list() {
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+    let cache = JwksCache::new(jwks_url(&server), Duration::from_secs(300));
+
+    // A policy that accepts EC and Ed only — the token below is neither.
+    let mut validation = Validation::new(Algorithm::ES256);
+    validation.algorithms = vec![Algorithm::ES256, Algorithm::ES384, Algorithm::EdDSA];
+    validation.validate_aud = false;
+
+    let claims = TestClaims {
+        sub: "user-1".to_string(),
+        exp: future_exp(),
+        aud: None,
+    };
+    let token = sign_token(&key.encoding_key, Some("kid-1"), &claims);
+
+    let err = validate_jwt_generic::<TestClaims>(&token, &cache, &validation)
+        .await
+        .expect_err("RS256 is not in the policy and must be rejected");
+    assert!(
+        matches!(&err, ValidationError::InvalidToken(msg) if msg.contains("RS256")),
+        "expected an unaccepted-algorithm rejection naming RS256, got: {err}"
+    );
+}
+
+/// The classic algorithm-confusion attack: the attacker takes the *public* RSA
+/// key from the JWKS, uses its bytes as an HMAC secret, and presents an
+/// `HS256`-signed token. Keycloak's advertised list contains both `RS256` and
+/// `HS256`, so narrowing to the header's family leaves `HS256` in the policy —
+/// the attack must be stopped by the key's own family check instead, before the
+/// public key ever reaches an HMAC verifier.
+#[tokio::test]
+async fn rejects_hmac_token_verified_against_an_rsa_jwks_key() {
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+    let cache = JwksCache::new(jwks_url(&server), Duration::from_secs(300));
+
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.algorithms = keycloak_signing_algs();
+    validation.validate_aud = false;
+
+    // Sign with the published modulus as the shared secret — everything the
+    // attacker needs is in the JWKS.
+    let public_bytes = URL_SAFE_NO_PAD
+        .decode(key.jwk.n.as_ref().expect("RSA JWK carries 'n'"))
+        .expect("'n' is base64url");
+    let mut header = Header::new(Algorithm::HS256);
+    header.kid = Some("kid-1".to_string());
+    let forged = encode(
+        &header,
+        &TestClaims {
+            sub: "attacker".to_string(),
+            exp: future_exp(),
+            aud: None,
+        },
+        &EncodingKey::from_secret(&public_bytes),
+    )
+    .expect("failed to forge token");
+
+    let err = validate_jwt_generic::<TestClaims>(&forged, &cache, &validation)
+        .await
+        .expect_err("an HS256 token must never be verified with an RSA JWKS key");
+    assert!(
+        matches!(&err, ValidationError::Jwt(e) if matches!(e.kind(), ErrorKind::InvalidKeyFormat)),
+        "expected the RSA key to be refused by the HMAC verifier, got: {err}"
+    );
+}


### PR DESCRIPTION
Closes #335.

## The report

An external user wired `authkestra-oidc` up to a stock self-hosted Keycloak realm, followed the axum getting-started guide, and every login died at ID-token validation:

```
using ID token validation policy algorithms=[PS384, RS384, EdDSA, ES384, HS256, HS512, ES256, RS256, HS384, PS256, PS512, RS512] issuer="http://dev.kcl.lab.local/realms/master"
failed to validate OIDC ID Token error=JWT error: InvalidAlgorithm
```

Keycloak signs with RS256, and `RS256` is right there in the accepted list — which is what made this hard for them to self-diagnose.

## Cause

`jsonwebtoken` does not merely require the header's `alg` to be *among* `Validation::algorithms`. It requires **every** entry of that list to belong to the same key family as the verifying key ([`decoding::verify_signature_body`](https://docs.rs/jsonwebtoken/11.0.0/src/jsonwebtoken/decoding.rs.html)):

```rust
for alg in &validation.algorithms {
    if verifying_provider.algorithm().family() != alg.family() {
        return Err(new_error(ErrorKind::InvalidAlgorithm));
    }
}
```

So a policy naming more than one family is unverifiable by construction — whatever the token is signed with, the first entry from another family fails the loop.

That is exactly the policy an OIDC discovery document produces. Keycloak advertises all twelve algorithms it knows in `id_token_signing_alg_values_supported`, spanning HMAC/RSA/EC/Ed, and `default_validation` copies the list verbatim. **Every ID token from every stock Keycloak realm was rejected.** The same applied to any `ValidationConfig` whose `algorithms` deliberately spans families — the natural way to write "this resource server accepts RS256 or ES256".

`authkestra-op` was never affected: `assertion_algorithms` derives its set from the key, so it is always single-family.

## Fix

`validate_jwt_generic` — the single decode site every caller funnels through (`JwtStrategy`, the multi-issuer resolver, the OIDC login flow) — narrows the policy to the algorithms sharing a family with the token header's own `alg`.

## Why this does not weaken the policy

The set is only ever *narrowed*, and only to algorithms the caller already listed. A token signed with an algorithm outside the policy is still refused — now by an explicit check that names both the token's `alg` and the accepted set, instead of the opaque `InvalidAlgorithm` the reporter was left staring at.

What narrowing removes is `jsonwebtoken`'s use of the list as a *proxy* for "which family is this key". That proxy is not what protects against algorithm confusion: every verifier re-checks the key's own family when it is constructed (`DecodingKey::family` → `ErrorKind::InvalidKeyFormat`). This matters here because Keycloak's advertised list contains both `RS256` and `HS256`, so after narrowing on an `HS256` header the HMAC algorithms do remain in the policy — and the attack still has nowhere to land, because the RSA key is refused before it ever reaches the HMAC verifier.

`rejects_hmac_token_verified_against_an_rsa_jwks_key` proves it: it takes the public modulus straight from the JWKS, uses those bytes as an HMAC secret, forges an `HS256` token, and asserts it is refused with `InvalidKeyFormat`.

## Tests

| Test | Covers |
| --- | --- |
| `keycloak_shaped_multi_family_discovery_list_verifies_an_rs256_id_token` | End-to-end at the OIDC layer: the reporter's exact 12-algorithm discovery list |
| `multi_family_algorithm_policy_verifies_a_token_from_one_of_its_families` | The same at the `validate_jwt_generic` seam |
| `rejects_an_algorithm_the_policy_does_not_list` | Still fail-closed: RS256 token against an EC/Ed-only policy |
| `rejects_hmac_token_verified_against_an_rsa_jwks_key` | Algorithm confusion, forged from the published JWKS |

All four fail on `main` in the way the fix predicts, and pass here.

## Caller-visible note

A token whose `alg` is not in the policy now surfaces as `ValidationError::InvalidToken` with a descriptive message rather than `ValidationError::Jwt(InvalidAlgorithm)`. Both variants pre-exist and the enum is `#[non_exhaustive]`; the existing `algorithms_come_from_discovery_not_the_rs256_fallback` test was updated to assert on the new message.

## Verification

All five CI gates from `.github/workflows/ci.yml` pass locally: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-features -- -D warnings`, `cargo test --workspace --all-features`, `cargo llvm-cov ... --fail-under-lines 84` (85.66%), `cargo deny check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
