### PR TITLE
fix(engine): state the MFA continuation token's clock-skew window

### DIFF
--- a/crates/authkestra-engine/src/engine.rs
+++ b/crates/authkestra-engine/src/engine.rs
@@ -236,10 +236,27 @@ impl<S, T> Engine<S, T> {
         } = input
         {
             // Verify MFA Token
+            let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::HS256);
+            // Stated rather than inherited, for the reason #350 gives: a
+            // tolerance nobody wrote down is one nobody can review. This is
+            // the last site that still took `jsonwebtoken`'s default
+            // silently, and it matters more here than most — the 15-minute
+            // TTL below is a deliberate bound on how long a half-completed
+            // login stays resumable, and an unstated grace period quietly
+            // widens it.
+            //
+            // The value is unchanged at `DEFAULT_LEEWAY_SECS`, so nothing
+            // about today's behaviour moves. It is more tolerance than this
+            // token needs, though: unlike an ID token or a client assertion,
+            // this one is minted and verified by the same deployment with the
+            // same secret, so the only clocks that can disagree belong to
+            // instances of the same service. Tightening it is a deliberate
+            // decision to make on its own, not a side effect of naming it.
+            validation.leeway = crate::token::DEFAULT_LEEWAY_SECS;
             let token_data = jsonwebtoken::decode::<crate::auth::state::MfaTokenClaims>(
                 &mfa_token,
                 &jsonwebtoken::DecodingKey::from_secret(&self.mfa_jwt_secret),
-                &jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::HS256),
+                &validation,
             )
             .map_err(|_| AuthError::InvalidInput)?;
 

--- a/crates/authkestra-engine/src/tests.rs
+++ b/crates/authkestra-engine/src/tests.rs
@@ -279,3 +279,122 @@ async fn test_totp_primary_requires_mfa() {
         _ => panic!("Expected MFA required for TOTP primary"),
     }
 }
