### PR TITLE
fix(macros): anchor derive output so the state derives work through the facade

### DIFF
--- a/crates/authkestra-actix/src/lib.rs
+++ b/crates/authkestra-actix/src/lib.rs
@@ -412,3 +412,24 @@ where
         })
     }
 }
+
+/// Re-exports the derive macros reach through. Not public API.
+///
+/// `#[derive(ActixState)]` expands to code naming `authkestra_engine` and
+/// `actix_web`. Emitting those as bare paths made the expansion depend on what
+/// the *caller* happens to have in scope, so the derive only compiled for
+/// someone with both crates as direct dependencies under exactly those
+/// names — anyone following the documented advice to depend on the
+/// `authkestra` facade got an error naming a crate they never wrote down
+/// (#332). Routing every emitted path through this module fixes that: the
+/// anchor is this crate, which the caller demonstrably *can* name, since
+/// that is where the derive itself came from.
+///
+/// A caller reaching this crate under another name — through the facade's
+/// `authkestra::actix` re-export, say — says so with
+/// `#[authkestra(crate = ...)]` on the struct.
+#[doc(hidden)]
+pub mod __private {
+    pub use actix_web;
+    pub use authkestra_engine;
+}

--- a/crates/authkestra-axum/src/lib.rs
+++ b/crates/authkestra-axum/src/lib.rs
@@ -276,3 +276,24 @@ impl<S: Clone + Send + Sync + 'static, T: Clone + Send + Sync + 'static> AxumSta
             )
     }
 }
+
+/// Re-exports the derive macros reach through. Not public API.
+///
+/// `#[derive(AxumState)]` expands to code naming `authkestra_engine` and
+/// `axum`. Emitting those as bare paths made the expansion depend on what
+/// the *caller* happens to have in scope, so the derive only compiled for
+/// someone with both crates as direct dependencies under exactly those
+/// names — anyone following the documented advice to depend on the
+/// `authkestra` facade got an error naming a crate they never wrote down
+/// (#332). Routing every emitted path through this module fixes that: the
+/// anchor is this crate, which the caller demonstrably *can* name, since
+/// that is where the derive itself came from.
+///
+/// A caller reaching this crate under another name — through the facade's
+/// `authkestra::axum` re-export, say — says so with
+/// `#[authkestra(crate = ...)]` on the struct.
+#[doc(hidden)]
+pub mod __private {
+    pub use authkestra_engine;
+    pub use axum;
+}

--- a/crates/authkestra-macros/README.md
+++ b/crates/authkestra-macros/README.md
@@ -47,6 +47,31 @@ For Axum, this eliminates the need to manually implement `FromRef` for:
 - `SessionConfig`
 - `Result<Arc<TokenManager>, AxumError>` (if tokens are configured)
 
+### Using the derives through the `authkestra` facade
+
+The expansion names the adapter crate, `authkestra_engine`, and the web
+framework. By default it reaches all three through the adapter crate under its
+own name — `authkestra_axum` / `authkestra_actix` — which is right when that is
+how you depend on it.
+
+If you reach the adapter under a different name, say through the facade's
+re-export, point the anchor at that name:
+
+```rust,ignore
+use authkestra::axum::AxumState;
+
+#[derive(Clone, AxumState)]
+#[authkestra(crate = ::authkestra::axum)]
+struct AppState {
+    #[authkestra(engine)]
+    auth: authkestra::core::AkWebAppEngine,
+}
+```
+
+Without it the derive expands to paths naming crates a facade-only dependent
+never listed, and the resulting error points at those crates rather than at the
+cause.
+
 ## Part of authkestra
 
 This crate is part of the [authkestra](https://github.com/marcjazz/authkestra) workspace.

--- a/crates/authkestra-macros/src/actix.rs
+++ b/crates/authkestra-macros/src/actix.rs
@@ -1,9 +1,38 @@
-use proc_macro::TokenStream;
+//! # Actix state derive
+//!
+//! Generates `configure_authkestra`, registering the engine's pieces as
+//! `actix_web` app data.
+//!
+//! ## Reaching the adapter under another name
+//!
+//! Every emitted path hangs off `::authkestra_actix`. A caller reaching this
+//! adapter by a different name — the facade's `authkestra::actix` re-export,
+//! say — redirects the anchor on the struct:
+//!
+//! ```rust,ignore
+//! #[derive(Clone, ActixState)]
+//! #[authkestra(crate = ::authkestra::actix)]
+//! struct AppState { /* ... */ }
+//! ```
+
+use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Data, DeriveInput, Fields, Type};
+use syn::{Data, DeriveInput, Fields, Type};
 
 pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
