### PR TITLE
feat(engine): name and expose the clock-skew leeway JWT validation applies

### DIFF
--- a/crates/authkestra-engine/src/token/mod.rs
+++ b/crates/authkestra-engine/src/token/mod.rs
@@ -214,6 +214,22 @@ pub struct Claims {
     pub extra: HashMap<String, serde_json::Value>,
 }
 
+/// Clock-skew allowance applied to `exp` and `nbf` when validating a JWT, in
+/// seconds.
+///
+/// A token is accepted for this long *after* its `exp`, and this long *before*
+/// its `nbf`, absorbing the disagreement between the issuer's clock and the
+/// validator's. Sixty seconds is `jsonwebtoken`'s own default, which this
+/// crate used implicitly — and silently — before it was named here (#350).
+///
+/// It is a single constant, and `authkestra-resource`'s [`ValidationConfig`]
+/// defaults to it too, so the tolerance is stated once rather than restated
+/// per validation site. Downstream code that needs to size a token's lifetime
+/// against it can name it instead of hardcoding 60.
+///
+/// [`ValidationConfig`]: https://docs.rs/authkestra-resource
+pub const DEFAULT_LEEWAY_SECS: u64 = 60;
+
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct TokenManager {
@@ -223,6 +239,9 @@ pub struct TokenManager {
     kid: Option<String>,
     alg: Algorithm,
     public_jwk: Option<crate::token::jwk::Jwk>,
+    /// Clock-skew allowance for `exp`/`nbf`, in seconds. See
+    /// [`TokenManager::with_leeway`].
+    leeway: u64,
 }
 
 impl TokenManager {
@@ -235,6 +254,7 @@ impl TokenManager {
             kid: None,
             alg: Algorithm::HS256,
             public_jwk: None,
+            leeway: DEFAULT_LEEWAY_SECS,
         }
     }
 
@@ -290,6 +310,7 @@ impl TokenManager {
             kid: Some(kid_val),
             alg: Algorithm::RS256,
             public_jwk: Some(jwk),
+            leeway: DEFAULT_LEEWAY_SECS,
         })
     }
 
@@ -348,7 +369,40 @@ impl TokenManager {
             kid: Some(kid_val),
             alg: Algorithm::EdDSA,
             public_jwk: Some(jwk),
+            leeway: DEFAULT_LEEWAY_SECS,
         })
