### PR TITLE
fix(ci): stop giving unpublished crates a release-plz entry

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -58,19 +58,20 @@ version_group = "authkestra"
 name = "authkestra-store-testsuite"
 version_group = "authkestra"
 
-# Workspace members that exist only to be built and tested, never shipped.
-# Each already carries `publish = false`, which keeps `cargo publish` away from
-# them; `release = false` says the same thing to release-plz explicitly, so
-# they are also left out of version bumps, changelogs and release PRs rather
-# than relying on it inferring intent from the manifest.
-[[package]]
-name = "authkestra-facade-tests"
-release = false
-
-[[package]]
-name = "authkestra-example-seaorm"
-release = false
-
-[[package]]
-name = "authkestra-example-diesel"
-release = false
+# Crates that are never shipped — `authkestra-facade-tests`,
+# `authkestra-example-seaorm`, `authkestra-example-diesel` — are excluded by
+# `publish = false` in their own `Cargo.toml`, and must NOT be given a
+# `[[package]]` entry here.
+#
+# release-plz reads that manifest flag and cross-checks it against this file.
+# A `[[package]]` block materialises this file's defaults for that package,
+# `publish = true` among them, so merely adding an entry — even one whose only
+# key is `release = false` — contradicts the manifest and aborts the run
+# before any release happens:
+#
+#     ERROR Package `authkestra-example-seaorm` has `publish = false` or
+#     `publish = []` in the Cargo.toml, but it has `publish = true` in the
+#     release-plz configuration.
+#
+# The manifest is the single source of truth by design. Adding entries to
+# "make the exclusion explicit" is what broke the release run after #348.


### PR DESCRIPTION
Fixes the release-plz failure on main introduced by #348.

## The failure

```
ERROR Package `authkestra-example-seaorm` has `publish = false` or `publish = []`
in the Cargo.toml, but it has `publish = true` in the release-plz configuration.
```

## What I got wrong in #348

I added `[[package]]` entries carrying `release = false` for the three crates that are never shipped, reasoning that stating the exclusion explicitly beat letting release-plz infer it from the manifest.

That reasoning was wrong in a way the tool actively rejects. A `[[package]]` block materialises this file's defaults for that package — `publish = true` among them — so an entry whose *only* key is `release = false` still contradicts `publish = false` in the manifest. release-plz cross-checks the two and aborts before releasing anything.

## The manifest flag was already sufficient

The same failing run proves it. release-plz built the release PR with exactly the thirteen publishable crates and none of the three excluded ones, then failed only when the `release` step re-validated the config:

```
release_pr_output: {"prs":[{... "releases":[
  authkestra-crypto-util, authkestra-engine, authkestra-resource, authkestra-op,
  authkestra-store-testsuite, authkestra-store-sqlx, authkestra-providers,
  authkestra-devsig, authkestra-macros, authkestra-axum, authkestra-oidc,
  authkestra-actix, authkestra ]}]}
```

`publish = false` in `Cargo.toml` is what release-plz reads, and it is the single source of truth by design — which is exactly why it refuses to run when this file disagrees.

## The fix

The three entries are removed. `release-plz.toml` is now **byte-identical to the last version that released successfully** apart from an added comment recording why the entries must not come back, with the error message quoted so the next person doesn't repeat it.

`publish = false` remains set in all three manifests, unchanged.

## Verification

`release-plz.toml` parses with 13 `[[package]]` entries, matching the pre-#348 state exactly (`git diff 6a4ae538 -- release-plz.toml` shows only the comment). `fmt` and `deny` pass locally; the rest of CI is unaffected by a config-only change.

The real proof is the next run on main after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)