### PR TITLE
test(facade): move the facade tests where they can actually fail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,8 @@ version = "0.9.2"
 dependencies = [
  "actix-web",
  "authkestra",
+ "axum",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/authkestra-facade-tests/Cargo.toml
+++ b/crates/authkestra-facade-tests/Cargo.toml
@@ -26,6 +26,7 @@ publish = false
 authkestra = { path = "../authkestra", features = [
     "session",
     "token",
+    "axum",
     "actix",
     "memory",
     "redis",
@@ -37,6 +38,9 @@ authkestra = { path = "../authkestra", features = [
     "op",
     "devsig",
 ] }
-# Not a workspace crate: needed to name the type the `ActixState` derive
-# generates against, and it masks nothing.
+# None of these are workspace crates, so none of them mask anything. The web
+# frameworks are needed only to name the types the state derives generate
+# against (`FromRef`, `ServiceConfig`); tokio, to run the async tests.
 actix-web = "4"
+axum = "0.8.8"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/authkestra-facade-tests/tests/derive_reachability.rs
+++ b/crates/authkestra-facade-tests/tests/derive_reachability.rs
@@ -12,12 +12,17 @@
 //! are compile-time assertions: if the anchored paths do not resolve through
 //! the facade's re-export, the file does not build.
 //!
-//! What they cannot prove is the absence of the *original* fault, because this
-//! crate's own dev-dependencies include the adapters directly, so bare paths
-//! would resolve here too. The expansion itself is pinned by the unit tests in
-//! `authkestra-macros`, which assert no emitted path escapes the anchor.
+//! These moved here from `crates/authkestra/tests/`, where they could not
+//! prove the absence of the original fault: that crate's dev-dependencies name
+//! the adapters directly, so the bare paths the bug emitted would have
+//! resolved there too. This crate depends on `authkestra` and nothing else
+//! from the workspace, so an unanchored path in the expansion fails to
+//! resolve here exactly as it did for the reporter. See this crate's
+//! `Cargo.toml` for why that distinction is load-bearing.
+//!
+//! The expansion is separately pinned by unit tests in `authkestra-macros`,
+//! which assert no emitted path escapes the anchor at all.
 
-#[cfg(feature = "axum")]
 mod axum_facade {
     use authkestra::axum::AxumState;
 
@@ -37,7 +42,6 @@ mod axum_facade {
     }
 }
 
-#[cfg(feature = "actix")]
 mod actix_facade {
     use authkestra::actix::ActixState;
 

--- a/crates/authkestra-facade-tests/tests/feature_reachability.rs
+++ b/crates/authkestra-facade-tests/tests/feature_reachability.rs
@@ -88,14 +88,12 @@ fn device_signatures_are_reachable() {
 /// The state derives. `macros` is the only route to `ActixState` through the
 /// facade — the `axum` feature already carries `AxumState`, which is the
 /// asymmetry this feature works around without changing it.
+///
+/// Reachability only: `derive_reachability.rs` exercises both derives properly.
 #[test]
-fn the_actix_state_derive_is_reachable() {
-    #[derive(Clone, authkestra::actix::ActixState)]
-    #[authkestra(crate = ::authkestra::actix)]
-    struct AppState {
-        #[authkestra(engine)]
-        auth: authkestra::core::AkWebAppEngine,
-    }
-
-    let _: fn(&AppState, &mut ::actix_web::web::ServiceConfig) = AppState::configure_authkestra;
+fn the_state_derives_are_reachable() {
+    #[allow(unused_imports)]
+    use authkestra::actix::ActixState;
+    #[allow(unused_imports)]
+    use authkestra::axum::AxumState;
 }

--- a/crates/authkestra-facade-tests/tests/typestate.rs
+++ b/crates/authkestra-facade-tests/tests/typestate.rs
@@ -1,5 +1,21 @@
+//! The typestate builder, driven entirely through the facade.
+//!
+//! `Authkestra::builder()` is the facade's own entry point, so this belongs
+//! with the other facade tests. It moved here from `crates/authkestra/tests/`
+//! for the reason given in this crate's `Cargo.toml`: there it reached
+//! `authkestra_engine::` directly for `Identity` and `MemoryStore`, which
+//! resolved through that crate's dev-dependencies rather than through
+//! anything the facade forwards.
+//!
+//! It was declared `required-features = ["full"]`, yet `full` does not include
+//! `memory` — the store it builds with. It compiled anyway, because the
+//! dev-dependency enabled `memory` regardless. Reaching both types through
+//! `authkestra::core` from here makes the test depend on the `memory`
+//! forwarding it always implicitly relied on.
+
+use authkestra::core::state::Identity;
+use authkestra::core::store::memory::MemoryStore;
 use authkestra::Authkestra;
-use authkestra_engine::state::Identity;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -7,9 +23,7 @@ use std::sync::Arc;
 async fn test_typestate_session_flow() {
     let builder = Authkestra::builder();
     let auth = builder
-        .session_store(Arc::new(
-            authkestra_engine::store::memory::MemoryStore::default(),
-        ))
+        .session_store(Arc::new(MemoryStore::default()))
         .build();
 
     // create_session should be available
@@ -52,9 +66,7 @@ fn test_typestate_token_flow() {
 #[tokio::test]
 async fn test_typestate_full_flow() {
     let auth = Authkestra::builder()
-        .session_store(Arc::new(
-            authkestra_engine::store::memory::MemoryStore::default(),
-        ))
+        .session_store(Arc::new(MemoryStore::default()))
         .jwt_secret(b"secret")
         .build();
 

--- a/crates/authkestra/Cargo.toml
+++ b/crates/authkestra/Cargo.toml
@@ -136,29 +136,3 @@ devsig = [
     "authkestra-axum?/devsig",
     "authkestra-actix?/devsig",
 ]
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-[[test]]
-name = "typestate_tests"
-required-features = ["full"]
-

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -57,3 +57,20 @@ version_group = "authkestra"
 [[package]]
 name = "authkestra-store-testsuite"
 version_group = "authkestra"
+
+# Workspace members that exist only to be built and tested, never shipped.
+# Each already carries `publish = false`, which keeps `cargo publish` away from
+# them; `release = false` says the same thing to release-plz explicitly, so
+# they are also left out of version bumps, changelogs and release PRs rather
+# than relying on it inferring intent from the manifest.
+[[package]]
+name = "authkestra-facade-tests"
+release = false
+
+[[package]]
+name = "authkestra-example-seaorm"
+release = false
+
+[[package]]
+name = "authkestra-example-diesel"
+release = false


### PR DESCRIPTION
Follow-up to #347. Moves the remaining facade tests into `authkestra-facade-tests`, and makes release-plz's exclusion of the build-only members explicit.

## Why `crates/authkestra/tests/` cannot host a facade test

That crate's dev-dependencies name the sub-crates directly:

```toml
authkestra-engine = { workspace = true, features = ["token", "session", "memory", "redis", "totp", "webauthn"] }
```

Cargo unifies features across normal and dev dependencies, so a path resolves during those tests whether or not the facade is what made it resolvable. Both moved suites were weakened by exactly that.

### `facade_derive_tests.rs` → `derive_reachability.rs`

This one admitted the problem in its own module doc when it was written: it could not prove the absence of #332's fault, because the bare `authkestra_engine::` paths the bug emitted would have resolved through those dev-dependencies too.

From the new crate they do not. Re-introducing a single bare path in the macro now fails the build:

```
error[E0432]: unresolved import `authkestra_engine`
   |                     ^^^^^^^^^ use of unresolved module or unlinked crate `authkestra_engine`
```

That is the reporter's exact error from #332, now reproduced by the test suite rather than only described in a comment.

### `typestate_tests.rs` → `typestate.rs`

Subtler, and worth flagging. It declared `required-features = ["full"]` and built with `MemoryStore` — but **`full` does not include `memory`**. It compiled because the dev-dependency enabled `memory` regardless, so the `required-features` line never described what the test actually needed.

It now reaches `Identity` and `MemoryStore` through `authkestra::core`, so it depends on the `memory` forwarding it had always implicitly relied on. The misleading `required-features` declaration is gone.

### `examples_e2e.rs` stays

It spawns the facade crate's own example binaries and asserts on those. It tests the examples, not the facade's surface, and moving it would separate it from the binaries it drives.

## Deduplication

The overlapping `ActixState` case in `feature_reachability.rs` narrows to a plain reachability check covering both derives, since `derive_reachability.rs` now exercises them properly.

## release-plz

All three build-and-test-only members already carry `publish = false`, which is what keeps `cargo publish` away from them. `release = false` now says the same thing to release-plz directly, so they are also left out of version bumps, changelogs and release PRs rather than depending on it inferring intent from the manifest.

Applied to all three rather than only the new crate, so the exclusion is uniform instead of leaving `authkestra-example-seaorm` and `authkestra-example-diesel` excluded only incidentally. Every workspace member now has an entry: thirteen in the `authkestra` version group, three excluded. Verified the file still parses and resolves as intended (16 packages, 3 with `release = false`).

## Result

`authkestra-facade-tests` now holds 14 tests — 2 derive, 9 reachability, 3 typestate — all of which fail if the facade stops forwarding what they name.

## Verification

All five CI gates pass locally: `fmt`, `clippy`, `test`, `coverage` (87.11%, up from 85.98%), `deny`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