+    let input = match syn::parse2::<DeriveInput>(input) {
+        Ok(input) => input,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    // Every emitted path hangs off this, so the expansion never depends on
+    // what the caller happens to have in scope (#332).
+    let anchor = match crate::anchor::resolve(&input.attrs, "::authkestra_actix") {
+        Ok(anchor) => anchor,
+        Err(err) => return err.to_compile_error(),
+    };
+    let engine = quote!(#anchor::__private::authkestra_engine);
+    let web = quote!(#anchor::__private::actix_web);
 
     let struct_name = &input.ident;
     let generics = &input.generics;
@@ -37,14 +66,12 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                     &input,
                     "State can only be derived for structs with named fields",
                 )
-                .to_compile_error()
-                .into();
+                .to_compile_error();
             }
         },
         _ => {
             return syn::Error::new_spanned(&input, "State can only be derived for structs")
-                .to_compile_error()
-                .into();
+                .to_compile_error();
         }
     };
 
@@ -61,31 +88,31 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                 if ident_str == "AkWebAppEngine" {
                     (
                         syn::parse_quote!(
-                            authkestra_engine::Configured<
-                                ::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>,
+                            #engine::Configured<
+                                ::std::sync::Arc<dyn #engine::auth::SessionStore>,
                             >
                         ),
-                        syn::parse_quote!(authkestra_engine::Missing),
+                        syn::parse_quote!(#engine::Missing),
                     )
                 } else if ident_str == "AkApiEngine" {
                     (
-                        syn::parse_quote!(authkestra_engine::Missing),
+                        syn::parse_quote!(#engine::Missing),
                         syn::parse_quote!(
-                            authkestra_engine::Configured<
-                                ::std::sync::Arc<authkestra_engine::TokenManager>,
+                            #engine::Configured<
+                                ::std::sync::Arc<#engine::TokenManager>,
                             >
                         ),
                     )
                 } else if ident_str == "AkEngine" {
                     (
                         syn::parse_quote!(
-                            authkestra_engine::Configured<
-                                ::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>,
+                            #engine::Configured<
+                                ::std::sync::Arc<dyn #engine::auth::SessionStore>,
                             >
                         ),
                         syn::parse_quote!(
-                            authkestra_engine::Configured<
-                                ::std::sync::Arc<authkestra_engine::TokenManager>,
+                            #engine::Configured<
+                                ::std::sync::Arc<#engine::TokenManager>,
                             >
                         ),
                     )
@@ -97,8 +124,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                                     &field.ty,
                                     "Engine must have exactly 2 type parameters: Engine<S, T>",
                                 )
-                                .to_compile_error()
-                                .into();
+                                .to_compile_error();
                             }
                             let s = &args.args[0];
                             let t = &args.args[1];
@@ -109,8 +135,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                                 &field.ty,
                                 "Engine must have type parameters: Engine<S, T>",
                             )
-                            .to_compile_error()
-                            .into();
+                            .to_compile_error();
                         }
                     }
                 } else {
@@ -118,8 +143,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                         &field.ty,
                         "Field marked with #[authkestra(engine)] must be of type Engine<S, T>, AkWebAppEngine, AkApiEngine, or AkEngine",
                     )
-                    .to_compile_error()
-                    .into();
+                    .to_compile_error();
                 }
             }
             _ => {
@@ -127,26 +151,25 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                     &field.ty,
                     "Field marked with #[authkestra(engine)] must be a valid path type",
                 )