+    }
+
+    /// Sets the clock-skew allowance applied to `exp` and `nbf` when
+    /// validating, in seconds.
+    ///
+    /// Defaults to [`DEFAULT_LEEWAY_SECS`] (60), which is what this crate
+    /// inherited from `jsonwebtoken` before the value was ever named (#350).
+    /// A token therefore keeps validating for about a minute past its `exp`
+    /// unless this is lowered.
+    ///
+    /// Set it to `0` when the issuer and the validator share a clock, or in a
+    /// test that asserts a token is rejected once it expires — with the
+    /// default, "issue a one-second token, sleep, assert rejection" passes
+    /// when it should fail, and the time goes into looking for a bug that
+    /// isn't there.
+    ///
+    /// ```
+    /// # use authkestra_engine::token::TokenManager;
+    /// let manager = TokenManager::new(b"secret", None).with_leeway(0);
+    /// ```
+    ///
+    /// Raising it instead widens the window in which an expired token is
+    /// still honoured, so it trades revocation latency for tolerance of
+    /// badly-synchronised clocks.
+    pub fn with_leeway(mut self, seconds: u64) -> Self {
+        self.leeway = seconds;
+        self
+    }
+
+    /// The configured clock-skew allowance, in seconds.
+    pub fn leeway(&self) -> u64 {
+        self.leeway
     }
 
     pub fn public_jwk(&self) -> Option<crate::token::jwk::Jwk> {
@@ -610,12 +664,24 @@ impl TokenManager {
         encode(&header, &claims, &self.encoding_key).map_err(|e| AuthError::Token(e.to_string()))
     }
 
+    /// Validates a token's signature and claims, returning them on success.
+    ///
+    /// # Clock skew
+    ///
+    /// `exp` and `nbf` are checked with a tolerance of
+    /// [`TokenManager::leeway`] seconds, [`DEFAULT_LEEWAY_SECS`] by default,
+    /// so a token is accepted for roughly a minute past its expiry unless
+    /// [`TokenManager::with_leeway`] lowers it. This was inherited silently
+    /// from `jsonwebtoken` until #350; it is set explicitly here now, so the
+    /// window this crate honours no longer depends on a transitive
+    /// dependency's default.
     pub fn validate_token(
         &self,
         token: &str,
         expected_aud: Option<&str>,
     ) -> Result<Claims, AuthError> {
         let mut validation = Validation::new(self.alg);
+        validation.leeway = self.leeway;
         if let Some(aud) = expected_aud {
             validation.set_audience(&[aud]);
         } else {
@@ -1732,3 +1798,148 @@ MC4CAQAwBQYDK2VwBCIEIPlsnSfvh53rJ+Tlbo8e7cgq2mIkWQ1NCM5paVeinUh8
     }
 }
 pub mod jwk;
+
+/// Issue #350: the clock-skew tolerance applied to `exp`/`nbf` used to be
+/// `jsonwebtoken`'s default, inherited silently — invisible from the
+/// signature, absent from the docs, and with no way to change it.
+#[cfg(test)]
+mod leeway_tests {
+    use super::*;
+    use crate::auth::state::Identity;
+    use jsonwebtoken::EncodingKey;
+    use std::collections::HashMap;
+
+    const SECRET: &[u8] = b"a-test-signing-key-for-leeway-tests";
+
+    /// Mints an HS256 token whose `exp` is `seconds_ago` in the past.
+    ///
+    /// Signed here rather than through `issue_user_token`, which can only
+    /// place `exp` at or after *now*: a zero TTL yields `exp == iat == now`,
+    /// which is not yet expired even at zero tolerance. The alternative —
+    /// issuing a one-second token and sleeping — is exactly the shape #350
+    /// reports as confusing, and would make these tests slow and timing
+    /// dependent for no gain.
+    fn token_expired(seconds_ago: usize) -> String {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as usize;
+        let claims = Claims {
+            iss: None,
+            sub: "user-1".to_string(),
+            aud: Some(Audience::Single("api".to_string())),
+            exp: now - seconds_ago,
+            iat: now - seconds_ago - 1,
+            nbf: None,
+            jti: None,
+            scope: None,
+            identity: Some(Identity {
+                provider_id: "test".to_string(),
+                external_id: "user-1".to_string(),
+                email: None,
+                username: None,
+                attributes: HashMap::new(),
+            }),
+            extra: HashMap::new(),
+        };
+        encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(SECRET),
+        )
+        .expect("signing should succeed")
+    }
+
+    fn manager() -> TokenManager {
+        TokenManager::new(SECRET, None)
+    }
+
+    /// Pins the claim made in `DEFAULT_LEEWAY_SECS`'s own documentation.
+    ///
+    /// The value is now set explicitly at every validation site, so a change
+    /// upstream would not alter behaviour — it would just quietly make the
+    /// docs wrong about where the number came from. This keeps them honest.
+    #[test]
+    fn the_default_matches_the_jsonwebtoken_default_it_documents() {
+        assert_eq!(
+            Validation::new(Algorithm::HS256).leeway,
+            DEFAULT_LEEWAY_SECS,
+            "DEFAULT_LEEWAY_SECS no longer matches jsonwebtoken's default; \
+             update the docs that say it does"
+        );
+    }
+
+    /// The surprise reported in #350: a token that expired half a minute ago
+    /// still validates, because the inherited tolerance covers it.
+    #[test]
+    fn a_token_expired_within_the_default_leeway_is_still_accepted() {
+        assert!(
+            manager()
+                .validate_token(&token_expired(30), Some("api"))
+                .is_ok(),
+            "the documented 60s tolerance should still accept this token"
+        );
+    }
+
+    /// The tolerance is a window, not a licence: past it, the token is gone.
+    #[test]
+    fn a_token_expired_beyond_the_default_leeway_is_rejected() {
+        let err = manager()
+            .validate_token(
+                &token_expired(DEFAULT_LEEWAY_SECS as usize + 60),
+                Some("api"),
+            )
+            .expect_err("beyond the tolerance the token must be refused");
+        assert!(
+            err.to_string().contains("ExpiredSignature"),
+            "expected an expiry rejection, got: {err}"
+        );
+    }
+
+    /// `with_leeway(0)` is the knob that makes validation behave the way the
+    /// person writing "issue, expire, assert rejected" expected all along.
+    /// Same token, both settings, so the contrast is the assertion.
+    #[test]
+    fn with_leeway_zero_rejects_a_token_the_default_would_accept() {
+        let token = token_expired(5);
+
+        assert!(
+            manager().validate_token(&token, Some("api")).is_ok(),
+            "precondition: the default tolerance accepts this token"
+        );
+
+        let err = manager()
+            .with_leeway(0)
+            .validate_token(&token, Some("api"))
+            .expect_err("with no tolerance an expired token must be refused");
+        assert!(
+            err.to_string().contains("ExpiredSignature"),
+            "expected an expiry rejection, got: {err}"
+        );
+    }
+
+    /// A token still inside its lifetime is unaffected: this is a tolerance
+    /// on expiry, not a cap on it.
+    #[test]
+    fn a_live_token_is_accepted_with_no_leeway_at_all() {
+        let identity = Identity {
+            provider_id: "test".to_string(),
+            external_id: "user-1".to_string(),
+            email: None,
+            username: None,
+            attributes: HashMap::new(),
+        };
+        let manager = manager().with_leeway(0);
+        let token = manager
+            .issue_user_token(identity, 3600, None, Some("api".to_string()))
+            .expect("issuing should succeed");
+
+        assert!(manager.validate_token(&token, Some("api")).is_ok());
+    }
+
+    #[test]
+    fn the_configured_value_is_readable_back() {
+        assert_eq!(manager().leeway(), DEFAULT_LEEWAY_SECS);
+        assert_eq!(manager().with_leeway(5).leeway(), 5);
+    }
+}