+
+// --- MFA continuation token: clock-skew window (#350 follow-up) ---
+//
+// `Engine::authenticate` validates the MFA token that resumes a
+// half-completed login. That validation used to take `jsonwebtoken`'s
+// 60-second `exp` tolerance silently; it is now stated explicitly. These
+// characterize the window rather than a change, because the value did not
+// move — the point is that the boundary is now visible in the suite, so
+// tightening or widening it later has to be a deliberate edit with a failing
+// test attached rather than an invisible consequence of a dependency bump.
+//
+// `Totp` is the `challenge_input`, not `Password`: `authenticate` maps only
+// `Totp`/`WebAuthnAuthentication` to an MFA method and returns
+// `InvalidInput` for anything else *before* it ever looks at `exp`. A first
+// draft of these tests used `Password`, which made the "beyond the leeway"
+// case pass for entirely the wrong reason — it would have passed with the
+// expiry check deleted outright.
+#[cfg(feature = "totp")]
+mod mfa_token_leeway {
+    use super::*;
+    use crate::auth::AuthResult;
+    use crate::Engine;
+
+    /// An MFA method registered under the name the `Totp` challenge maps to,
+    /// returning the same `external_id` the MFA token's `sub` carries so the
+    /// post-validation user check passes.
+    struct MockTotpMethod;
+    #[async_trait]
+    impl AuthMethod for MockTotpMethod {
+        fn name(&self) -> &str {
+            "totp"
+        }
+        async fn authenticate(&self, _input: AuthInput) -> Result<Identity, AuthError> {
+            Ok(Identity {
+                provider_id: "totp".to_string(),
+                external_id: "user123".to_string(),
+                email: None,
+                username: None,
+                attributes: HashMap::new(),
+            })
+        }
+        async fn has_enrolled(&self, _user_id: &str) -> Result<bool, AuthError> {
+            Ok(true)
+        }
+    }
+
+    fn engine() -> crate::Engine<crate::engine::Missing, crate::engine::Missing> {
+        Engine::builder().with_mfa_method(MockTotpMethod).build()
+    }
+
+    /// Mints an MFA continuation token whose `exp` is `seconds_ago` in the
+    /// past, signed with the engine's own secret so that expiry is the only
+    /// thing wrong with it.
+    fn expired_mfa_token<S, T>(engine: &crate::Engine<S, T>, seconds_ago: i64) -> String {
+        let exp = chrono::Utc::now() - chrono::Duration::seconds(seconds_ago);
+        let claims = crate::auth::state::MfaTokenClaims {
+            sub: "user123".to_string(),
+            mfa_pending: true,
+            exp: exp.timestamp() as usize,
+        };
+        jsonwebtoken::encode(
+            &jsonwebtoken::Header::default(),
+            &claims,
+            &jsonwebtoken::EncodingKey::from_secret(&engine.mfa_jwt_secret),
+        )
+        .expect("signing the MFA token should succeed")
+    }
+
+    fn challenge(mfa_token: String) -> AuthInput {
+        AuthInput::MfaChallenge {
+            mfa_token,
+            challenge_input: Box::new(AuthInput::Totp {
+                user_id: "user123".to_string(),
+                code: "000000".to_string(),
+            }),
+        }
+    }
+
+    /// A live token resumes the login. Establishes that everything *other*
+    /// than expiry is wired correctly, so the rejection below is attributable
+    /// to the window and not to the fixture.
+    #[tokio::test]
+    async fn a_live_mfa_token_resumes_the_login() {
+        let engine = engine();
+        // Negative "seconds ago" puts `exp` in the future.
+        let token = expired_mfa_token(&engine, -600);
+
+        let result = engine.authenticate(challenge(token)).await;
+        assert!(
+            matches!(result, Ok(AuthResult::Success(_))),
+            "a live MFA token should resume the login, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_mfa_token_expired_within_the_leeway_still_resumes_the_login() {
+        let engine = engine();
+        let token = expired_mfa_token(&engine, 30);
+
+        let result = engine.authenticate(challenge(token)).await;
+        assert!(
+            matches!(result, Ok(AuthResult::Success(_))),
+            "within DEFAULT_LEEWAY_SECS the token is still honoured, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_mfa_token_expired_beyond_the_leeway_is_refused() {
+        let engine = engine();
+        // Comfortably past the tolerance, so this does not sit on the boundary.
+        let token = expired_mfa_token(&engine, crate::token::DEFAULT_LEEWAY_SECS as i64 + 60);
+
+        let result = engine.authenticate(challenge(token)).await;
+        assert!(
+            matches!(result, Err(AuthError::InvalidInput)),
+            "past the tolerance a stale MFA token must not resume a login, got {result:?}"
+        );
+    }
+}


### PR DESCRIPTION
Follow-up to #351 (merged), rebased onto `main` and targeting it directly. Uses the `DEFAULT_LEEWAY_SECS` that PR introduced.

## Why there is a follow-up at all

#351 fixed the two sites #350 named. It did not audit the rest. When I finally enumerated every `Validation` construction site, two things fell out — one embarrassing, one useful.

**The embarrassing one:** my "Not included" note on #351 claimed `authkestra-op`'s `client_assertion.rs` "inherits the same default... worth its own issue". It doesn't. It *chose* the value and says so, four lines below the `Validation::new` I pattern-matched on:

```rust
// `leeway` stays at jsonwebtoken's 60s default: an assertion is minted
// seconds before it is presented, and the clocks of the client and the OP
// are not the same clock.
```

There's a test at `client_assertion.rs:764` referencing that window too. #350 even predicted this: *"The crate does document clock skew where it chose the value itself."* I've corrected #351's description; the note would have sent someone to file a non-issue.

**The useful one:** the full audit.

| Site | Status |
| --- | --- |
| `op/client_assertion.rs:392` | Documented decision, tested ✓ |
| `engine/token/dpop.rs:257` | `validate_exp = false`; own `CLOCK_SKEW_ALLOWANCE_SECS = 5` ✓ |
| `op/attestation.rs:510` | `validate_exp = false`; TTL enforced by the challenge store ✓ |
| `engine/token/mod.rs` ×3 | Inside `#[cfg(test)]` ✓ |
| **`engine/engine.rs:242`** | **Silent 60s, `exp` validated, undocumented** |

## The one real gap

`engine.rs:242` validates the **MFA continuation token** — the ticket that resumes a login between the first and second factor.

It's the site where an unstated grace matters most: the 15-minute TTL a few lines below (`engine.rs:321`) is a deliberate bound on how long a half-completed login stays resumable, and a tolerance nobody wrote down quietly widens it.

## What this changes, and what it doesn't

The value **does not move**. It's set to `DEFAULT_LEEWAY_SECS`, so behaviour is unchanged and this stays patch-compatible. What changes is that the window is stated and bracketed by tests.

### A judgment left for you, deliberately

This token is minted *and* verified by the same deployment with the same secret. Unlike an ID token or a client assertion, the only clocks that can disagree belong to instances of the same service — NTP-synced, typically within milliseconds. Sixty seconds is considerably more tolerance than that needs, and it extends the MFA window from 15 minutes to ~16.

I did not tighten it. That has its own blast radius — a fleet with drifted clocks would start failing second factors — and #350's own stance is *"The default is defensible. Being silent about it is the problem."* Changing a security window as a side effect of naming it would be the wrong way round. The reasoning is recorded in the code comment so the decision can be made on its merits.

## Tests

Three, bracketing the window: a live token, one expired *inside* the tolerance, one expired *past* it.

Verified both edges bite: disabling `exp` validation fails the third; setting leeway to `0` fails the second. A change in either direction fails a test rather than passing silently.

### The first draft was worthless

It used `AuthInput::Password` as the `challenge_input`. `authenticate` maps only `Totp` and `WebAuthnAuthentication` to an MFA method and returns `InvalidInput` for anything else **before it ever looks at `exp`** — so the "beyond the tolerance" case passed for entirely the wrong reason and would have passed with the expiry check deleted outright.

They use `Totp` now, and `a_live_mfa_token_resumes_the_login` exists specifically to prove the fixture reaches success at all, so the two rejection/acceptance cases are attributable to the window rather than to the setup.

## Verification

All five CI gates pass locally: `fmt`, `clippy`, `test`, `coverage` (87.28%), `deny`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
