### PR TITLE
feat(facade): forward the sub-crate features the facade never exposed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "authkestra-facade-tests"
+version = "0.9.2"
+dependencies = [
+ "actix-web",
+ "authkestra",
+]
+
+[[package]]
 name = "authkestra-macros"
 version = "0.9.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/authkestra-store-sqlx",
     "crates/authkestra-example-seaorm",
     "crates/authkestra-example-diesel",
+    "crates/authkestra-facade-tests",
 ]
 
 [workspace.package]

--- a/crates/authkestra-facade-tests/Cargo.toml
+++ b/crates/authkestra-facade-tests/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "authkestra-facade-tests"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Compile-time tests that the authkestra facade reaches what it claims to"
+# Never released: this exists only to hold the facade's dependency surface
+# honest from the outside.
+publish = false
+
+[dependencies]
+
+# `authkestra` and nothing else from the workspace. That is the entire point:
+# `crates/authkestra`'s own tests cannot verify what the facade forwards,
+# because its dev-dependencies name the sub-crates directly and Cargo unifies
+# features across normal and dev dependencies. A sub-crate feature enabled
+# there is on during the test build whether or not the facade forwards it, so
+# an in-crate test passes with the forwarding entry deleted. Verified: removing
+# `authkestra-engine/webauthn` from the facade's `webauthn` feature left that
+# suite green.
+#
+# From here there is no such dependency, so every path named in `tests/` can
+# only resolve if the facade genuinely forwarded the feature.
+[dev-dependencies]
+authkestra = { path = "../authkestra", features = [
+    "session",
+    "token",
+    "actix",
+    "memory",
+    "redis",
+    "sql-sqlite",
+    "webauthn",
+    "totp",
+    "captcha",
+    "macros",
+    "op",
+    "devsig",
+] }
+# Not a workspace crate: needed to name the type the `ActixState` derive
+# generates against, and it masks nothing.
+actix-web = "4"

--- a/crates/authkestra-facade-tests/tests/feature_reachability.rs
+++ b/crates/authkestra-facade-tests/tests/feature_reachability.rs
@@ -1,0 +1,101 @@
+//! Issue #325: what the facade forwards, pinned from outside.
+//!
+//! The facade used to forward nine features while its sub-crates offered
+//! roughly twice that. Passkeys, TOTP, captcha, every persistent store, the
+//! OP server, device signatures and the `ActixState` derive were unreachable
+//! through `authkestra`, so an application wanting any of them had to depend
+//! on the sub-crates directly — which defeats the point of a facade, and is
+//! why the documented advice was to skip it.
+//!
+//! # Why this lives in its own crate
+//!
+//! `crates/authkestra`'s own tests cannot check this. Its dev-dependencies
+//! name the sub-crates directly, and Cargo unifies features across normal and
+//! dev dependencies, so a sub-crate feature enabled there is on during the
+//! test build whether or not the facade forwards it. An in-crate version of
+//! this file passed with the forwarding entry deleted — confirmed by removing
+//! `authkestra-engine/webauthn` from the facade's `webauthn` feature and
+//! watching the suite stay green.
+//!
+//! This crate depends on `authkestra` and nothing else from the workspace, so
+//! every path below resolves only if the facade genuinely forwarded the
+//! feature. The feature list lives in `Cargo.toml`; there are no `cfg` gates
+//! here, so a dropped or misspelled forwarding entry is a hard compile error
+//! rather than a silently skipped test.
+//!
+//! Paths are named rather than values constructed: the assertion is
+//! reachability, and constructing these types would drag in trait bounds that
+//! have nothing to do with it. Each `use` sits in a named `#[test]` so a break
+//! points at the feature that regressed.
+
+#[test]
+fn memory_store_is_reachable() {
+    #[allow(unused_imports)]
+    use authkestra::core::store::memory::MemoryStore;
+}
+
+#[test]
+fn redis_store_is_reachable() {
+    #[allow(unused_imports)]
+    use authkestra::core::store::redis::RedisStore;
+}
+
+/// The SQL-backed credential store, which the engine gates on
+/// `any(sql-*)` **and** `any(webauthn, totp)`. Naming it therefore asserts
+/// that both families forward, not just the `sql-*` one — the shape an
+/// application storing passkeys in Postgres actually needs.
+#[test]
+fn the_sql_credential_store_is_reachable() {
+    #[allow(unused_imports)]
+    use authkestra::core::store::sql::SqlxCredentialStore;
+}
+
+#[test]
+fn webauthn_is_reachable() {
+    #[allow(unused_imports)]
+    use authkestra::core::auth::webauthn::WebAuthnAuthMethod;
+}
+
+#[test]
+fn totp_is_reachable() {
+    #[allow(unused_imports)]
+    use authkestra::core::auth::totp::TotpAuthMethod;
+}
+
+#[test]
+fn captcha_is_reachable() {
+    let _ = authkestra::core::CaptchaProvider::Turnstile;
+    #[allow(unused_imports)]
+    use authkestra::core::CaptchaVerifier;
+}
+
+#[test]
+fn the_op_server_is_reachable() {
+    // Forwarding the adapters' `op` feature without this crate would leave
+    // the routes mounted but unconfigurable: `OpConfig` lives here.
+    #[allow(unused_imports)]
+    use authkestra::core::oauth2::client::ClientRegistration;
+    #[allow(unused_imports)]
+    use authkestra::op::{config::OpConfig, CloneableOpStore};
+}
+
+#[test]
+fn device_signatures_are_reachable() {
+    #[allow(unused_imports)]
+    use authkestra::devsig::DeviceIdentity;
+}
+
+/// The state derives. `macros` is the only route to `ActixState` through the
+/// facade — the `axum` feature already carries `AxumState`, which is the
+/// asymmetry this feature works around without changing it.
+#[test]
+fn the_actix_state_derive_is_reachable() {
+    #[derive(Clone, authkestra::actix::ActixState)]
+    #[authkestra(crate = ::authkestra::actix)]
+    struct AppState {
+        #[authkestra(engine)]
+        auth: authkestra::core::AkWebAppEngine,
+    }
+
+    let _: fn(&AppState, &mut ::actix_web::web::ServiceConfig) = AppState::configure_authkestra;
+}

