### PR TITLE
fix(engine)!: enforce JWKS key-use separation when selecting a verification key

### DIFF
--- a/crates/authkestra-engine/src/token/jwk.rs
+++ b/crates/authkestra-engine/src/token/jwk.rs
@@ -4,12 +4,16 @@ use serde::{Deserialize, Serialize};
 
 /// A JSON Web Key, as published at `/jwks.json`.
 ///
-/// This struct is widened (not an enum) so that every existing call site
-/// that builds a `Jwk` with a plain struct literal — inside this crate and
-/// downstream — keeps compiling: it only needs two more fields (`crv`, `x`),
-/// both `None` for the RSA shape it already builds. See the `to_decoding_key`
-/// doc comment for why an enum/`#[serde(untagged)]` representation was
-/// rejected in favor of this.
+/// This struct is widened (not an enum) rather than split per key type, so a
+/// call site that builds a `Jwk` with a plain struct literal names one set of
+/// fields whatever shape it is describing. See the `to_decoding_key` doc
+/// comment for why an enum/`#[serde(untagged)]` representation was rejected
+/// in favor of this. The trade-off is that widening it again is a breaking
+/// change for those literals, which is what adding `use`/`key_ops` cost.
+///
+/// `use` and `key_ops` (RFC 7517 §4.2/§4.3) are carried so that key-use
+/// separation can be enforced when selecting a verification key — see
+/// [`Jwk::is_usable_for_signature_verification`].
 ///
 /// Two shapes are represented today:
 /// - RSA (`kty: "RSA"`): `n`, `e` are populated; `crv`, `x` are `None`.
@@ -42,9 +46,57 @@ pub struct Jwk {
     /// keys.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub x: Option<String>,
+    /// Intended use of the public key (RFC 7517 §4.2): `"sig"` or `"enc"`.
+    ///
+    /// Named `r#use` because `use` is a keyword; it is `use` on the wire.
+    /// `None` — the shape most IdPs publish — asserts nothing either way,
+    /// and [`Jwk::is_usable_for_signature_verification`] treats it as
+    /// permitted.
+    #[serde(rename = "use", skip_serializing_if = "Option::is_none")]
+    pub r#use: Option<String>,
+    /// Operations the key is intended for (RFC 7517 §4.3), e.g. `["verify"]`.
+    ///
+    /// RFC 7517 §4.3 says `use` and `key_ops` "SHOULD NOT be used together";
+    /// both are honoured here because a publisher that ignores that advice
+    /// should not end up with *neither* restriction enforced.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_ops: Option<Vec<String>>,
 }
 
 impl Jwk {
+    /// Whether this key may be used to **verify a signature**.
+    ///
+    /// A JWKS endpoint routinely publishes keys that exist for something
+    /// other than signature verification. A stock Keycloak realm serves an
+    /// RSA signing key and an RSA *encryption* key side by side, both
+    /// `kty: "RSA"` and distinguishable only by `use`/`alg`, so selecting a
+    /// verification key on `kty` (or on JWKS member order) alone can land on
+    /// the encryption key and reject a perfectly good token with a bare
+    /// `InvalidSignature` — see #341.
+    ///
+    /// Only an *explicit* exclusion rejects: `use: "enc"`, or a `key_ops`
+    /// that is present and does not list `"verify"`. A key declaring neither
+    /// is permitted, because that is what the majority of IdPs publish and
+    /// refusing it would fail closed on the common case.
+    ///
+    /// This is about key **purpose**, not about trust: it never decides
+    /// whether a key is the right one, only whether it is the right *kind*.
+    pub fn is_usable_for_signature_verification(&self) -> bool {
+        if let Some(r#use) = self.r#use.as_deref() {
+            if r#use != "sig" {
+                return false;
+            }
+        }
+
+        if let Some(key_ops) = self.key_ops.as_deref() {
+            if !key_ops.iter().any(|op| op == "verify") {
+                return false;
+            }
+        }
+
+        true
+    }
+
     /// Derives a `DecodingKey` from this JWK, dispatching on `kty`.
     ///
     /// Supports `"RSA"` (unchanged from before this key gained the OKP
@@ -114,6 +166,8 @@ mod tests {
             e: None,
             crv: Some("Ed25519".to_string()),
             x: Some(identity_b64.to_string()),
+            r#use: None,
+            key_ops: None,
         };
 
         let err = jwk

--- a/crates/authkestra-engine/src/token/jwk.rs
+++ b/crates/authkestra-engine/src/token/jwk.rs
@@ -4,16 +4,31 @@ use serde::{Deserialize, Serialize};
 
 /// A JSON Web Key, as published at `/jwks.json`.
 ///