-                .to_compile_error()
-                .into();
+                .to_compile_error();
             }
         };
 
         config_statements.push(quote! {
-            cfg.app_data(actix_web::web::Data::new(self.#field_name.clone()));
+            cfg.app_data(#web::web::Data::new(self.#field_name.clone()));
         });
 
         let s_param_str = quote!(#s_param).to_string();
         if !s_param_str.contains("Missing") {
             config_statements.push(quote! {
-                cfg.app_data(actix_web::web::Data::new(
-                    authkestra_engine::SessionStoreState::get_store(&self.#field_name.session_store)
+                cfg.app_data(#web::web::Data::new(
+                    #engine::SessionStoreState::get_store(&self.#field_name.session_store)
                 ));
             });
         }
 
         config_statements.push(quote! {
-            cfg.app_data(actix_web::web::Data::new(
+            cfg.app_data(#web::web::Data::new(
                 self.#field_name.session_config.clone()
             ));
         });
@@ -154,8 +177,8 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
         let t_param_str = quote!(#t_param).to_string();
         if !t_param_str.contains("Missing") {
             config_statements.push(quote! {
-                cfg.app_data(actix_web::web::Data::new(
-                    authkestra_engine::TokenManagerState::get_manager(&self.#field_name.token_manager)
+                cfg.app_data(#web::web::Data::new(
+                    #engine::TokenManagerState::get_manager(&self.#field_name.token_manager)
                 ));
             });
         }
@@ -164,7 +187,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
     for field in store_fields {
         let field_name = field.ident.as_ref().unwrap();
         config_statements.push(quote! {
-            cfg.app_data(actix_web::web::Data::new(self.#field_name.clone()));
+            cfg.app_data(#web::web::Data::new(self.#field_name.clone()));
         });
     }
 
@@ -173,17 +196,79 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
             &input,
             "No field marked with #[authkestra(engine)] found. Add #[authkestra(engine)] to your Engine field."
         )
-        .to_compile_error()
-        .into();
+        .to_compile_error();
     }
 
     let expanded = quote! {
         impl #impl_generics #struct_name #ty_generics #where_clause {
-            pub fn configure_authkestra(&self, cfg: &mut actix_web::web::ServiceConfig) {
+            pub fn configure_authkestra(&self, cfg: &mut #web::web::ServiceConfig) {
                 #(#config_statements)*
             }
         }
     };
 
-    TokenStream::from(expanded)
+    expanded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expand(container_attrs: TokenStream) -> String {
+        let input = quote! {
+            #container_attrs
+            struct AppState {
+                #[authkestra(engine)]
+                auth: AkEngine,
+                #[authkestra(store)]
+                clients: ::std::sync::Arc<dyn ClientStore>,
+            }
+        };
+        derive_authkestra_state_impl(input).to_string()
+    }
+
+    /// #332, actix half. The bug was identical in both derives, so the fix and
+    /// its tests are too — covering only one would recreate exactly the
+    /// adapter asymmetry #320/#327/#329 are about.
+    #[test]
+    fn every_engine_path_is_anchored() {
+        let expanded = expand(quote!());
+
+        assert!(expanded.contains("authkestra_engine"));
+        assert_eq!(
+            expanded.matches("authkestra_engine").count(),
+            expanded
+                .matches(":: __private :: authkestra_engine")
+                .count(),
+            "some engine path is not routed through the anchor: {expanded}"
+        );
+    }
+
+    #[test]
+    fn every_actix_web_path_is_anchored() {
+        let expanded = expand(quote!());
+
+        assert!(expanded.contains("web :: Data"));
+        assert_eq!(
+            expanded.matches("web :: Data").count(),
+            expanded
+                .matches(":: __private :: actix_web :: web :: Data")
+                .count(),
+            "some actix-web path is not routed through the anchor: {expanded}"
+        );
+    }
+
+    #[test]
+    fn the_anchor_can_be_redirected_at_the_struct() {
+        let expanded = expand(quote!(#[authkestra(crate = ::authkestra::actix)]));
+
+        assert!(
+            expanded.contains(":: authkestra :: actix :: __private :: authkestra_engine"),
+            "the `crate = ...` override was ignored: {expanded}"
+        );
+        assert!(
+            !expanded.contains(":: authkestra_actix ::"),
+            "the default anchor leaked through despite the override: {expanded}"
+        );
+    }
 }

--- a/crates/authkestra-macros/src/anchor.rs
+++ b/crates/authkestra-macros/src/anchor.rs
@@ -1,0 +1,45 @@
+//! Resolving the crate path a derive's output hangs off.
+
+use syn::{Attribute, Path};
+
+/// The path the expansion routes every emitted item through.
+///
+/// Macro output must not depend on what the caller happens to have in scope.
+/// Emitting bare `authkestra_engine::` / `axum::` paths meant the derive only
+/// compiled for someone with those exact crates as direct dependencies, so a
+/// caller depending on the `authkestra` facade — the documented advice — got
+/// an error naming a crate they never wrote down (#332).
+///
+/// The default anchor is the adapter crate the derive was re-exported from,
+/// which the caller demonstrably can name. A caller reaching that crate under
+/// a different name says so on the struct:
+///
+/// ```ignore
+/// #[derive(Clone, AxumState)]
+/// #[authkestra(crate = ::authkestra::axum)]
+/// struct AppState { /* ... */ }
+/// ```
+///
+/// Unrecognised keys are left alone: field-level `engine`/`store` share this
+/// attribute, and a container may carry keys this function does not own.
+pub(crate) fn resolve(attrs: &[Attribute], default: &str) -> syn::Result<Path> {
+    let mut anchor = None;
+
+    for attr in attrs {
+        if !attr.path().is_ident("authkestra") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("crate") {
+                anchor = Some(meta.value()?.parse::<Path>()?);
+            }
+            Ok(())
+        })?;
+    }
+
+    match anchor {
+        Some(path) => Ok(path),
+        None => syn::parse_str(default),
+    }
+}

--- a/crates/authkestra-macros/src/axum.rs
+++ b/crates/authkestra-macros/src/axum.rs
@@ -20,13 +20,37 @@
 //!     db_pool: Arc<PgPool>,
 //! }
 //! ```
+//!
+//! ## Reaching the adapter under another name
+//!
+//! Every emitted path hangs off `::authkestra_axum`. A caller reaching this
+//! adapter by a different name — the facade's `authkestra::axum` re-export,
+//! say — redirects the anchor on the struct:
+//!
+//! ```rust,ignore
+//! #[derive(Clone, AxumState)]
+//! #[authkestra(crate = ::authkestra::axum)]
+//! struct AppState { /* ... */ }
+//! ```
 
-use proc_macro::TokenStream;
+use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Data, DeriveInput, Fields, Type};
+use syn::{Data, DeriveInput, Fields, Type};
 
 pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
+    let input = match syn::parse2::<DeriveInput>(input) {
+        Ok(input) => input,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    // Every emitted path hangs off this, so the expansion never depends on
+    // what the caller happens to have in scope (#332).
+    let anchor = match crate::anchor::resolve(&input.attrs, "::authkestra_axum") {
+        Ok(anchor) => anchor,
+        Err(err) => return err.to_compile_error(),
+    };
+    let engine = quote!(#anchor::__private::authkestra_engine);
+    let web = quote!(#anchor::__private::axum);
 
     // Extract struct name and generics
     let struct_name = &input.ident;
@@ -61,14 +85,12 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                     &input,
                     "AxumState can only be derived for structs with named fields",
                 )
-                .to_compile_error()
-                .into();
+                .to_compile_error();
             }
         },
         _ => {
             return syn::Error::new_spanned(&input, "AxumState can only be derived for structs")
-                .to_compile_error()
-                .into();
+                .to_compile_error();
         }
     };
 
@@ -86,31 +108,31 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                 if ident_str == "AkWebAppEngine" {
                     (
                         syn::parse_quote!(
-                            authkestra_engine::Configured<
-                                ::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>,
+                            #engine::Configured<
+                                ::std::sync::Arc<dyn #engine::auth::SessionStore>,
                             >
                         ),
-                        syn::parse_quote!(authkestra_engine::Missing),
+                        syn::parse_quote!(#engine::Missing),
                     )
                 } else if ident_str == "AkApiEngine" {
                     (
-                        syn::parse_quote!(authkestra_engine::Missing),
+                        syn::parse_quote!(#engine::Missing),
                         syn::parse_quote!(
-                            authkestra_engine::Configured<
-                                ::std::sync::Arc<authkestra_engine::TokenManager>,
+                            #engine::Configured<
+                                ::std::sync::Arc<#engine::TokenManager>,
                             >
                         ),
                     )
                 } else if ident_str == "AkEngine" {
                     (
                         syn::parse_quote!(
-                            authkestra_engine::Configured<
-                                ::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>,
+                            #engine::Configured<
+                                ::std::sync::Arc<dyn #engine::auth::SessionStore>,
                             >
                         ),
                         syn::parse_quote!(
-                            authkestra_engine::Configured<
-                                ::std::sync::Arc<authkestra_engine::TokenManager>,
+                            #engine::Configured<
+                                ::std::sync::Arc<#engine::TokenManager>,
                             >
                         ),
                     )
@@ -122,8 +144,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                                     &field.ty,
                                     "Engine must have exactly 2 type parameters: Engine<S, T>",
                                 )
-                                .to_compile_error()
-                                .into();
+                                .to_compile_error();
                             }
                             let s = &args.args[0];
                             let t = &args.args[1];
@@ -134,8 +155,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                                 &field.ty,
                                 "Engine must have type parameters: Engine<S, T>",
                             )
-                            .to_compile_error()
-                            .into();
+                            .to_compile_error();
                         }
                     }
                 } else {
@@ -143,8 +163,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                         &field.ty,
                         "Field marked with #[authkestra(engine)] must be of type Engine<S, T>, AkWebAppEngine, AkApiEngine, or AkEngine",
                     )
-                    .to_compile_error()
-                    .into();
+                    .to_compile_error();
                 }
             }
             _ => {
@@ -152,13 +171,12 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                     &field.ty,
                     "Field marked with #[authkestra(engine)] must be a valid path type",
                 )
-                .to_compile_error()
-                .into();
+                .to_compile_error();
             }
         };
 
         generated_impls.push(quote! {
-            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for authkestra_engine::Engine<#s_param, #t_param>
+            impl #impl_generics #web::extract::FromRef<#struct_name #ty_generics> for #engine::Engine<#s_param, #t_param>
             where
                 #s_param: Clone,
                 #t_param: Clone,
@@ -170,16 +188,16 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
             }
 
             #[allow(unused_imports)]
-            use authkestra_engine::{SessionStoreState as _, TokenManagerState as _};
+            use #engine::{SessionStoreState as _, TokenManagerState as _};
         });
 
         let s_param_str = quote!(#s_param).to_string();
         if !s_param_str.contains("Missing") {
             generated_impls.push(quote! {
-                impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics>
-                    for ::std::result::Result<::std::sync::Arc<dyn authkestra_engine::auth::SessionStore>, authkestra_axum::AxumError>
+                impl #impl_generics #web::extract::FromRef<#struct_name #ty_generics>
+                    for ::std::result::Result<::std::sync::Arc<dyn #engine::auth::SessionStore>, #anchor::AxumError>
                 where
-                    #s_param: authkestra_engine::SessionStoreState,
+                    #s_param: #engine::SessionStoreState,
                     #where_clause
                 {
                     fn from_ref(state: &#struct_name #ty_generics) -> Self {
@@ -190,7 +208,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
         }
 
         generated_impls.push(quote! {
-            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for authkestra_engine::SessionConfig
+            impl #impl_generics #web::extract::FromRef<#struct_name #ty_generics> for #engine::SessionConfig
             #where_clause
             {
                 fn from_ref(state: &#struct_name #ty_generics) -> Self {
@@ -202,10 +220,10 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
         let t_param_str = quote!(#t_param).to_string();
         if !t_param_str.contains("Missing") {
             generated_impls.push(quote! {
-                impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics>
-                    for ::std::result::Result<::std::sync::Arc<authkestra_engine::TokenManager>, authkestra_axum::AxumError>
+                impl #impl_generics #web::extract::FromRef<#struct_name #ty_generics>
+                    for ::std::result::Result<::std::sync::Arc<#engine::TokenManager>, #anchor::AxumError>
                 where
-                    #t_param: authkestra_engine::TokenManagerState,
+                    #t_param: #engine::TokenManagerState,
                     #where_clause
                 {
                     fn from_ref(state: &#struct_name #ty_generics) -> Self {
@@ -222,7 +240,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
         let field_ty = &field.ty;
 
         generated_impls.push(quote! {
-            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for #field_ty
+            impl #impl_generics #web::extract::FromRef<#struct_name #ty_generics> for #field_ty
             #where_clause
             {
                 fn from_ref(state: &#struct_name #ty_generics) -> Self {
@@ -230,7 +248,7 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
                 }
             }
 
-            impl #impl_generics axum::extract::FromRef<#struct_name #ty_generics> for ::std::result::Result<#field_ty, authkestra_axum::AxumError>
+            impl #impl_generics #web::extract::FromRef<#struct_name #ty_generics> for ::std::result::Result<#field_ty, #anchor::AxumError>
             #where_clause
             {
                 fn from_ref(state: &#struct_name #ty_generics) -> Self {
@@ -245,13 +263,97 @@ pub(crate) fn derive_authkestra_state_impl(input: TokenStream) -> TokenStream {
             &input,
             "No field marked with #[authkestra(engine)] found. Add #[authkestra(engine)] to your Engine field."
         )
-        .to_compile_error()
-        .into();
+        .to_compile_error();
     }
 
     let expanded = quote! {
         #(#generated_impls)*
     };
 
-    TokenStream::from(expanded)
+    expanded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expand(container_attrs: TokenStream) -> String {
+        let input = quote! {
+            #container_attrs
+            struct AppState {
+                #[authkestra(engine)]
+                auth: AkEngine,
+                #[authkestra(store)]
+                clients: ::std::sync::Arc<dyn ClientStore>,
+            }
+        };
+        derive_authkestra_state_impl(input).to_string()
+    }
+
+    /// #332: every `authkestra_engine` path must be anchored. A bare one only
+    /// resolves if the caller happens to have that exact crate as a direct
+    /// dependency, which someone depending on the `authkestra` facade does
+    /// not — and the resulting error names a crate they never wrote down.
+    #[test]
+    fn every_engine_path_is_anchored() {
+        let expanded = expand(quote!());
+
+        assert!(
+            expanded.contains("authkestra_engine"),
+            "expansion should reference the engine at all"
+        );
+        assert_eq!(
+            expanded.matches("authkestra_engine").count(),
+            expanded
+                .matches(":: __private :: authkestra_engine")
+                .count(),
+            "some engine path is not routed through the anchor: {expanded}"
+        );
+    }
+
+    /// The same applies to `axum` itself: the expansion names
+    /// `axum::extract::FromRef`, so a facade-only caller without `axum` as a
+    /// direct dependency fails there too.
+    #[test]
+    fn every_axum_path_is_anchored() {
+        let expanded = expand(quote!());
+
+        assert!(expanded.contains("extract :: FromRef"));
+        assert_eq!(
+            expanded.matches("extract :: FromRef").count(),
+            expanded
+                .matches(":: __private :: axum :: extract :: FromRef")
+                .count(),
+            "some axum path is not routed through the anchor: {expanded}"
+        );
+    }
+
+    #[test]
+    fn the_error_type_is_anchored_too() {
+        let expanded = expand(quote!());
+
+        assert!(expanded.contains("AxumError"));
+        assert_eq!(
+            expanded.matches("AxumError").count(),
+            expanded.matches(":: authkestra_axum :: AxumError").count(),
+            "some AxumError path is not routed through the anchor: {expanded}"
+        );
+    }
+
+    /// A caller reaching this crate under another name — `authkestra::axum`
+    /// through the facade — redirects the anchor rather than being stuck with
+    /// a crate name they cannot use.
+    #[test]
+    fn the_anchor_can_be_redirected_at_the_struct() {
+        let expanded = expand(quote!(#[authkestra(crate = ::authkestra::axum)]));
+
+        assert!(
+            expanded.contains(":: authkestra :: axum :: __private :: authkestra_engine"),
+            "the `crate = ...` override was ignored: {expanded}"
+        );
+        assert!(
+            !expanded.contains(":: authkestra_axum ::"),
+            "the default anchor leaked through despite the override: {expanded}"
+        );
+    }
 }

--- a/crates/authkestra-macros/src/lib.rs
+++ b/crates/authkestra-macros/src/lib.rs
@@ -1,5 +1,7 @@
 use proc_macro::TokenStream;
 
+mod anchor;
+
 #[cfg(feature = "axum")]
 mod axum;
 
@@ -11,13 +13,13 @@ mod derive;
 #[cfg(feature = "axum")]
 #[proc_macro_derive(AxumState, attributes(authkestra))]
 pub fn derive_authkestra_axum_state(input: TokenStream) -> TokenStream {
-    axum::derive_authkestra_state_impl(input)
+    axum::derive_authkestra_state_impl(input.into()).into()
 }
 
 #[cfg(feature = "actix")]
 #[proc_macro_derive(ActixState, attributes(authkestra))]
 pub fn derive_authkestra_actix_state(input: TokenStream) -> TokenStream {
-    actix::derive_authkestra_state_impl(input)
+    actix::derive_authkestra_state_impl(input.into()).into()
 }
 
 #[proc_macro_derive(KvStore, attributes(authkestra))]

--- a/crates/authkestra/tests/facade_derive_tests.rs
+++ b/crates/authkestra/tests/facade_derive_tests.rs
@@ -1,0 +1,58 @@
+//! Issue #332: the state derives must be usable by someone who depends only on
+//! the `authkestra` facade.
+//!
+//! The derives expand to code naming `authkestra_engine`, `axum`/`actix_web`
+//! and the adapter crate itself. Emitted as bare paths, those only resolved
+//! for a caller with every one of those crates as a direct dependency under
+//! exactly those names — so the documented facade-only setup failed with an
+//! error naming crates the integrator never wrote down.
+//!
+//! Every path now hangs off an anchor, and `#[authkestra(crate = ...)]` points
+//! that anchor at whatever name the caller reaches the adapter by. These tests
+//! are compile-time assertions: if the anchored paths do not resolve through
+//! the facade's re-export, the file does not build.
+//!
+//! What they cannot prove is the absence of the *original* fault, because this
+//! crate's own dev-dependencies include the adapters directly, so bare paths
+//! would resolve here too. The expansion itself is pinned by the unit tests in
+//! `authkestra-macros`, which assert no emitted path escapes the anchor.
+
+#[cfg(feature = "axum")]
+mod axum_facade {
+    use authkestra::axum::AxumState;
+
+    #[derive(Clone, AxumState)]
+    #[authkestra(crate = ::authkestra::axum)]
+    struct AppState {
+        #[authkestra(engine)]
+        auth: authkestra::core::AkWebAppEngine,
+    }
+
+    #[test]
+    fn the_axum_derive_resolves_through_the_facade() {
+        // Reaching the generated `FromRef` impl is what proves the anchored
+        // paths resolved; constructing state would need a live session store.
+        fn assert_from_ref<T: ::axum::extract::FromRef<AppState>>() {}
+        assert_from_ref::<authkestra::core::SessionConfig>();
+    }
+}
+
+#[cfg(feature = "actix")]
+mod actix_facade {
+    use authkestra::actix::ActixState;
+
+    #[derive(Clone, ActixState)]
+    #[authkestra(crate = ::authkestra::actix)]
+    struct AppState {
+        #[authkestra(engine)]
+        auth: authkestra::core::AkWebAppEngine,
+    }
+
+    #[test]
+    fn the_actix_derive_resolves_through_the_facade() {
+        // `configure_authkestra` is what the derive generates; naming it is
+        // enough to prove the anchored paths inside it resolved.
+        let _configure: fn(&AppState, &mut ::actix_web::web::ServiceConfig) =
+            AppState::configure_authkestra;
+    }
+}


### PR DESCRIPTION
Closes #332.

## The defect

Both state derives expanded to bare paths:

```rust
syn::parse_quote!(authkestra_engine::Missing)
impl ... axum::extract::FromRef<..> for authkestra_engine::Engine<..>
    for ::std::result::Result<.., authkestra_axum::AxumError>
```

Macro output should never depend on what the *caller* happens to have in scope. As written, the derive compiled only for someone with `authkestra-engine`, `authkestra-axum` **and** `axum` as direct dependencies under exactly those names. Anyone following the documented advice to depend on the `authkestra` facade got:

```
error[E0433]: cannot find module or crate `authkestra_engine` in this scope
  = note: this error originates in the derive macro `AxumState`
```

— naming a crate the integrator never wrote down.

## Two things the issue understates

**Both derives were broken, not just `AxumState`.** `actix.rs` had the identical fault (`authkestra_engine::`, `actix_web::web::Data`). Fixing only axum would recreate exactly the adapter asymmetry #320, #327 and #329 exist about, so both are fixed here.

**`axum` and `actix_web` themselves were bare too.** The issue names `authkestra_engine` and the adapter crate, but `axum::extract::FromRef` (`axum.rs:161`) and `actix_web::web::Data` fail for a facade-only caller for the same reason. All of them are anchored.

## Fix

Every emitted path hangs off one anchor, defaulting to the adapter crate the derive was re-exported from — which the caller demonstrably *can* name, since that is where the derive itself came from. A `#[doc(hidden)] pub mod __private` in each adapter re-exports `authkestra_engine` and the web framework for the anchor to reach through.

A caller reaching the adapter under another name redirects it:

```rust
use authkestra::axum::AxumState;

#[derive(Clone, AxumState)]
#[authkestra(crate = ::authkestra::axum)]
struct AppState {
    #[authkestra(engine)]
    auth: authkestra::core::AkWebAppEngine,
}
```

This is the `#[serde(crate = "...")]` shape the issue suggests.

## Tests

The `*_impl` functions now take and return `proc_macro2::TokenStream` instead of `proc_macro::TokenStream`, which makes the expansion unit-testable without a compile fixture.

**Seven expansion tests** (`authkestra-macros`) assert that no emitted path escapes the anchor. They work by *counting* — `matches("authkestra_engine").count() == matches(":: __private :: authkestra_engine").count()` — so a newly added bare path fails them rather than slipping past an allowlist. Plus one test per derive that `crate = ...` redirects the anchor and the default does not leak.

**Two facade tests** (`authkestra/tests/facade_derive_tests.rs`) compile both derives through `authkestra::axum` / `authkestra::actix`, proving the anchored paths actually resolve through a re-export rather than merely looking right as tokens.

Verified the unit tests catch the original fault by restoring one bare path: two fail immediately.

One caveat stated in the test file itself — the facade tests cannot prove the absence of the *original* fault, because this crate's dev-dependencies include the adapters directly, so bare paths would resolve there too. That half is what the counting assertions in `authkestra-macros` are for.

`authkestra-axum` derives `AxumState` on its own `AxumState` struct, so the default anchor is exercised in-tree against a real engine field.

## Semver

Patch-compatible. `__private` is additive and `#[doc(hidden)]`; `crate = ...` is an optional new attribute; the changed expansion still resolves for every caller it resolved for before.

## Docs

`crates/authkestra-macros/README.md` and both module docs gain the facade section. Per AGENTS.md the wider guides were checked — they document the direct sub-crate setup, which is unchanged here (the facade-only path is #325's territory).

## Verification

All five CI gates from `.github/workflows/ci.yml` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
