### PR TITLE
fix(engine): wait on a timer in DeviceFlow::poll_for_token instead of blocking

### DIFF
--- a/crates/authkestra-engine/Cargo.toml
+++ b/crates/authkestra-engine/Cargo.toml
@@ -111,4 +111,11 @@ actix-files = "0.6"
 testcontainers = "0.27.3"
 testcontainers-modules = { version = "0.15.0", features = ["redis"] }
 wiremock = "0.6.5"
+
+# Test-only: `test-util` brings `#[tokio::test(start_paused = true)]`, which
+# `full` does not include. The device-flow tests use the paused clock to prove
+# `poll_for_token` waits on a timer rather than blocking the thread (#306) --
+# under a paused clock a real timer costs no wall-clock time, so a blocking
+# sleep is unmistakable.
+tokio = { version = "1.0", features = ["full", "test-util"] }
 authkestra-store-testsuite = { path = "../authkestra-store-testsuite" }

--- a/crates/authkestra-engine/src/flow/device_flow.rs
+++ b/crates/authkestra-engine/src/flow/device_flow.rs
@@ -3,7 +3,6 @@ use crate::auth::{
     state::OAuthToken,
 };
 use serde::{Deserialize, Serialize};
-use std::thread::sleep;
 use std::time::Duration;
 
 /// Represents the response from the device authorization endpoint.
@@ -154,7 +153,17 @@ impl DeviceFlow {
                 ));
             }
 
-            sleep(Duration::from_secs(current_interval));
+            // `tokio::time::sleep`, never `std::thread::sleep`: this is an
+            // `async fn`, so blocking the thread here parks the whole worker
+            // for the interval (5s by default, growing on `slow_down`).
+            // On a multi-thread runtime that starves every other task on
+            // that worker; on a current-thread runtime it stalls the entire
+            // executor for the length of the device ceremony (#306).
+            tracing::debug!(
+                interval_secs = current_interval,
+                "authorization still pending; waiting before polling the token endpoint again"
+            );
+            tokio::time::sleep(Duration::from_secs(current_interval)).await;
         }
     }
 }

--- a/crates/authkestra-engine/tests/device_flow_tests.rs
+++ b/crates/authkestra-engine/tests/device_flow_tests.rs
@@ -1,5 +1,8 @@
 use authkestra_engine::flow::device_flow::DeviceFlow;
 use serde_json::json;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -37,4 +40,118 @@ async fn test_initiate_device_authorization() {
     );
     assert_eq!(response.user_code, "WDJB-MJHT");
     assert_eq!(response.expires_in, 1800);