-/// This struct is widened (not an enum) rather than split per key type, so a
-/// call site that builds a `Jwk` with a plain struct literal names one set of
-/// fields whatever shape it is describing. See the `to_decoding_key` doc
-/// comment for why an enum/`#[serde(untagged)]` representation was rejected
-/// in favor of this. The trade-off is that widening it again is a breaking
-/// change for those literals, which is what adding `use`/`key_ops` cost.
+/// This struct is widened (not an enum) rather than split per key type, so one
+/// set of fields describes whatever shape a key has. See the `to_decoding_key`
+/// doc comment for why an enum/`#[serde(untagged)]` representation was
+/// rejected in favor of this.
 ///
 /// `use` and `key_ops` (RFC 7517 §4.2/§4.3) are carried so that key-use
 /// separation can be enforced when selecting a verification key — see
 /// [`Jwk::is_usable_for_signature_verification`].
+///
+/// # Why `#[non_exhaustive]`
+///
+/// A JWK has as many members as the RFCs care to define, so this struct gets
+/// widened whenever a new one turns out to matter — `crv`/`x` for the OKP
+/// shape, then `use`/`key_ops` for key-use separation. While downstream could
+/// build one with a struct literal, every one of those widenings was a
+/// breaking change for code that had nothing to do with the new field.
+///
+/// `#[non_exhaustive]` ends that: construction goes through [`Jwk::rsa`] /
+/// [`Jwk::ed25519`] and the `with_*` builders, so a future field is additive
+/// and costs downstream nothing. This matches the rest of the crate —
+/// including this type's own containers, `Jwks` and `JwksResponse`, which
+/// were already `#[non_exhaustive]`. Reading and mutating the public fields
+/// is unaffected; only literal construction and exhaustive destructuring are
+/// restricted, and a key with some other `kty` can still be obtained by
+/// deserializing it.
 ///
 /// Two shapes are represented today:
 /// - RSA (`kty: "RSA"`): `n`, `e` are populated; `crv`, `x` are `None`.
@@ -26,6 +41,7 @@ use serde::{Deserialize, Serialize};
 /// shape ever emits the other's fields, and neither emits a stray `"n":null`
 /// / `"x":null`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Jwk {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kid: Option<String>,