--- a/crates/authkestra-oidc/src/provider.rs
+++ b/crates/authkestra-oidc/src/provider.rs
@@ -242,6 +242,15 @@ impl OidcProvider {
 /// `iss` must equal the discovered issuer, `aud` must contain `client_id`,
 /// and `algorithms` is taken from the discovery document (falling back to
 /// RS256, the most common IdP default, if the document omits it).
+///
+/// # Clock skew
+///
+/// `leeway` is left at `jsonwebtoken`'s default of 60 seconds, so an ID token
+/// is accepted for about a minute past its `exp`. Unlike `TokenManager` and
+/// `ValidationConfig`, which name that tolerance themselves since #350, this
+/// one is deliberately not given a knob of its own: [`OidcProvider::
+/// with_validation`] already replaces the whole policy, which is the seam for
+/// changing it. Set `leeway` on the `Validation` you supply there.
 fn default_validation(metadata: &ProviderMetadata, client_id: &str) -> Validation {
     let algorithms = metadata
         .id_token_signing_alg_values_supported

--- a/crates/authkestra-resource/README.md
+++ b/crates/authkestra-resource/README.md
@@ -44,6 +44,26 @@ let config = ValidationConfig::builder()
 let strategy = JwtStrategy::new(config);
 ```
 
+### Clock-skew tolerance
+
+`exp` and `nbf` are validated with a 60-second allowance, so a token is
+accepted for roughly a minute after it expires. This absorbs the disagreement
+between the issuing clock and the validating one.
+
+```rust
+let config = ValidationConfig::builder()
+    .jwks_url("https://example.com/.well-known/jwks.json")
+    .leeway(0) // no tolerance: expiry takes effect immediately
+    .build();
+```
+
+The default is `authkestra_engine::token::DEFAULT_LEEWAY_SECS`, the same
+constant `TokenManager` validates with, so both halves of a deployment apply
+the same window. Set it to `0` when issuer and validator share a clock, or in
+a test asserting that an expired token is refused — at the default such a test
+passes where you expect it to fail. Raising it widens the window in which an
+expired token is still honoured.
+
 ### Trusting several issuers
 
 One verifier can accept tokens from several issuers, each with its own JWKS

--- a/crates/authkestra-resource/src/jwt.rs
+++ b/crates/authkestra-resource/src/jwt.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use authkestra_engine::token::DEFAULT_LEEWAY_SECS;
 use authkestra_engine::{
     error::AuthError,
     strategy::AuthenticationStrategy,
@@ -342,6 +343,18 @@ pub struct ValidationConfig {
     pub audience: Vec<String>,
     pub algorithms: Vec<Algorithm>,
     pub require_kid: bool,
+    /// Clock-skew allowance applied to `exp` and `nbf`, in seconds.
+    ///
+    /// Defaults to [`DEFAULT_LEEWAY_SECS`] (60) — the same constant
+    /// `TokenManager` uses, so a deployment does not have to discover that
+    /// the two halves of the system agreed on a tolerance neither of them
+    /// stated. Before #350 this was `jsonwebtoken`'s default, applied
+    /// silently and with no way to change it.
+    ///
+    /// Set it to `0` where issuer and validator share a clock, or in tests
+    /// that assert on expiry. Raising it widens the window in which an
+    /// expired token is still honoured.
+    pub leeway: u64,
     /// When `true`, enforce RFC 8705 §3.1 certificate binding: a token
     /// carrying a `cnf.x5t#S256` claim is only accepted if the same
     /// certificate (by SHA-256 thumbprint) was presented on the connection
@@ -431,6 +444,10 @@ pub struct ValidationConfigBuilder {
     audience: Vec<String>,
     algorithms: Vec<Algorithm>,
     require_kid: bool,
+    // `Option`, not a bare `u64`: the builder derives `Default`, where a
+    // `u64` would default to 0 and silently turn the documented 60-second
+    // tolerance into none at all.
+    leeway: Option<u64>,
     require_cert_binding: bool,
     require_dpop: bool,
     dpop_resource_origin: Option<String>,
@@ -524,6 +541,15 @@ impl ValidationConfigBuilder {
     /// [`JwksCache::require_kid`].
     pub fn require_kid(mut self, value: bool) -> Self {
         self.require_kid = value;
+        self
+    }
+
+    /// Sets the clock-skew allowance applied to `exp` and `nbf`, in seconds.
+    ///
+    /// Defaults to [`DEFAULT_LEEWAY_SECS`] (60). See
+    /// [`ValidationConfig::leeway`].
+    pub fn leeway(mut self, seconds: u64) -> Self {
+        self.leeway = Some(seconds);
         self
     }
 
@@ -648,6 +674,7 @@ impl ValidationConfigBuilder {
                 self.algorithms
             },
             require_kid: self.require_kid,
+            leeway: self.leeway.unwrap_or(DEFAULT_LEEWAY_SECS),
             require_cert_binding: self.require_cert_binding,
             require_dpop: self.require_dpop,
             dpop_resource_origin: self.dpop_resource_origin,
@@ -778,6 +805,10 @@ fn build_resolver(config: &ValidationConfig) -> Box<dyn JwksResolver> {
 fn build_validation(config: &ValidationConfig, multi_issuer: bool) -> Validation {
     let mut validation = Validation::new(config.algorithms[0]);
     validation.algorithms = config.algorithms.clone();
+    // Set explicitly rather than left to `jsonwebtoken`'s default, so the
+    // window in which an expired token is still honoured is this crate's
+    // decision and is visible in `ValidationConfig` (#350).
+    validation.leeway = config.leeway;
 
     // `set_issuer` has always taken a slice; the pre-#243 config simply had no
     // way to express more than one name. Every trusted issuer goes in, so a

--- a/crates/authkestra-resource/tests/jwt_test.rs
+++ b/crates/authkestra-resource/tests/jwt_test.rs
@@ -12,6 +12,7 @@
 use authkestra_engine::strategy::AuthenticationStrategy;
 use authkestra_engine::token::cert_binding::{x5t_s256_thumbprint, ClientCertificateDer};
 use authkestra_engine::token::jwk::Jwk;
+use authkestra_engine::token::DEFAULT_LEEWAY_SECS;
 use authkestra_resource::jwt::{
     validate_jwt_generic, validate_jwt_with_resolver, IssuerTrustMap, JwksCache, JwtStrategy,
     ValidationConfig, ValidationError,
@@ -203,6 +204,137 @@ async fn single_audience_builder_validates_like_before() {
         .await
         .expect_err("token with mismatched single audience must be rejected");
     assert!(matches!(err, ValidationError::Jwt(_)));
+}
+
+// --- Issue #350: clock-skew leeway ---
+//
+// `ValidationConfig` inherited `jsonwebtoken`'s 60-second tolerance on `exp`
+// with nothing naming it and no way to change it. It now carries the same
+// `DEFAULT_LEEWAY_SECS` constant `TokenManager` uses, so the two halves of a
+// deployment state the same tolerance instead of both borrowing one.
+
+/// Signs a token whose `exp` is `seconds_ago` in the past.
+fn expired_token(key: &TestKey, seconds_ago: usize) -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as usize;
+    sign_token(
+        &key.encoding_key,
+        Some("kid-1"),
+        &TestClaims {
+            sub: "user-1".to_string(),
+            exp: now - seconds_ago,
+            aud: None,
+        },
+    )
+}
+
+fn validation_with_leeway(leeway: u64) -> Validation {
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.validate_aud = false;
+    validation.leeway = leeway;
+    validation
+}
+
+/// The builder defaults to the shared constant rather than to zero — the trap
+/// a plain `u64` field on a `#[derive(Default)]` builder would have set.
+#[test]
+fn the_builder_defaults_leeway_to_the_shared_constant() {
+    let config = ValidationConfig::builder()
+        .jwks_url("https://idp.example.com/jwks")
+        .build();
+    assert_eq!(config.leeway, DEFAULT_LEEWAY_SECS);
+
+    let configured = ValidationConfig::builder()
+        .jwks_url("https://idp.example.com/jwks")
+        .leeway(0)
+        .build();
+    assert_eq!(configured.leeway, 0);
+}
+
+/// The default tolerance accepts a token that has already expired...
+#[tokio::test]
+async fn a_token_expired_within_the_leeway_is_accepted() {
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+    let cache = JwksCache::new(jwks_url(&server), Duration::from_secs(3600));
+
+    let token = expired_token(&key, 30);
+
+    let validated: TestClaims =
+        validate_jwt_generic(&token, &cache, &validation_with_leeway(DEFAULT_LEEWAY_SECS))
+            .await
+            .expect("the default tolerance should still accept this token");
+    assert_eq!(validated.sub, "user-1");
+}
+
+/// ...and setting the leeway to zero is what makes expiry bite immediately.
+#[tokio::test]
+async fn leeway_zero_rejects_a_token_the_default_would_accept() {
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+    let cache = JwksCache::new(jwks_url(&server), Duration::from_secs(3600));
+
+    let token = expired_token(&key, 5);
+
+    // Precondition: this is a token the default would let through, so the
+    // rejection below is attributable to the setting and nothing else.
+    validate_jwt_generic::<TestClaims>(
+        &token,
+        &cache,
+        &validation_with_leeway(DEFAULT_LEEWAY_SECS),
+    )
+    .await
+    .expect("precondition: the default tolerance accepts this token");
+
+    let err = validate_jwt_generic::<TestClaims>(&token, &cache, &validation_with_leeway(0))
+        .await
+        .expect_err("with no tolerance an expired token must be refused");
+    assert!(
+        matches!(&err, ValidationError::Jwt(e) if matches!(e.kind(), ErrorKind::ExpiredSignature)),
+        "expected an expiry rejection, got: {err}"
+    );
+}
+
+/// The wiring, end to end through `JwtStrategy`.
+///
+/// The two tests above build a `Validation` by hand, so they would still pass
+/// if `build_validation` stopped copying `config.leeway` across. This one goes
+/// through the strategy, which is the path an application actually takes, so
+/// it fails if the config field is set but never applied.
+#[tokio::test]
+async fn the_strategy_applies_the_configured_leeway() {
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+    let token = expired_token(&key, 5);
+
+    async fn authenticate(config: ValidationConfig, token: &str) -> bool {
+        let strategy: JwtStrategy<TestClaims> = JwtStrategy::new(config);
+        let request = Request::builder()
+            .header(AUTHORIZATION, format!("Bearer {token}"))
+            .body(())
+            .unwrap();
+        let (parts, _) = request.into_parts();
+        matches!(strategy.authenticate(&parts).await, Ok(Some(_)))
+    }
+
+    let default_config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .build();
+    assert!(
+        authenticate(default_config, &token).await,
+        "precondition: the default tolerance accepts a token expired 5s ago"
+    );
+
+    let strict_config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .leeway(0)
+        .build();
+    assert!(
+        !authenticate(strict_config, &token).await,
+        "leeway(0) was set on the config but never reached the Validation"
+    );
 }
 
 #[tokio::test]

--- a/website/src/content/docs/advanced/resource-server.mdx
+++ b/website/src/content/docs/advanced/resource-server.mdx
@@ -62,6 +62,7 @@ The `ValidationConfig::builder()` supports advanced validation rules and cryptog
 - **Supported Signing Algorithms**: Supports `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, and `EdDSA` (`Ed25519` OKP keys).
 - **Multi-Audience Support**: To accept tokens minted for any of multiple distinct client IDs, chain `.audiences(["client_a", "client_b"])`.
 - **Strict Key IDs (`kid`)**: To strictly reject malformed tokens that lack a `kid` header instead of falling back to the first JWKS key, chain `.require_kid(true)`.
+- **Clock-skew tolerance**: `exp` and `nbf` are checked with a 60-second allowance, so a token is accepted for about a minute past its expiry. That absorbs disagreement between the issuer's clock and yours. Chain `.leeway(0)` where both share a clock, or in tests that assert a token is rejected once it expires — with the default, such a test passes when you expect it to fail. The value is `authkestra_engine::token::DEFAULT_LEEWAY_SECS`, the same constant `TokenManager` uses.
 
 ```rust
 let advanced_config = ValidationConfig::builder()


### PR DESCRIPTION
Closes #350.

## The defect

`TokenManager::validate_token` and `authkestra-resource`'s `build_validation` both constructed a `jsonwebtoken::Validation` and never touched `leeway`, inheriting that crate's 60-second default. A token kept validating for about a minute past its `exp`, and nothing in authkestra said so or offered a way to change it.

The default is defensible. Being silent about it was the problem — invisible from the signature, absent from the docs, findable only by reading a transitive dependency's defaults.

## Fix

`DEFAULT_LEEWAY_SECS` names it once. Both validation paths now set it **explicitly** rather than inheriting it, so the window this crate honours is its own decision rather than an upstream default that could shift underneath it.

| API | Purpose |
| --- | --- |
| `TokenManager::with_leeway(secs)` | Set it (consuming builder, matching `JwksCache::require_kid`) |
| `TokenManager::leeway()` | Read it back |
| `ValidationConfigBuilder::leeway(secs)` | Same, resource side |
| `ValidationConfig::leeway` | The field, `pub` like its siblings |

Both default to the constant, so **behaviour is unchanged**.

### One constant, not one per crate

The issue asked to "decide once for both rather than twice", and `authkestra-resource` defaults to the engine's constant rather than repeating `60`. The two halves of a deployment now state the same tolerance instead of separately borrowing an unstated one — and the playground that prompted this can name `DEFAULT_LEEWAY_SECS` instead of hardcoding an upstream default it cannot see, which was the issue's closing complaint.

### `authkestra-oidc` gets a doc note, not a knob

`with_validation` already replaces the whole ID-token policy, which is the seam for changing leeway there. Adding a second, narrower knob beside it would be two ways to set one thing. Its doc now names the inherited 60 seconds and points at that seam, rather than leaving the tolerance unmentioned.

### One implementation detail worth a look

`ValidationConfigBuilder` stores `Option<u64>`, not `u64`. The builder derives `Default`, where a bare `u64` would default to `0` — silently turning the documented 60-second tolerance into none at all for anyone using the builder. `the_builder_defaults_leeway_to_the_shared_constant` pins that.

## Tests

Ten, and each was checked for teeth by deleting the line it exists to protect.

**Engine (6)** — the reported surprise (expired 30s ago, still accepted), the far edge of the window (beyond 60s, rejected), and `with_leeway(0)` flipping *the same token* from accepted to rejected, so the contrast is the assertion rather than two unrelated outcomes.

Tokens are minted at a chosen `exp` rather than by sleeping. `issue_user_token` can only place `exp` at or after now, and a zero-TTL token is not yet expired even at zero tolerance — I hit exactly that when the first draft of this test failed. Signing directly in-crate makes it deterministic and instant, and avoids reproducing the very "sleep and see" shape the issue calls confusing.

**Resource (4)** — including `the_strategy_applies_the_configured_leeway`, which drives `JwtStrategy` end to end. The other three build a `Validation` by hand and would **all still pass** if `build_validation` stopped copying `config.leeway` across; verified by removing that line, where only the end-to-end test fails. Removing the engine's wiring likewise fails exactly one test.

**`the_default_matches_the_jsonwebtoken_default_it_documents`** pins the claim that 60 is where upstream sits. Behaviour no longer depends on it — the value is always set explicitly now — but the docs assert it, so the docs are held to it rather than being allowed to rot quietly.

## Docs

The issue's minimum ask was a documentation line, so: `validate_token` gains a **Clock skew** section, `resource-server.mdx` gains a bullet beside `.require_kid(true)`, and `authkestra-resource/README.md` gains a short section with the `.leeway(0)` example. Each names the number, where it came from, and when to change it.

## Semver

Patch-compatible. `TokenManager` and `ValidationConfig` are both `#[non_exhaustive]` with builders — `ValidationConfig`'s own doc already records that adding a knob is non-breaking. No default changes.

## Not included

~~`authkestra-op`'s `client_assertion.rs` builds a `Validation` the same way and inherits the same default.~~

**Correction.** That was wrong, and I've since audited every `Validation` construction site rather than pattern-matching on `Validation::new`. `client_assertion.rs` does not inherit the default — it *chose* it and says so four lines below, with a test at `client_assertion.rs:764` referencing the window:

```rust
// `leeway` stays at jsonwebtoken's 60s default: an assertion is minted
// seconds before it is presented, and the clocks of the client and the OP
// are not the same clock.
```

Which is the opposite of this issue's complaint, as #350 itself anticipated: *"The crate does document clock skew where it chose the value itself."*

The full audit: `dpop.rs` and `attestation.rs` both set `validate_exp = false` and handle freshness themselves (`dpop.rs` with its own 5-second allowance), and the three sites in `token/mod.rs` are inside `#[cfg(test)]`. One genuine gap remained — `engine.rs:242`, the MFA continuation token — addressed in #352, stacked on this branch.

## Verification

All five CI gates pass locally: `fmt`, `clippy`, `test`, `coverage` (87.17%), `deny`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