--- a/crates/authkestra/Cargo.toml
+++ b/crates/authkestra/Cargo.toml
@@ -17,6 +17,8 @@ authkestra-axum = { workspace = true, optional = true, default-features = false 
 authkestra-actix = { workspace = true, optional = true, default-features = false }
 authkestra-providers = { workspace = true, optional = true, default-features = false }
 authkestra-resource = { workspace = true, optional = true, default-features = false }
+authkestra-op = { workspace = true, optional = true, default-features = false }
+authkestra-devsig = { workspace = true, optional = true }
 
 [dev-dependencies]
 reqwest = { version = "0.13", default-features = false, features = ["json"] }
@@ -74,6 +76,7 @@ rustls-aws-lc-rs = [
     "authkestra-actix?/rustls-aws-lc-rs",
     "authkestra-providers?/rustls-aws-lc-rs",
     "authkestra-resource?/rustls-aws-lc-rs",
+    "authkestra-op?/rustls-aws-lc-rs",
 ]
 rustls-no-provider = [
     "authkestra-engine/rustls-no-provider",
@@ -82,6 +85,7 @@ rustls-no-provider = [
     "authkestra-actix?/rustls-no-provider",
     "authkestra-providers?/rustls-no-provider",
     "authkestra-resource?/rustls-no-provider",
+    "authkestra-op?/rustls-no-provider",
 ]
 
 # Core features
@@ -99,6 +103,39 @@ actix = ["dep:authkestra-actix", "authkestra-actix/session", "authkestra-actix/t
 github = ["authkestra-providers/github"]
 google = ["authkestra-providers/google"]
 discord = ["authkestra-providers/discord"]
+
+# Storage backends. Forwarded to the engine, and to `authkestra-op` where it
+# has a matching backend of its own, so an application picks a store once
+# rather than per sub-crate.
+memory = ["authkestra-engine/memory"]
+redis = ["authkestra-engine/redis", "authkestra-op?/redis"]
+sql-postgres = ["authkestra-engine/sql-postgres"]
+sql-mysql = ["authkestra-engine/sql-mysql"]
+sql-sqlite = ["authkestra-engine/sql-sqlite"]
+
+# Authentication methods beyond sessions and OAuth.
+webauthn = ["authkestra-engine/webauthn"]
+totp = ["authkestra-engine/totp"]
+captcha = [
+    "authkestra-engine/captcha",
+    "authkestra-axum?/captcha",
+    "authkestra-actix?/captcha",
+]
+
+# Adapter extras. `?` throughout: turning one of these on must not drag in a
+# web framework the application never asked for.
+#
+# `macros` is a no-op for axum, whose facade feature already enables it, and
+# is the only way to reach the `ActixState` derive — that asymmetry predates
+# this and is left alone here, since removing it from `axum` would break
+# anyone relying on it.
+macros = ["authkestra-axum?/macros", "authkestra-actix?/macros"]
+op = ["dep:authkestra-op", "authkestra-axum?/op", "authkestra-actix?/op"]
+devsig = [
+    "dep:authkestra-devsig",
+    "authkestra-axum?/devsig",
+    "authkestra-actix?/devsig",
+]
 
 
 

--- a/crates/authkestra/src/lib.rs
+++ b/crates/authkestra/src/lib.rs
@@ -26,6 +26,20 @@ pub use authkestra_axum as axum;
 #[cfg(feature = "actix")]
 pub use authkestra_actix as actix;
 
+/// The OpenID Provider server: `OpConfig`, `OpStore` and the handlers the
+/// adapters' `op` routes are built from.
+///
+/// Re-exported alongside the adapters' `op` feature because those routes are
+/// configured with types from this crate — forwarding the feature without it
+/// would leave the endpoints reachable but unconfigurable (#325).
+#[cfg(feature = "op")]
+pub use authkestra_op as op;
+
+/// Device and service signatures: `DeviceIdentity`, `SignedRequest` and the
+/// verification entry points the adapters' `devsig` layers wrap.
+#[cfg(feature = "devsig")]
+pub use authkestra_devsig as devsig;
+
 /// Authentication providers.
 pub mod providers {
     #[cfg(feature = "github")]


### PR DESCRIPTION
Refs #325 — the **additive half only**. The restructuring half is deliberately left for the breaking release; see below.

## What was unreachable

The facade forwarded nine features while its sub-crates offered roughly twice that. Passkeys, TOTP, captcha, every persistent store, the OP server, device signatures and the `ActixState` derive could not be reached through `authkestra` at all — so an application wanting any of them had to depend on the sub-crates directly, which is what the docs advised, and which defeats the point of a facade.

## Forwarded now

`memory`, `redis`, `sql-postgres`, `sql-mysql`, `sql-sqlite`, `webauthn`, `totp`, `captcha`, `macros`, `op`, `devsig`.

Adapter-facing entries use `?` throughout, so turning one on never drags in a web framework the application never asked for. Verified with `cargo tree -e normal`: `--features op` pulls **neither** adapter; `--features op,axum` pulls axum.

**`op` and `devsig` also add the underlying crates**, re-exported as `authkestra::op` / `authkestra::devsig`. Forwarding the adapters' features alone would mount the routes while leaving them unconfigurable — `OpConfig` and `CloneableOpStore` live in `authkestra-op`, and nothing re-exports them. The OP example imports `authkestra_op::{client::ClientRegistration, config::OpConfig}` directly, which is exactly what a facade-only user could not do.

## Deliberately excluded

Each of these changes existing behaviour rather than adding to it, so each belongs with the restructuring:

- **The engine stays non-optional**, pinned to `features = ["token"]`. Making it optional is what lets `--no-default-features` yield an empty facade, but it changes what existing feature sets compile — `session = ["authkestra-engine/session"]` currently *enables* a non-optional dep, and switching to `?` syntax would quietly turn it into a no-op.
- **`full` is unchanged.** Widening it would pull redis and three sqlx backends into every `features = ["full"]` build, native dependencies and all.
- **`urlencoding` is not forwarded.** It is a deliberate no-op in `authkestra-providers`, kept for backward compatibility; forwarding it would advertise a switch that does nothing.
- **The `axum`/`actix` macros asymmetry is left alone.** `axum` enables `authkestra-axum/macros`; `actix` does not enable the actix equivalent. The new `macros` feature makes the derive reachable for both, which is the actual gap. Removing it from `axum` would break anyone relying on it.

## The tests, and why they live in a new crate

This is the part worth reviewing.

The reachability tests are in a new `publish = false` member, `authkestra-facade-tests`, that depends on `authkestra` **and nothing else** from the workspace. That is not tidiness — it is the only arrangement that works.

`crates/authkestra`'s own dev-dependencies name the sub-crates directly:

```toml
authkestra-engine = { workspace = true, features = ["token", "session", "memory", "redis", "totp", "webauthn"] }
```

Cargo unifies features across normal and dev dependencies, so those are on during any test build in that crate **whether or not the facade forwards them**. I wrote this test suite in-crate first, and it passed with `authkestra-engine/webauthn` deleted from the `webauthn` feature — a completely green suite asserting nothing.

From the new crate, deleting that same entry fails the build:

```
error[E0432]: unresolved import `authkestra::core::auth::webauthn`
   |                                 ^^^^^^^^ could not find `webauthn` in `auth`
```

Nine tests, one per forwarded capability. There are no `cfg` gates — the feature set is pinned by the dependency, so a dropped or misspelled entry is a hard compile error rather than a silently skipped test.

One detail found while writing them: `SqlxCredentialStore` is gated on `any(sql-*)` **and** `any(webauthn, totp)`, so that test asserts the conjunction. The name and comment say so rather than implying it tests `sql-*` alone.

## Semver

Patch-compatible. New features and two new optional dependencies are additive; no existing feature's meaning changes.

## Verification

All eleven new features were also checked in isolation (`cargo check -p authkestra --features X`) and in adapter combinations. All five CI gates pass locally: `fmt`, `clippy`, `test`, `coverage` (85.98%), `deny`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