@@ -64,6 +80,70 @@ pub struct Jwk {
 }
 
 impl Jwk {
+    /// An RSA public key (RFC 7517 §6.3.1) from its base64url modulus and
+    /// exponent.
+    ///
+    /// `kid`, `alg`, `use` and `key_ops` are unset; add them with the
+    /// `with_*` builders.
+    pub fn rsa(n: impl Into<String>, e: impl Into<String>) -> Self {
+        Self {
+            kid: None,
+            kty: "RSA".to_string(),
+            alg: None,
+            n: Some(n.into()),
+            e: Some(e.into()),
+            crv: None,
+            x: None,
+            r#use: None,
+            key_ops: None,
+        }
+    }
+
+    /// An Ed25519 OKP public key (RFC 8037 §2) from its base64url public key.
+    ///
+    /// `kid`, `alg`, `use` and `key_ops` are unset; add them with the
+    /// `with_*` builders.
+    pub fn ed25519(x: impl Into<String>) -> Self {
+        Self {
+            kid: None,
+            kty: "OKP".to_string(),
+            alg: None,
+            n: None,
+            e: None,
+            crv: Some("Ed25519".to_string()),
+            x: Some(x.into()),
+            r#use: None,
+            key_ops: None,
+        }
+    }
+
+    /// Sets the key ID (RFC 7517 §4.5).
+    pub fn with_kid(mut self, kid: impl Into<String>) -> Self {
+        self.kid = Some(kid.into());
+        self
+    }
+
+    /// Sets the algorithm this key is intended for (RFC 7517 §4.4).
+    pub fn with_alg(mut self, alg: impl Into<String>) -> Self {
+        self.alg = Some(alg.into());
+        self
+    }
+
+    /// Sets the intended use (RFC 7517 §4.2) — `"sig"` or `"enc"`.
+    ///
+    /// See [`Jwk::is_usable_for_signature_verification`] for what this
+    /// declaration then rules in or out.
+    pub fn with_use(mut self, r#use: impl Into<String>) -> Self {
+        self.r#use = Some(r#use.into());
+        self
+    }
+
+    /// Sets the permitted key operations (RFC 7517 §4.3), e.g. `["verify"]`.
+    pub fn with_key_ops(mut self, key_ops: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.key_ops = Some(key_ops.into_iter().map(Into::into).collect());
+        self
+    }
+
     /// Whether this key may be used to **verify a signature**.
     ///
     /// A JWKS endpoint routinely publishes keys that exist for something
@@ -157,17 +237,14 @@ mod tests {
     /// A minimal RSA-shaped JWK; the `use`/`key_ops` fields are what each
     /// test below varies.
     fn rsa_jwk(r#use: Option<&str>, key_ops: Option<&[&str]>) -> Jwk {
-        Jwk {
-            kid: Some("kid-1".to_string()),
-            kty: "RSA".to_string(),
-            alg: Some("RS256".to_string()),
-            n: Some("bg".to_string()),
-            e: Some("AQAB".to_string()),
-            crv: None,
-            x: None,
-            r#use: r#use.map(str::to_string),
-            key_ops: key_ops.map(|ops| ops.iter().map(|op| op.to_string()).collect()),
+        let mut jwk = Jwk::rsa("bg", "AQAB").with_kid("kid-1").with_alg("RS256");
+        if let Some(r#use) = r#use {
+            jwk = jwk.with_use(r#use);
         }
+        if let Some(key_ops) = key_ops {
+            jwk = jwk.with_key_ops(key_ops.iter().copied());
+        }
+        jwk
     }
 
     #[test]
@@ -210,17 +287,7 @@ mod tests {
     fn rejects_low_order_ed25519_key() {
         // The identity point: the canonical universal low-order vector.
         let identity_b64 = "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        let jwk = Jwk {
-            kid: None,
-            kty: "OKP".to_string(),
-            alg: None,
-            n: None,
-            e: None,
-            crv: Some("Ed25519".to_string()),
-            x: Some(identity_b64.to_string()),
-            r#use: None,
-            key_ops: None,
-        };
+        let jwk = Jwk::ed25519(identity_b64);
 
         let err = jwk
             .to_decoding_key()

--- a/crates/authkestra-engine/src/token/jwk.rs
+++ b/crates/authkestra-engine/src/token/jwk.rs
@@ -154,6 +154,58 @@ impl Jwk {
 mod tests {
     use super::*;
 
+    /// A minimal RSA-shaped JWK; the `use`/`key_ops` fields are what each
+    /// test below varies.
+    fn rsa_jwk(r#use: Option<&str>, key_ops: Option<&[&str]>) -> Jwk {
+        Jwk {
+            kid: Some("kid-1".to_string()),
+            kty: "RSA".to_string(),
+            alg: Some("RS256".to_string()),
+            n: Some("bg".to_string()),
+            e: Some("AQAB".to_string()),
+            crv: None,
+            x: None,
+            r#use: r#use.map(str::to_string),
+            key_ops: key_ops.map(|ops| ops.iter().map(|op| op.to_string()).collect()),
+        }
+    }
+
+    #[test]
+    fn a_key_declaring_no_restriction_may_verify() {
+        // The shape most IdPs publish. Rejecting it would fail closed on
+        // nearly every deployment in existence.
+        assert!(rsa_jwk(None, None).is_usable_for_signature_verification());
+    }
+
+    #[test]
+    fn use_decides_when_it_is_the_only_restriction() {
+        assert!(rsa_jwk(Some("sig"), None).is_usable_for_signature_verification());
+        assert!(!rsa_jwk(Some("enc"), None).is_usable_for_signature_verification());
+        // An unrecognised `use` is not "no restriction": it is a restriction
+        // to something that is not signing.
+        assert!(!rsa_jwk(Some("wat"), None).is_usable_for_signature_verification());
+    }
+
+    #[test]
+    fn key_ops_decides_when_it_is_the_only_restriction() {
+        assert!(rsa_jwk(None, Some(&["verify"])).is_usable_for_signature_verification());
+        assert!(rsa_jwk(None, Some(&["sign", "verify"])).is_usable_for_signature_verification());
+        assert!(!rsa_jwk(None, Some(&["encrypt"])).is_usable_for_signature_verification());
+        // Present but empty still means "these are the operations", and
+        // `verify` is not among them.
+        assert!(!rsa_jwk(None, Some(&[])).is_usable_for_signature_verification());
+    }
+
+    /// RFC 7517 §4.3 says `use` and `key_ops` "SHOULD NOT be used together",
+    /// but a publisher that ignores that must not end up with *neither*
+    /// restriction enforced: either one alone is enough to disqualify a key.
+    #[test]
+    fn use_and_key_ops_are_both_honoured_when_both_are_present() {
+        assert!(rsa_jwk(Some("sig"), Some(&["verify"])).is_usable_for_signature_verification());
+        assert!(!rsa_jwk(Some("sig"), Some(&["encrypt"])).is_usable_for_signature_verification());
+        assert!(!rsa_jwk(Some("enc"), Some(&["verify"])).is_usable_for_signature_verification());
+    }
+
     #[test]
     fn rejects_low_order_ed25519_key() {
         // The identity point: the canonical universal low-order vector.

--- a/crates/authkestra-engine/src/token/mod.rs
+++ b/crates/authkestra-engine/src/token/mod.rs
@@ -267,20 +267,13 @@ impl TokenManager {
 
         let kid_val = kid.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
-        let jwk = crate::token::jwk::Jwk {
-            kid: Some(kid_val.clone()),
-            kty: "RSA".to_string(),
-            alg: Some("RS256".to_string()),
-            n: Some(n),
-            e: Some(e),
-            crv: None,
-            x: None,
-            // Declared explicitly so a relying party enforcing RFC 7517 §4.2
-            // key-use separation (as this crate's own `Jwks::find_key` now
-            // does) sees what this key is for instead of having to assume.
-            r#use: Some("sig".to_string()),
-            key_ops: None,
-        };
+        // `use` is declared explicitly so a relying party enforcing RFC 7517
+        // §4.2 key-use separation (as this crate's own `Jwks::find_key` now
+        // does) sees what this key is for instead of having to assume.
+        let jwk = crate::token::jwk::Jwk::rsa(n, e)
+            .with_kid(kid_val.clone())
+            .with_alg("RS256")
+            .with_use("sig");
 
         // The decoding key must come from the PUBLIC half. `DecodingKey::from_rsa_pem`
         // expects a public-key PEM; handed a private one it still constructs, but every
@@ -329,20 +322,11 @@ impl TokenManager {
 
         let kid_val = kid.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
-        let jwk = crate::token::jwk::Jwk {
-            kid: Some(kid_val.clone()),
-            kty: "OKP".to_string(),
-            alg: Some("EdDSA".to_string()),
-            n: None,
-            e: None,
-            crv: Some("Ed25519".to_string()),
-            x: Some(x),
-            // Declared explicitly so a relying party enforcing RFC 7517 §4.2
-            // key-use separation (as this crate's own `Jwks::find_key` now
-            // does) sees what this key is for instead of having to assume.
-            r#use: Some("sig".to_string()),
-            key_ops: None,
-        };
+        // Same `use` rationale as `new_asymmetric`.
+        let jwk = crate::token::jwk::Jwk::ed25519(x)
+            .with_kid(kid_val.clone())
+            .with_alg("EdDSA")
+            .with_use("sig");
 
         // Same rationale as `new_asymmetric`: derive the decoding key from
         // the JWK we just built (the public half) rather than from the

--- a/crates/authkestra-engine/src/token/mod.rs
+++ b/crates/authkestra-engine/src/token/mod.rs
@@ -275,6 +275,11 @@ impl TokenManager {
             e: Some(e),
             crv: None,
             x: None,
+            // Declared explicitly so a relying party enforcing RFC 7517 §4.2
+            // key-use separation (as this crate's own `Jwks::find_key` now
+            // does) sees what this key is for instead of having to assume.
+            r#use: Some("sig".to_string()),
+            key_ops: None,
         };
 
         // The decoding key must come from the PUBLIC half. `DecodingKey::from_rsa_pem`
@@ -332,6 +337,11 @@ impl TokenManager {
             e: None,
             crv: Some("Ed25519".to_string()),
             x: Some(x),
+            // Declared explicitly so a relying party enforcing RFC 7517 §4.2
+            // key-use separation (as this crate's own `Jwks::find_key` now
+            // does) sees what this key is for instead of having to assume.
+            r#use: Some("sig".to_string()),
+            key_ops: None,
         };
 
         // Same rationale as `new_asymmetric`: derive the decoding key from

--- a/crates/authkestra-oidc/tests/provider_tests.rs
+++ b/crates/authkestra-oidc/tests/provider_tests.rs
@@ -145,17 +145,10 @@ fn generate_rsa_key(kid: &str) -> TestKey {
     let n = URL_SAFE_NO_PAD.encode(private_key.n().to_bytes_be());
     let e = URL_SAFE_NO_PAD.encode(private_key.e().to_bytes_be());
 
-    let jwk = Jwk {
-        kid: Some(kid.to_string()),
-        kty: "RSA".to_string(),
-        alg: Some("RS256".to_string()),
-        n: Some(n),
-        e: Some(e),
-        crv: None,
-        x: None,
-        r#use: Some("sig".to_string()),
-        key_ops: None,
-    };
+    let jwk = Jwk::rsa(n, e)
+        .with_kid(kid)
+        .with_alg("RS256")
+        .with_use("sig");
 
     TestKey { encoding_key, jwk }
 }

--- a/crates/authkestra-oidc/tests/provider_tests.rs
+++ b/crates/authkestra-oidc/tests/provider_tests.rs
@@ -153,6 +153,8 @@ fn generate_rsa_key(kid: &str) -> TestKey {
         e: Some(e),
         crv: None,
         x: None,
+        r#use: Some("sig".to_string()),
+        key_ops: None,
     };
 
     TestKey { encoding_key, jwk }

--- a/crates/authkestra-op/src/handlers/jwks.rs
+++ b/crates/authkestra-op/src/handlers/jwks.rs
@@ -51,6 +51,8 @@ mod tests {
             e: Some("AQAB".to_string()),
             crv: None,
             x: None,
+            r#use: None,
+            key_ops: None,
         };
         let response = JwksResponse::new(Some(jwk.clone()));
         assert_eq!(response.keys.len(), 1);
@@ -67,6 +69,8 @@ mod tests {
             e: Some("AQAB".into()),
             crv: None,
             x: None,
+            r#use: None,
+            key_ops: None,
         };
         let jwk2 = Jwk {
             kty: "RSA".into(),
@@ -76,6 +80,8 @@ mod tests {
             e: Some("AQAB".into()),
             crv: None,
             x: None,
+            r#use: None,
+            key_ops: None,
         };
         let response = JwksResponse::new(vec![jwk1, jwk2]);
         assert_eq!(response.keys.len(), 2);

--- a/crates/authkestra-op/src/handlers/jwks.rs
+++ b/crates/authkestra-op/src/handlers/jwks.rs
@@ -43,17 +43,7 @@ mod tests {
 
     #[test]
     fn test_jwks_response_with_key() {
-        let jwk = Jwk {
-            kty: "RSA".to_string(),
-            alg: Some("RS256".to_string()),
-            kid: Some("123".to_string()),
-            n: Some("abc".to_string()),
-            e: Some("AQAB".to_string()),
-            crv: None,
-            x: None,
-            r#use: None,
-            key_ops: None,
-        };
+        let jwk = Jwk::rsa("abc", "AQAB").with_alg("RS256").with_kid("123");
         let response = JwksResponse::new(Some(jwk.clone()));
         assert_eq!(response.keys.len(), 1);
         assert_eq!(response.keys[0].kid.as_deref(), Some("123"));
@@ -61,28 +51,8 @@ mod tests {
 
     #[test]
     fn test_jwks_response_with_multiple_keys() {
-        let jwk1 = Jwk {
-            kty: "RSA".into(),
-            alg: Some("RS256".into()),
-            kid: Some("key-1".into()),
-            n: Some("n1".into()),
-            e: Some("AQAB".into()),
-            crv: None,
-            x: None,
-            r#use: None,
-            key_ops: None,
-        };
-        let jwk2 = Jwk {
-            kty: "RSA".into(),
-            alg: Some("RS256".into()),
-            kid: Some("key-2".into()),
-            n: Some("n2".into()),
-            e: Some("AQAB".into()),
-            crv: None,
-            x: None,
-            r#use: None,
-            key_ops: None,
-        };
+        let jwk1 = Jwk::rsa("n1", "AQAB").with_alg("RS256").with_kid("key-1");
+        let jwk2 = Jwk::rsa("n2", "AQAB").with_alg("RS256").with_kid("key-2");
         let response = JwksResponse::new(vec![jwk1, jwk2]);
         assert_eq!(response.keys.len(), 2);
         assert_eq!(response.keys[0].kid.as_deref(), Some("key-1"));

--- a/crates/authkestra-resource/src/jwt.rs
+++ b/crates/authkestra-resource/src/jwt.rs
@@ -98,10 +98,38 @@ impl Jwks {
         Ok(jwks)
     }
 
+    /// Selects the key a token should be verified against.
+    ///
+    /// Only keys that may actually *verify a signature* are considered
+    /// ([`Jwk::is_usable_for_signature_verification`]). A JWKS commonly
+    /// carries keys published for something else — a stock Keycloak realm
+    /// serves an RSA signing key and an RSA encryption key side by side,
+    /// identical in `kty` — and without this filter the `kid`-less fallback
+    /// below picks whichever of them JWKS member order happens to put first,
+    /// rejecting a good token with a bare `InvalidSignature` (#341). The
+    /// filter applies to the `kid` branch too: a `kid` naming an encryption
+    /// key is not a licence to verify with it.
+    ///
+    /// The `kid`-less fallback stays first-match, and so stays ambiguous when
+    /// a JWKS holds several *signing* keys. That ambiguity is inherent, and
+    /// [`JwksCache::require_kid`] is what closes it.
     pub fn find_key(&self, kid: Option<&str>) -> Option<&Jwk> {
+        let mut usable = self.keys.iter().filter(|k| {
+            if k.is_usable_for_signature_verification() {
+                return true;
+            }
+            tracing::warn!(
+                kid = ?k.kid,
+                key_use = ?k.r#use,
+                key_ops = ?k.key_ops,
+                "skipping a JWKS key that is not published for signature verification"
+            );
+            false
+        });
+
         match kid {
-            Some(id) => self.keys.iter().find(|k| k.kid.as_deref() == Some(id)),
-            None => self.keys.first(),
+            Some(id) => usable.find(|k| k.kid.as_deref() == Some(id)),
+            None => usable.next(),
         }
     }
 }

--- a/crates/authkestra-resource/tests/jwt_test.rs
+++ b/crates/authkestra-resource/tests/jwt_test.rs
@@ -68,9 +68,20 @@ fn generate_rsa_key(kid: Option<&str>) -> TestKey {
         e: Some(e),
         crv: None,
         x: None,
+        r#use: None,
+        key_ops: None,
     };
 
     TestKey { encoding_key, jwk }
+}
+
+/// As [`generate_rsa_key`], but stamps RFC 7517 §4.2 `use` on the published
+/// JWK — `"sig"` for a signing key, `"enc"` for an encryption key such as the
+/// RSA-OAEP key a stock Keycloak realm serves alongside its signing key.
+fn generate_rsa_key_for_use(kid: Option<&str>, key_use: &str) -> TestKey {
+    let mut key = generate_rsa_key(kid);
+    key.jwk.r#use = Some(key_use.to_string());
+    key
 }
 
 fn sign_token<T: Serialize>(key: &EncodingKey, kid: Option<&str>, claims: &T) -> String {
@@ -227,6 +238,120 @@ async fn missing_kid_falls_back_to_first_key_by_default() {
         .await
         .expect("kid-less token should fall back to the first JWKS key by default");
     assert_eq!(result.sub, "user-1");
+}
+
+/// Issue #341: a stock Keycloak realm publishes an RSA *encryption* key next to
+/// its RSA signing key, identical in `kty`. With no `kid` on the token the
+/// fallback used to take `keys.first()` — whichever JWKS member order happened
+/// to put first — so a good token could be rejected with a bare
+/// `InvalidSignature`. Key selection must skip the encryption key and find the
+/// signing key behind it.
+#[tokio::test]
+async fn missing_kid_skips_an_encryption_key_to_reach_the_signing_key() {
+    let enc = generate_rsa_key_for_use(Some("enc-key"), "enc");
+    let sig = generate_rsa_key_for_use(Some("sig-key"), "sig");
+    // Encryption key first, which is the ordering that used to break.
+    let server = start_jwks_server(vec![enc.jwk.clone(), sig.jwk.clone()]).await;
+
+    let cache = JwksCache::new(jwks_url(&server), Duration::from_secs(3600));
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.validate_aud = false;
+
+    let claims = TestClaims {
+        sub: "user-1".to_string(),
+        exp: future_exp(),
+        aud: None,
+    };
+    let token = sign_token(&sig.encoding_key, None, &claims);
+
+    let validated: TestClaims = validate_jwt_generic(&token, &cache, &validation)
+        .await
+        .expect("the encryption key must be skipped in favour of the signing key");
+    assert_eq!(validated.sub, "user-1");
+}
+
+/// A `kid` naming an encryption key is not a licence to verify with it: the
+/// filter applies to the `kid` branch too, so the key is passed over and the
+/// lookup fails closed.
+#[tokio::test]
+async fn a_kid_naming_an_encryption_key_is_refused() {
+    let enc = generate_rsa_key_for_use(Some("enc-key"), "enc");
+    let server = start_jwks_server(vec![enc.jwk.clone()]).await;
+
+    let cache = JwksCache::new(jwks_url(&server), Duration::from_secs(3600));
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.validate_aud = false;
+
+    let claims = TestClaims {
+        sub: "user-1".to_string(),
+        exp: future_exp(),
+        aud: None,
+    };
+    // Genuinely signed by that key's private half — only its declared *use*
+    // makes it unacceptable.
+    let token = sign_token(&enc.encoding_key, Some("enc-key"), &claims);
+
+    let err = validate_jwt_generic::<TestClaims>(&token, &cache, &validation)
+        .await
+        .expect_err("an encryption key must never verify a signature");
+    assert!(
+        matches!(err, ValidationError::KeyNotFound),
+        "expected the key to be passed over, got: {err}"
+    );
+}
+
+/// `key_ops` is honoured on the same footing as `use` (RFC 7517 §4.3): a key
+/// whose declared operations do not include `verify` is not a verification key.
+#[tokio::test]
+async fn a_key_whose_key_ops_exclude_verify_is_refused() {
+    let mut key = generate_rsa_key(Some("kid-1"));
+    key.jwk.key_ops = Some(vec!["encrypt".to_string()]);
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+
+    let cache = JwksCache::new(jwks_url(&server), Duration::from_secs(3600));
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.validate_aud = false;
+
+    let claims = TestClaims {
+        sub: "user-1".to_string(),
+        exp: future_exp(),
+        aud: None,
+    };
+    let token = sign_token(&key.encoding_key, Some("kid-1"), &claims);
+
+    let err = validate_jwt_generic::<TestClaims>(&token, &cache, &validation)
+        .await
+        .expect_err("a key that may not verify must not be selected");
+    assert!(
+        matches!(err, ValidationError::KeyNotFound),
+        "expected the key to be passed over, got: {err}"
+    );
+}
+
+/// The overwhelmingly common JWKS shape declares neither `use` nor `key_ops`.
+/// Those keys must stay usable, or the filter would fail closed on almost
+/// every IdP in existence.
+#[tokio::test]
+async fn a_key_declaring_neither_use_nor_key_ops_is_still_usable() {
+    let key = generate_rsa_key(Some("kid-1"));
+    assert!(key.jwk.r#use.is_none() && key.jwk.key_ops.is_none());
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+
+    let cache = JwksCache::new(jwks_url(&server), Duration::from_secs(3600));
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.validate_aud = false;
+
+    let claims = TestClaims {
+        sub: "user-1".to_string(),
+        exp: future_exp(),
+        aud: None,
+    };
+    let token = sign_token(&key.encoding_key, Some("kid-1"), &claims);
+
+    let validated: TestClaims = validate_jwt_generic(&token, &cache, &validation)
+        .await
+        .expect("a key declaring no use restriction must remain usable");
+    assert_eq!(validated.sub, "user-1");
 }
 
 #[tokio::test]

--- a/crates/authkestra-resource/tests/jwt_test.rs
+++ b/crates/authkestra-resource/tests/jwt_test.rs
@@ -60,17 +60,12 @@ fn generate_rsa_key(kid: Option<&str>) -> TestKey {
     let n = URL_SAFE_NO_PAD.encode(private_key.n().to_bytes_be());
     let e = URL_SAFE_NO_PAD.encode(private_key.e().to_bytes_be());
 
-    let jwk = Jwk {
-        kid: kid.map(|s| s.to_string()),
-        kty: "RSA".to_string(),
-        alg: Some("RS256".to_string()),
-        n: Some(n),
-        e: Some(e),
-        crv: None,
-        x: None,
-        r#use: None,
-        key_ops: None,
-    };
+    // `use`/`key_ops` are left unset on purpose: that is the shape most IdPs
+    // publish, so the existing tests keep exercising the permissive path.
+    let mut jwk = Jwk::rsa(n, e).with_alg("RS256");
+    if let Some(kid) = kid {
+        jwk = jwk.with_kid(kid);
+    }
 
     TestKey { encoding_key, jwk }
 }


### PR DESCRIPTION
Closes #341. Found while investigating #335; the root cause is unrelated to that one (see #340).

## The defect

`Jwks::find_key` considered neither RFC 7517 §4.2 `use` nor §4.3 `key_ops` — and `Jwk` did not even model them:

```rust
match kid {
    Some(id) => self.keys.iter().find(|k| k.kid.as_deref() == Some(id)),
    None => self.keys.first(),
}
```

A stock Keycloak realm serves an RSA **signing** key and an RSA **encryption** key at the same endpoint, both `kty: "RSA"`, distinguishable only by `use`/`alg`:

```json
{"keys": [
  {"kid": "...", "kty": "RSA", "alg": "RS256",    "use": "sig", ...},
  {"kid": "...", "kty": "RSA", "alg": "RSA-OAEP", "use": "enc", ...}
]}
```

With `require_kid` at its default `false`, a `kid`-less token fell back to `keys.first()`. JWKS member order is unspecified, so this intermittently selected the encryption key and rejected a good token with a bare `InvalidSignature` — a false rejection indistinguishable, to the operator, from a genuinely bad token. Separately, even a `kid`-**matched** key marked `"use": "enc"` was accepted for verification.

## Impact, stated honestly

Correctness and key-use hygiene — **not** a forgery vulnerability. An attacker still cannot sign without the private key. Cross-purpose reuse of one RSA keypair for both OAEP decryption and signing is what key-use separation exists to prevent, and Keycloak already uses distinct keys, so the realistic damage was the confusing false rejection above.

## Fix

`Jwk` carries `use` and `key_ops`; `Jwk::is_usable_for_signature_verification` filters **both** branches of `find_key`, with a `tracing::warn!` naming any skipped key's `kid` and declared use so an operator can see why it was passed over.

Only an *explicit* exclusion rejects — `use: "enc"`, or a `key_ops` present and lacking `"verify"`. A key declaring neither stays usable, because that is what most IdPs publish and refusing it would fail closed on the overwhelmingly common case.

### Deliberately unchanged

The `kid`-less fallback stays first-match, so a JWKS holding several *signing* keys remains ambiguous. That ambiguity is inherent, and `JwksCache::require_kid(true)` is what closes it.

## Tests

| Test | Covers |
| --- | --- |
| `missing_kid_skips_an_encryption_key_to_reach_the_signing_key` | The reported shape: enc key first, `kid`-less token, must still verify |
| `a_kid_naming_an_encryption_key_is_refused` | A `kid` naming an enc key is not a licence to verify with it — token genuinely signed by that key, refused on declared use alone |
| `a_key_whose_key_ops_exclude_verify_is_refused` | `key_ops` honoured on the same footing as `use` |
| `a_key_declaring_neither_use_nor_key_ops_is_still_usable` | Guards the common case — the filter must not widen into rejecting everything |

Verified by neutralising `is_usable_for_signature_verification` to `true` and re-running: the first three fail, and the fourth still passes — so they pin the defect rather than the filter merely being blanket-restrictive.

## Breaking changes — and why this should be the last one

Two, deliberately shipped together so the cost is paid once.

**1. `Jwk` gains `use` (as `r#use`) and `key_ops`.** Both `skip_serializing_if = "Option::is_none"`, so the wire format is otherwise unchanged.

**2. `Jwk` is now `#[non_exhaustive]`.**

The second exists because of how often the first keeps happening. A JWK has as many members as the RFCs care to define, so this struct gets widened whenever a new one turns out to matter — `crv`/`x` for the OKP shape, now `use`/`key_ops` for key-use separation. Because downstream could build one with a struct literal, *every one of those widenings was a breaking change for code that had nothing to do with the new field*. Same tax, again, every time.

`#[non_exhaustive]` ends the category. Construction now goes through:

```rust
let jwk = Jwk::rsa(n, e)
    .with_kid("kid-1")
    .with_alg("RS256")
    .with_use("sig");

let jwk = Jwk::ed25519(x).with_kid("kid-2").with_alg("EdDSA");
```

plus `with_key_ops`. Field reads and assignments are unaffected — only literal construction and exhaustive destructuring are restricted, and a key with some other `kty` is still reachable by deserializing one. The next field added is additive and costs downstream nothing.

This is what the rest of the crate already does: **93 of 137 public structs** carry the attribute, including this type's own containers `Jwks` and `JwksResponse` — the latter already pairing it with a `new` constructor. `Jwk` was simply missed.

No `Default` was derived, deliberately: a defaulted `Jwk` has an empty `kty` and is not a meaningful key, and `..Default::default()` would hide exactly the fields this change is about.

One deliberate wire-format addition: the OP's own published signing JWKs now declare `"use": "sig"`, so a relying party enforcing the same separation sees what the key is for. Client-registered JWKS (`authkestra-op` private_key_jwt) are parsed by `jsonwebtoken`'s own `Jwk` type and are untouched.

## Verification

All five CI gates from `.github/workflows/ci.yml` pass locally: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-features -- -D warnings`, `cargo test --workspace --all-features`, `cargo llvm-cov ... --fail-under-lines 84` (85.69%), `cargo deny check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