+}
+
+/// Regression test for #306: `poll_for_token` is an `async fn`, so it must
+/// wait on a timer rather than blocking the thread.
+///
+/// It used to wait with `std::thread::sleep`, parking the worker for the whole
+/// interval on every iteration — starving other tasks on a multi-thread
+/// runtime, and stalling the entire executor on a current-thread one.
+///
+/// Two independent signals, both of which the blocking version fails:
+///
+/// - A sibling task whose timer fires *during* the poll interval must have run
+///   by the time polling finishes. Under `std::thread::sleep` on this
+///   current-thread runtime the executor cannot poll it at all.
+/// - With the clock paused, a real timer costs no wall-clock time, because
+///   Tokio auto-advances virtual time whenever the runtime goes idle.
+///   `std::thread::sleep` ignores the paused clock and burns the full five
+///   seconds for real.
+#[tokio::test(start_paused = true)]
+async fn poll_for_token_waits_on_a_timer_rather_than_blocking_the_runtime() {
+    let mock_server = MockServer::start().await;
+
+    // First poll: not authorized yet, so the flow waits out one interval.
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(
+            ResponseTemplate::new(400).set_body_json(json!({ "error": "authorization_pending" })),
+        )
+        .up_to_n_times(1)
+        .mount(&mock_server)
+        .await;
+
+    // Second poll: the user has approved.
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "at_12345",
+            "token_type": "Bearer",
+            "expires_in": 3600
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let flow = DeviceFlow::new(
+        "test_client_id".to_string(),
+        format!("{}/device_auth", mock_server.uri()),
+        format!("{}/token", mock_server.uri()),
+    );
+
+    // Fires partway through the five-second interval, so it can only have run
+    // if the runtime stayed free while the flow was waiting.
+    let ran_during_the_wait = Arc::new(AtomicBool::new(false));
+    let flag = Arc::clone(&ran_during_the_wait);
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        flag.store(true, Ordering::SeqCst);
+    });
+
+    let started = Instant::now();
+    let token = flow
+        .poll_for_token("device_code_abc", Some(5))
+        .await
+        .expect("polling should return the token once authorization completes");
+    let wall_clock = started.elapsed();
+
+    assert_eq!(token.access_token, "at_12345");
+    assert!(
+        ran_during_the_wait.load(Ordering::SeqCst),
+        "a sibling task never got to run: the poll interval blocked the runtime"
+    );
+    assert!(
+        wall_clock < Duration::from_secs(1),
+        "waiting cost {wall_clock:?} of real time under a paused clock, so it was not a timer"
+    );
+}
+
+/// `slow_down` must lengthen the interval without changing how it waits.
+#[tokio::test(start_paused = true)]
+async fn slow_down_extends_the_interval_and_still_yields() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({ "error": "slow_down" })))
+        .up_to_n_times(1)
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "at_after_slow_down",
+            "token_type": "Bearer"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let flow = DeviceFlow::new(
+        "test_client_id".to_string(),
+        format!("{}/device_auth", mock_server.uri()),
+        format!("{}/token", mock_server.uri()),
+    );
+
+    let started = Instant::now();
+    let token = flow
+        .poll_for_token("device_code_abc", Some(5))
+        .await
+        .expect("polling should recover from slow_down");
+
+    assert_eq!(token.access_token, "at_after_slow_down");
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "the lengthened interval was waited out by blocking the thread"
+    );
 }


### PR DESCRIPTION
Closes #306.

## The defect

`DeviceFlow::poll_for_token` is an `async fn`, but its polling loop waited with `std::thread::sleep`:

```rust
use std::thread::sleep;          // device_flow.rs:6
...
sleep(Duration::from_secs(current_interval));   // :157, inside the async loop
```

That parks the worker thread for the whole interval on *every* iteration — five seconds by default, growing by five more on each `slow_down`. On a multi-thread runtime it starves the other tasks scheduled on that worker; on a current-thread runtime it stalls the entire executor for the length of the device ceremony, which can run for minutes while a user finishes at the verification URI.

## Fix

`tokio::time::sleep(..).await`. No dependency change — `tokio` is already a non-optional dependency of `authkestra-engine` with `features = ["full"]`.

A `tracing::debug!` goes with it, naming the interval being waited out. `slow_down` silently grew that interval before, with nothing in the logs to show it.

## Tests

`poll_for_token` had **no test at all**, so two arrive with the fix. Each fails against the blocking version for an independent reason:

| Test | Signal |
| --- | --- |
| `poll_for_token_waits_on_a_timer_rather_than_blocking_the_runtime` | A sibling task whose timer fires partway through the interval must have run by the time polling finishes. Under `std::thread::sleep` on a current-thread runtime the executor cannot poll it at all. |
| `slow_down_extends_the_interval_and_still_yields` | Covers the path that made the old behaviour worse the longer it ran, and pins the same wall-clock property. |

Both also assert that under a paused clock the wait costs no real time: Tokio auto-advances virtual time whenever the runtime goes idle, so a genuine timer is free while `std::thread::sleep` ignores the paused clock and burns the full interval.

Verified by reverting to `std::thread::sleep` and re-running: both fail, and the suite takes **10s** of real waiting instead of **0.05s**.

`test-util` joins tokio's dev-dependency features for the paused clock — `full` does not include it.

## Semver

Patch-compatible. No signature or type changes; the fix is entirely internal to the loop body.

## Verification

All five CI gates from `.github/workflows/ci.yml` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
