### PR TITLE
feat(engine): instrument the authentication path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,7 @@ dependencies = [
  "totp-rs",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
  "url",
  "uuid",
  "webauthn-rs",

--- a/crates/authkestra-engine/Cargo.toml
+++ b/crates/authkestra-engine/Cargo.toml
@@ -112,6 +112,13 @@ testcontainers = "0.27.3"
 testcontainers-modules = { version = "0.15.0", features = ["redis"] }
 wiremock = "0.6.5"
 
+# Test-only: captures emitted `tracing` output so the instrumentation on
+# `Engine::authenticate` can be asserted on directly — both that it exists and,
+# more importantly, that a password handed to it never reaches a log line
+# (#353). Without a capturing subscriber that second property is unassertable,
+# and it is precisely the one that would matter if it broke.
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
+
 # Test-only: `test-util` brings `#[tokio::test(start_paused = true)]`, which
 # `full` does not include. The device-flow tests use the paused clock to prove
 # `poll_for_token` waits on a timer rather than blocking the thread (#306) --

--- a/crates/authkestra-engine/src/auth/strategy.rs
+++ b/crates/authkestra-engine/src/auth/strategy.rs
@@ -435,4 +435,82 @@ mod tests {
         headers3.insert(COOKIE, HeaderValue::from_static("foo=bar; sid=123"));
         assert_eq!(utils::extract_cookie(&headers3, "sid"), Some("123"));
     }
+
+    /// No existing test produced an `Err` from a delegate, so the strategies'
+    /// *rejection* path was untested — which is the case `log_outcome` exists
+    /// to keep distinguishable from a decline (#353). Under a first-success
+    /// policy both let the next strategy run, so the difference lives only in
+    /// the logs and in what the caller sees.
+    struct RejectingValidator;
+    #[async_trait]
+    impl TokenValidator for RejectingValidator {
+        type Identity = DummyIdentity;
+        async fn validate(&self, _t: &str) -> Result<Option<Self::Identity>, AuthError> {
+            Err(AuthError::Token("expired".into()))
+        }
+    }
+
+    #[tokio::test]
+    async fn a_rejected_token_is_an_error_not_a_decline() {
+        let strategy = TokenStrategy::new(RejectingValidator);
+        let req = Request::builder()
+            .uri("/")
+            .header(AUTHORIZATION, "Bearer whatever")
+            .body(())
+            .unwrap();
+
+        let result = strategy.authenticate(&req.into_parts().0).await;
+        assert!(
+            matches!(result, Err(AuthError::Token(_))),
+            "a credential this strategy owns and refuses must surface as Err, \
+             not as Ok(None) — the latter reads as \"not mine\" to the caller"
+        );
+    }
+
+    /// A header that is present but not ASCII is neither absent nor readable.
+    /// It declines, so another strategy may still succeed, but it is logged
+    /// distinctly because it is not the same as absent.
+    #[tokio::test]
+    async fn a_non_ascii_header_value_declines_rather_than_erroring() {
+        let strategy = HeaderStrategy::new(
+            HeaderName::from_static("x-api-key"),
+            // Returns `Ok(Some(..))` for any input, which is what makes the
+            // assertion below meaningful: had the unreadable header reached
+            // this validator, the result would be `Ok(Some(..))`, so
+            // `Ok(None)` proves the strategy declined without calling it.
+            // The body is consequently expected to show as uncovered.
+            |_key: String| async move { Ok(Some(DummyIdentity("user".to_string()))) },
+        );
+        let mut req = Request::builder().uri("/").body(()).unwrap();
+        req.headers_mut().insert(
+            HeaderName::from_static("x-api-key"),
+            HeaderValue::from_bytes(&[0xff, 0xfe]).unwrap(),
+        );
+
+        let result = strategy.authenticate(&req.into_parts().0).await;
+        assert!(matches!(result, Ok(None)));
+    }
+
+    /// The third outcome, distinct from both a decline and a rejection: the
+    /// strategy found credentials of its kind, handed them to its delegate,
+    /// and the delegate recognised nobody. `DummyBasic` returns `Ok(None)`
+    /// for an unknown user, but no existing test presented one — so this arm
+    /// of the outcome reporting was never exercised (#353).
+    #[tokio::test]
+    async fn credentials_that_resolve_to_nobody_are_a_decline_not_an_error() {
+        // base64("nobody:whatever")
+        let strategy = BasicStrategy::new(DummyBasic);
+        let req = Request::builder()
+            .uri("/")
+            .header(AUTHORIZATION, "Basic bm9ib2R5OndoYXRldmVy")
+            .body(())
+            .unwrap();
+
+        let result: Result<Option<DummyIdentity>, AuthError> =
+            strategy.authenticate(&req.into_parts().0).await;
+        assert!(
+            matches!(result, Ok(None)),
+            "an unrecognised user is not an error; another strategy may still succeed"
+        );
+    }
 }

--- a/crates/authkestra-engine/src/auth/strategy.rs
+++ b/crates/authkestra-engine/src/auth/strategy.rs
@@ -18,6 +18,26 @@ pub trait AuthenticationStrategy<I>: Send + Sync {
     async fn authenticate(&self, parts: &Parts) -> Result<Option<I>, AuthError>;
 }
 
+/// Reports a strategy's outcome, so the three cases a caller collapses stay
+/// distinguishable in the logs.
+///
+/// The distinction is load-bearing rather than cosmetic: under a
+/// first-success policy, "I found no credentials of my kind" and "I found
+/// credentials and they were wrong" both let the next strategy run, and an
+/// operator looking at a 401 needs to know which strategies declined and
+/// which actually rejected something. None of these log the credential.
+fn log_outcome<I>(strategy: &'static str, outcome: &Result<Option<I>, AuthError>) {
+    match outcome {
+        Ok(Some(_)) => tracing::debug!(strategy, "strategy authenticated the request"),
+        Ok(None) => tracing::debug!(strategy, "credentials were present but yielded no identity"),
+        Err(error) => tracing::warn!(
+            strategy,
+            %error,
+            "strategy rejected the request's credentials"
+        ),
+    }
+}
+
 /// Trait for a provider that validates username and password (Basic Auth).
 #[async_trait]
 pub trait BasicAuthenticator: Send + Sync {
@@ -56,8 +76,14 @@ where
 {
     async fn authenticate(&self, parts: &Parts) -> Result<Option<I>, AuthError> {
         if let Some((username, password)) = utils::extract_basic_credentials(&parts.headers) {
-            self.authenticator.authenticate(&username, &password).await
+            let outcome = self.authenticator.authenticate(&username, &password).await;
+            log_outcome("basic", &outcome);
+            outcome
         } else {
+            tracing::debug!(
+                strategy = "basic",
+                "no Basic credentials present; declining"
+            );
             Ok(None)
         }
     }
@@ -97,8 +123,11 @@ where
 {
     async fn authenticate(&self, parts: &Parts) -> Result<Option<I>, AuthError> {
         if let Some(token) = utils::extract_bearer_token(&parts.headers) {
-            self.validator.validate(token).await
+            let outcome = self.validator.validate(token).await;
+            log_outcome("bearer", &outcome);
+            outcome
         } else {
+            tracing::debug!(strategy = "bearer", "no Bearer token present; declining");
             Ok(None)
         }
     }
@@ -132,9 +161,26 @@ where
 {
     async fn authenticate(&self, parts: &Parts) -> Result<Option<I>, AuthError> {
         if let Some(value) = parts.headers.get(&self.header_name) {
-            if let Ok(value_str) = value.to_str() {
-                return (self.validator)(value_str.to_string()).await;
+            match value.to_str() {
+                Ok(value_str) => {
+                    let outcome = (self.validator)(value_str.to_string()).await;
+                    log_outcome("header", &outcome);
+                    return outcome;
+                }
+                // Present but not valid UTF-8, which is not the same as absent.
+                Err(error) => tracing::warn!(
+                    strategy = "header",
+                    header = %self.header_name,
+                    %error,
+                    "header is present but is not valid ASCII; declining"
+                ),
             }
+        } else {
+            tracing::debug!(
+                strategy = "header",
+                header = %self.header_name,
+                "header not present; declining"
+            );
         }
         Ok(None)
     }
@@ -176,8 +222,17 @@ where
 {
     async fn authenticate(&self, parts: &Parts) -> Result<Option<I>, AuthError> {
         if let Some(session_id) = utils::extract_cookie(&parts.headers, &self.cookie_name) {
-            self.provider.load_session(session_id).await
+            // The cookie value is the session credential, so it is not
+            // logged; only that one was found.
+            let outcome = self.provider.load_session(session_id).await;
+            log_outcome("session", &outcome);
+            outcome
         } else {
+            tracing::debug!(
+                strategy = "session",
+                cookie = %self.cookie_name,
+                "no session cookie present; declining"
+            );
             Ok(None)
         }
     }

--- a/crates/authkestra-engine/src/engine.rs
+++ b/crates/authkestra-engine/src/engine.rs
@@ -411,6 +411,11 @@ impl<S, T> Engine<S, T> {
                 &claims,
                 &jsonwebtoken::EncodingKey::from_secret(&self.mfa_jwt_secret),
             )
+            // Not covered by a test, and deliberately so: HS256 signing
+            // with a fixed 32-byte secret has no reachable failure mode, so
+            // exercising this would mean contriving one. It is logged rather
+            // than dropped because if it ever does fire, the login has
+            // failed for a reason nothing else would explain.
             .map_err(|e| {
                 tracing::error!(error = %e, "failed to mint the MFA continuation token");
                 AuthError::Internal(e.to_string())

--- a/crates/authkestra-engine/src/engine.rs
+++ b/crates/authkestra-engine/src/engine.rs
@@ -228,6 +228,13 @@ impl<S, T> Engine<S, T> {
     /// Attempt to authenticate a user.
     /// Returns `AuthResult::Success` if authentication is fully complete,
     /// or `AuthResult::MfaRequired` if a second factor is needed.
+    // `input` is skipped, not merely unformatted: `AuthInput` carries
+    // passwords and TOTP codes, and a span field would print them. The
+    // method name is recorded instead, once it is known.
+    #[tracing::instrument(
+        skip(self, input),
+        fields(auth_method = tracing::field::Empty, user_id = tracing::field::Empty)
+    )]
     pub async fn authenticate(&self, input: AuthInput) -> Result<AuthResult, AuthError> {
         // Handle MFA Challenge Continuation
         if let AuthInput::MfaChallenge {
@@ -258,11 +265,22 @@ impl<S, T> Engine<S, T> {
                 &jsonwebtoken::DecodingKey::from_secret(&self.mfa_jwt_secret),
                 &validation,
             )
-            .map_err(|_| AuthError::InvalidInput)?;
+            .map_err(|e| {
+                // The caller deliberately learns nothing beyond
+                // `InvalidInput` — expired and forged must look alike from
+                // outside. Server-side there is no such reason to discard
+                // it, and "was that token stale or unsigned?" is the first
+                // question anyone debugging a stalled second factor asks.
+                tracing::warn!(error = %e, "MFA continuation token failed validation");
+                AuthError::InvalidInput
+            })?;
 
             if !token_data.claims.mfa_pending {
+                tracing::warn!("token presented as an MFA continuation is not marked mfa_pending");
                 return Err(AuthError::InvalidInput);
             }
+            tracing::Span::current().record("user_id", token_data.claims.sub.as_str());
+            tracing::debug!("resuming a login from a valid MFA continuation token");
 
             let method_name = match &*challenge_input {
                 #[cfg(feature = "totp")]
@@ -273,23 +291,46 @@ impl<S, T> Engine<S, T> {
             };
 
             if method_name.is_empty() {
+                tracing::warn!(
+                    "MFA challenge carries an input that maps to no second factor; \
+                     only Totp and WebAuthnAuthentication are dispatched here"
+                );
                 return Err(AuthError::InvalidInput);
             }
+            tracing::Span::current().record("auth_method", method_name);
 
             let method = self
                 .auth_methods
                 .get(method_name)
                 .or_else(|| self.mfa_methods.get(method_name))
                 .ok_or_else(|| {
+                    tracing::error!(
+                        method = method_name,
+                        "MFA method is not registered on this engine"
+                    );
                     AuthError::Internal(format!("MFA method {} not registered", method_name))
                 })?;
 
-            let identity = method.authenticate(*challenge_input).await?;
+            let identity = method.authenticate(*challenge_input).await.map_err(|e| {
+                tracing::warn!(error = %e, method = method_name, "second factor rejected");
+                e
+            })?;
 
             if identity.external_id != token_data.claims.sub {
+                // The second factor verified, but for a different user than
+                // the one the continuation token was minted for.
+                tracing::warn!(
+                    token_sub = %token_data.claims.sub,
+                    verified_user = %identity.external_id,
+                    "second factor verified a different user than the MFA token names"
+                );
                 return Err(AuthError::Credentials("MFA token user mismatch".into()));
             }
 
+            tracing::info!(
+                method = method_name,
+                "authentication completed via second factor"
+            );
             return Ok(AuthResult::Success(identity));
         }
 
@@ -304,17 +345,32 @@ impl<S, T> Engine<S, T> {
         };
 
         if method_name.is_empty() {
+            tracing::warn!("authentication input maps to no primary method");
             return Err(AuthError::InvalidInput);
         }
+        tracing::Span::current().record("auth_method", method_name);
+        tracing::debug!("dispatching primary authentication");
 
         let method = self.auth_methods.get(method_name).ok_or_else(|| {
+            // A configuration fault, not a credential one: the input named a
+            // method this engine was never given. Distinguishing the two is
+            // the point of logging it at `error!` rather than `warn!`.
+            tracing::error!(
+                method = method_name,
+                "primary auth method is not registered, or is registered as step-up only"
+            );
             AuthError::Internal(format!(
                 "Primary auth method {} not registered or is step-up only",
                 method_name
             ))
         })?;
 
-        let identity = method.authenticate(input).await?;
+        let identity = method.authenticate(input).await.map_err(|e| {
+            tracing::warn!(error = %e, "primary authentication rejected");
+            e
+        })?;
+        tracing::Span::current().record("user_id", identity.external_id.as_str());
+        tracing::debug!("primary authentication succeeded; checking for enrolled second factors");
 
         // Check if user has MFA enrolled
         let mut enrolled_methods = Vec::new();
@@ -332,6 +388,14 @@ impl<S, T> Engine<S, T> {
         // If this method was already an MFA method (e.g. WebAuthn primary), we don't prompt for MFA again.
         // Or if the user has no other MFA methods enrolled.
         if enrolled_methods.is_empty() || method.is_mfa_equivalent() {
+            // Two quite different reasons to skip the second factor, and an
+            // operator asked "why was MFA not enforced for this user?" needs
+            // to know which one applied.
+            tracing::info!(
+                mfa_equivalent = method.is_mfa_equivalent(),
+                enrolled_methods = enrolled_methods.len(),
+                "authentication completed without a second factor"
+            );
             Ok(AuthResult::Success(identity))
         } else {
             // Issue MFA Token
@@ -347,8 +411,15 @@ impl<S, T> Engine<S, T> {
                 &claims,
                 &jsonwebtoken::EncodingKey::from_secret(&self.mfa_jwt_secret),
             )
-            .map_err(|e| AuthError::Internal(e.to_string()))?;
+            .map_err(|e| {
+                tracing::error!(error = %e, "failed to mint the MFA continuation token");
+                AuthError::Internal(e.to_string())
+            })?;
 
+            tracing::info!(
+                allowed_methods = ?enrolled_methods,
+                "primary authentication succeeded; a second factor is required"
+            );
             Ok(AuthResult::MfaRequired {
                 mfa_token,
                 user_id: identity.external_id,

--- a/crates/authkestra-engine/src/lib.rs
+++ b/crates/authkestra-engine/src/lib.rs
@@ -29,4 +29,6 @@ pub use captcha::{CaptchaProvider, CaptchaVerifier};
 
 pub mod oauth2;
 #[cfg(test)]
+mod test_support;
+#[cfg(test)]
 mod tests;

--- a/crates/authkestra-engine/src/test_support.rs
+++ b/crates/authkestra-engine/src/test_support.rs
@@ -1,0 +1,62 @@
+//! Test-only helpers shared across this crate's test modules.
+
+use std::io;
+use std::sync::{Arc, Mutex};
+
+/// A `MakeWriter` that accumulates everything written to it, so a test can
+/// assert on the `tracing` output actually emitted.
+///
+/// Two reasons this exists rather than each test module rolling its own.
+///
+/// The first is the property it makes assertable: instrumentation on an
+/// authentication path is handed credentials, and "the password never reaches
+/// a log line" cannot be checked without capturing what was emitted.
+///
+/// The second is subtler. `tracing` macros do not evaluate their field
+/// expressions when no subscriber is installed, so a field like
+/// `ath_bound = expected_ath.is_some()` is never executed under a plain
+/// `cargo test` and shows as uncovered however well the surrounding function
+/// is exercised. Installing a subscriber makes the instrumentation genuinely
+/// run, which is both more honest about coverage and the only way to assert
+/// that a log line says what it claims to.
+#[derive(Clone, Default)]
+pub(crate) struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+impl CapturedLogs {
+    /// Everything emitted so far.
+    pub(crate) fn contents(&self) -> String {
+        String::from_utf8_lossy(&self.0.lock().unwrap()).into_owned()
+    }
+}
+
+impl io::Write for CapturedLogs {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturedLogs {
+    type Writer = Self;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Runs `body` with every `tracing` event captured, returning the output.
+///
+/// The subscriber is installed for the current thread only, so this composes
+/// with `#[tokio::test]`'s default current-thread runtime.
+pub(crate) fn capture<T>(body: impl FnOnce() -> T) -> (T, String) {
+    let captured = CapturedLogs::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(captured.clone())
+        .with_max_level(tracing::Level::TRACE)
+        .without_time()
+        .finish();
+    let value = tracing::subscriber::with_default(subscriber, body);
+    (value, captured.contents())
+}

--- a/crates/authkestra-engine/src/tests.rs
+++ b/crates/authkestra-engine/src/tests.rs
@@ -398,3 +398,119 @@ mod mfa_token_leeway {
         );
     }
 }
+
+// --- Tracing on the authentication path (#353) ---
+//
+// `Engine::authenticate` was entirely silent: 161 lines covering primary
+// dispatch, MFA continuation and four error paths, with no span and no
+// events, directly above two fully-instrumented methods. These assert the
+// instrumentation exists *and* that it cannot leak what it is handed —
+// `AuthInput` carries passwords and TOTP codes, so the span skips the
+// argument rather than formatting it.
+#[cfg(test)]
+mod authenticate_tracing {
+    use super::*;
+    use crate::Engine;
+    use std::io;
+    use std::sync::{Arc, Mutex};
+
+    /// A `MakeWriter` that accumulates everything written to it, so a test
+    /// can assert on what was actually emitted.
+    #[derive(Clone, Default)]
+    struct Captured(Arc<Mutex<Vec<u8>>>);
+
+    impl Captured {
+        fn contents(&self) -> String {
+            String::from_utf8_lossy(&self.0.lock().unwrap()).into_owned()
+        }
+    }
+
+    impl io::Write for Captured {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Captured {
+        type Writer = Self;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// A password method that always rejects, so the interesting path (a
+    /// failed login) is the one exercised.
+    struct RejectingPasswordMethod;
+    #[async_trait]
+    impl AuthMethod for RejectingPasswordMethod {
+        fn name(&self) -> &str {
+            "password"
+        }
+        async fn authenticate(&self, _input: AuthInput) -> Result<Identity, AuthError> {
+            Err(AuthError::Credentials("no such user".into()))
+        }
+    }
+
+    const SECRET_PASSWORD: &str = "correct-horse-battery-staple-9f3a";
+
+    async fn capture_failed_login() -> String {
+        let captured = Captured::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(captured.clone())
+            .with_max_level(tracing::Level::TRACE)
+            .without_time()
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let engine = Engine::builder()
+            .with_auth_method(RejectingPasswordMethod)
+            .build();
+        let result = engine
+            .authenticate(AuthInput::Password {
+                identifier: "someone@example.com".to_string(),
+                password: SECRET_PASSWORD.to_string(),
+            })
+            .await;
+        assert!(result.is_err(), "the fixture must produce a failed login");
+
+        captured.contents()
+    }
+
+    /// A rejected login has to leave a trace. Before #353 it left none, which
+    /// is the whole complaint: successful sessions logged three events and
+    /// failed logins logged nothing.
+    #[tokio::test]
+    async fn a_rejected_login_is_logged() {
+        let logs = capture_failed_login().await;
+
+        assert!(
+            !logs.is_empty(),
+            "a failed authentication emitted no log output at all"
+        );
+        assert!(
+            logs.contains("primary authentication rejected"),
+            "the rejection itself should be reported; got:\n{logs}"
+        );
+        assert!(
+            logs.contains("no such user"),
+            "the underlying reason should be carried through; got:\n{logs}"
+        );
+    }
+
+    /// The property worth protecting. `AuthInput` carries the password, so
+    /// the span skips the argument; if someone later adds it to the span or
+    /// logs `input` directly, this fails.
+    #[tokio::test]
+    async fn the_password_never_reaches_a_log_line() {
+        let logs = capture_failed_login().await;
+
+        assert!(
+            !logs.contains(SECRET_PASSWORD),
+            "the password appeared in emitted tracing output:\n{logs}"
+        );
+    }
+}

--- a/crates/authkestra-engine/src/tests.rs
+++ b/crates/authkestra-engine/src/tests.rs
@@ -410,37 +410,8 @@ mod mfa_token_leeway {
 #[cfg(test)]
 mod authenticate_tracing {
     use super::*;
+    use crate::test_support::capture;
     use crate::Engine;
-    use std::io;
-    use std::sync::{Arc, Mutex};
-
-    /// A `MakeWriter` that accumulates everything written to it, so a test
-    /// can assert on what was actually emitted.
-    #[derive(Clone, Default)]
-    struct Captured(Arc<Mutex<Vec<u8>>>);
-
-    impl Captured {
-        fn contents(&self) -> String {
-            String::from_utf8_lossy(&self.0.lock().unwrap()).into_owned()
-        }
-    }
-
-    impl io::Write for Captured {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.0.lock().unwrap().extend_from_slice(buf);
-            Ok(buf.len())
-        }
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
-
-    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Captured {
-        type Writer = Self;
-        fn make_writer(&'a self) -> Self::Writer {
-            self.clone()
-        }
-    }
 
     /// A password method that always rejects, so the interesting path (a
     /// failed login) is the one exercised.
@@ -457,35 +428,34 @@ mod authenticate_tracing {
 
     const SECRET_PASSWORD: &str = "correct-horse-battery-staple-9f3a";
 
-    async fn capture_failed_login() -> String {
-        let captured = Captured::default();
-        let subscriber = tracing_subscriber::fmt()
-            .with_writer(captured.clone())
-            .with_max_level(tracing::Level::TRACE)
-            .without_time()
-            .finish();
-        let _guard = tracing::subscriber::set_default(subscriber);
+    fn capture_failed_login() -> String {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("building a runtime should succeed");
 
-        let engine = Engine::builder()
-            .with_auth_method(RejectingPasswordMethod)
-            .build();
-        let result = engine
-            .authenticate(AuthInput::Password {
-                identifier: "someone@example.com".to_string(),
-                password: SECRET_PASSWORD.to_string(),
+        let (result, logs) = capture(|| {
+            runtime.block_on(async {
+                let engine = Engine::builder()
+                    .with_auth_method(RejectingPasswordMethod)
+                    .build();
+                engine
+                    .authenticate(AuthInput::Password {
+                        identifier: "someone@example.com".to_string(),
+                        password: SECRET_PASSWORD.to_string(),
+                    })
+                    .await
             })
-            .await;
+        });
         assert!(result.is_err(), "the fixture must produce a failed login");
-
-        captured.contents()
+        logs
     }
 
     /// A rejected login has to leave a trace. Before #353 it left none, which
     /// is the whole complaint: successful sessions logged three events and
     /// failed logins logged nothing.
-    #[tokio::test]
-    async fn a_rejected_login_is_logged() {
-        let logs = capture_failed_login().await;
+    #[test]
+    fn a_rejected_login_is_logged() {
+        let logs = capture_failed_login();
 
         assert!(
             !logs.is_empty(),
@@ -504,13 +474,221 @@ mod authenticate_tracing {
     /// The property worth protecting. `AuthInput` carries the password, so
     /// the span skips the argument; if someone later adds it to the span or
     /// logs `input` directly, this fails.
-    #[tokio::test]
-    async fn the_password_never_reaches_a_log_line() {
-        let logs = capture_failed_login().await;
+    #[test]
+    fn the_password_never_reaches_a_log_line() {
+        let logs = capture_failed_login();
 
         assert!(
             !logs.contains(SECRET_PASSWORD),
             "the password appeared in emitted tracing output:\n{logs}"
         );
+    }
+}
+
+// --- `Engine::authenticate` error paths (#353) ---
+//
+// Instrumenting `authenticate` surfaced that almost none of its rejection
+// branches had a test: `codecov/patch` flagged ten added lines as uncovered,
+// and every one sat on a path that predated the instrumentation. The log
+// lines were new; the untested branches were not. These cover the behaviour,
+// so the branches are exercised rather than merely annotated.
+#[cfg(all(test, feature = "totp"))]
+mod authenticate_error_paths {
+    use super::*;
+    use crate::auth::AuthResult;
+    use crate::Engine;
+
+    /// Returns the given identity, whatever it is asked.
+    struct FixedTotpMethod(&'static str);
+    #[async_trait]
+    impl AuthMethod for FixedTotpMethod {
+        fn name(&self) -> &str {
+            "totp"
+        }
+        async fn authenticate(&self, _input: AuthInput) -> Result<Identity, AuthError> {
+            Ok(Identity {
+                provider_id: "totp".to_string(),
+                external_id: self.0.to_string(),
+                email: None,
+                username: None,
+                attributes: HashMap::new(),
+            })
+        }
+        async fn has_enrolled(&self, _user_id: &str) -> Result<bool, AuthError> {
+            Ok(true)
+        }
+    }
+
+    /// Always refuses the second factor.
+    struct RejectingTotpMethod;
+    #[async_trait]
+    impl AuthMethod for RejectingTotpMethod {
+        fn name(&self) -> &str {
+            "totp"
+        }
+        async fn authenticate(&self, _input: AuthInput) -> Result<Identity, AuthError> {
+            Err(AuthError::Credentials("wrong code".into()))
+        }
+        async fn has_enrolled(&self, _user_id: &str) -> Result<bool, AuthError> {
+            Ok(true)
+        }
+    }
+
+    fn mfa_token<S, T>(engine: &Engine<S, T>, sub: &str, mfa_pending: bool) -> String {
+        let claims = crate::auth::state::MfaTokenClaims {
+            sub: sub.to_string(),
+            mfa_pending,
+            exp: (chrono::Utc::now() + chrono::Duration::minutes(10)).timestamp() as usize,
+        };
+        jsonwebtoken::encode(
+            &jsonwebtoken::Header::default(),
+            &claims,
+            &jsonwebtoken::EncodingKey::from_secret(&engine.mfa_jwt_secret),
+        )
+        .expect("signing should succeed")
+    }
+
+    fn totp_challenge(mfa_token: String) -> AuthInput {
+        AuthInput::MfaChallenge {
+            mfa_token,
+            challenge_input: Box::new(AuthInput::Totp {
+                user_id: "user123".to_string(),
+                code: "000000".to_string(),
+            }),
+        }
+    }
+
+    /// A validly-signed, unexpired token is still not a continuation ticket
+    /// unless it says so — otherwise any token minted with this secret for
+    /// another purpose would resume a half-completed login.
+    #[tokio::test]
+    async fn a_token_not_marked_mfa_pending_is_refused() {
+        let engine = Engine::builder()
+            .with_mfa_method(FixedTotpMethod("user123"))
+            .build();
+        let token = mfa_token(&engine, "user123", false);
+
+        assert!(matches!(
+            engine.authenticate(totp_challenge(token)).await,
+            Err(AuthError::InvalidInput)
+        ));
+    }
+
+    /// Only `Totp` and `WebAuthnAuthentication` dispatch as second factors.
+    /// Worth pinning: I wrote a test against this path earlier assuming
+    /// `Password` would reach the expiry check, and it silently did not.
+    #[tokio::test]
+    async fn a_challenge_whose_input_is_not_a_second_factor_is_refused() {
+        let engine = Engine::builder()
+            .with_mfa_method(FixedTotpMethod("user123"))
+            .build();
+        let token = mfa_token(&engine, "user123", true);
+
+        let result = engine
+            .authenticate(AuthInput::MfaChallenge {
+                mfa_token: token,
+                challenge_input: Box::new(AuthInput::Password {
+                    identifier: "user123".to_string(),
+                    password: "irrelevant".to_string(),
+                }),
+            })
+            .await;
+        assert!(matches!(result, Err(AuthError::InvalidInput)));
+    }
+
+    /// A misconfiguration, not a bad credential — hence `Internal` rather
+    /// than `InvalidInput`, and `error!` rather than `warn!` in the log.
+    #[tokio::test]
+    async fn a_second_factor_that_is_not_registered_is_an_internal_error() {
+        let engine = Engine::builder().build();
+        let token = mfa_token(&engine, "user123", true);
+
+        assert!(matches!(
+            engine.authenticate(totp_challenge(token)).await,
+            Err(AuthError::Internal(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_refused_second_factor_propagates_the_methods_error() {
+        let engine = Engine::builder()
+            .with_mfa_method(RejectingTotpMethod)
+            .build();
+        let token = mfa_token(&engine, "user123", true);
+
+        assert!(matches!(
+            engine.authenticate(totp_challenge(token)).await,
+            Err(AuthError::Credentials(_))
+        ));
+    }
+
+    /// The second factor verified, but for somebody else. Accepting this
+    /// would let anyone holding a continuation token for user A complete the
+    /// login by presenting their own valid second factor.
+    #[tokio::test]
+    async fn a_second_factor_verifying_a_different_user_is_refused() {
+        let engine = Engine::builder()
+            .with_mfa_method(FixedTotpMethod("someone-else"))
+            .build();
+        let token = mfa_token(&engine, "user123", true);
+
+        let err = engine
+            .authenticate(totp_challenge(token))
+            .await
+            .expect_err("a mismatched user must not complete the login");
+        assert!(
+            matches!(&err, AuthError::Credentials(m) if m.contains("user mismatch")),
+            "expected a user-mismatch rejection, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_input_that_maps_to_no_primary_method_is_refused() {
+        let engine = Engine::builder()
+            .with_mfa_method(FixedTotpMethod("user123"))
+            .build();
+
+        let result = engine
+            .authenticate(AuthInput::OAuthCode {
+                code: "abc".to_string(),
+                code_verifier: None,
+            })
+            .await;
+        assert!(matches!(result, Err(AuthError::InvalidInput)));
+    }
+
+    /// `Totp` maps to a primary method name too, so an engine that registers
+    /// it only as a step-up factor has no *primary* method under that name.
+    #[tokio::test]
+    async fn a_primary_method_registered_only_as_step_up_is_an_internal_error() {
+        let engine = Engine::builder()
+            .with_mfa_method(FixedTotpMethod("user123"))
+            .build();
+
+        let result = engine
+            .authenticate(AuthInput::Totp {
+                user_id: "user123".to_string(),
+                code: "000000".to_string(),
+            })
+            .await;
+        assert!(
+            matches!(result, Err(AuthError::Internal(_))),
+            "expected an Internal error, got {result:?}"
+        );
+    }
+
+    /// The happy path through the same fixtures, so the rejections above are
+    /// attributable to what each test varies rather than to the setup.
+    #[tokio::test]
+    async fn the_fixture_completes_a_login_when_nothing_is_wrong() {
+        let engine = Engine::builder()
+            .with_mfa_method(FixedTotpMethod("user123"))
+            .build();
+        let token = mfa_token(&engine, "user123", true);
+
+        assert!(matches!(
+            engine.authenticate(totp_challenge(token)).await,
+            Ok(AuthResult::Success(_))
+        ));
     }
 }

--- a/crates/authkestra-engine/src/token/dpop.rs
+++ b/crates/authkestra-engine/src/token/dpop.rs
@@ -166,6 +166,52 @@ pub fn verify_dpop_proof(
     expected_ath: Option<&str>,
     max_age: chrono::Duration,
 ) -> Result<VerifiedDpopProof, DpopError> {
+    // Logged once here rather than at each of the eleven rejection points
+    // inside. Every `DpopError` variant already names the check that failed
+    // — `WrongHtm`, `WrongHtu`, `Stale`, `AthMismatch`, `JtiTooLong(n)`,
+    // `UnsupportedAlgorithm(alg)` — so one line at the boundary carries the
+    // same information as eleven near-identical ones, and cannot drift out
+    // of step with the checks the way per-site logging does. Callers see
+    // only that verification failed (the adapters map every variant onto one
+    // `invalid_dpop_proof` response, deliberately), so without this the
+    // reason existed nowhere at all (#353).
+    //
+    // `compact_jws` is never logged: the proof is a credential.
+    let outcome = verify_dpop_proof_inner(
+        compact_jws,
+        expected_htm,
+        expected_htu,
+        expected_ath,
+        max_age,
+    );
+    match &outcome {
+        Ok(proof) => tracing::debug!(
+            jti = %proof.jti,
+            htm = %expected_htm,
+            htu = ?expected_htu,
+            ath_bound = expected_ath.is_some(),
+            "DPoP proof verified"
+        ),
+        Err(error) => tracing::warn!(
+            %error,
+            htm = %expected_htm,
+            htu = ?expected_htu,
+            ath_bound = expected_ath.is_some(),
+            "DPoP proof rejected"
+        ),
+    }
+    outcome
+}
+
+/// The verification itself. Split out so [`verify_dpop_proof`] can report the
+/// outcome in one place; see the comment there.
+fn verify_dpop_proof_inner(
+    compact_jws: &str,
+    expected_htm: &str,
+    expected_htu: Option<&str>,
+    expected_ath: Option<&str>,
+    max_age: chrono::Duration,
+) -> Result<VerifiedDpopProof, DpopError> {
     let mut parts = compact_jws.split('.');
     let header_b64 = parts
         .next()

--- a/crates/authkestra-engine/src/token/dpop.rs
+++ b/crates/authkestra-engine/src/token/dpop.rs
@@ -184,19 +184,24 @@ pub fn verify_dpop_proof(
         expected_ath,
         max_age,
     );
+    // Computed once outside the fields rather than inline in both arms. A
+    // call inside a `tracing` field expands into regions that no test can
+    // fully execute, so it reads as permanently uncovered however well the
+    // function is exercised; a plain binding is both covered and used twice.
+    let ath_bound = expected_ath.is_some();
     match &outcome {
         Ok(proof) => tracing::debug!(
             jti = %proof.jti,
             htm = %expected_htm,
             htu = ?expected_htu,
-            ath_bound = expected_ath.is_some(),
+            ath_bound,
             "DPoP proof verified"
         ),
         Err(error) => tracing::warn!(
             %error,
             htm = %expected_htm,
             htu = ?expected_htu,
-            ath_bound = expected_ath.is_some(),
+            ath_bound,
             "DPoP proof rejected"
         ),
     }
@@ -958,6 +963,67 @@ mod tests {
         assert_eq!(
             compute_jwk_thumbprint(&jwk).unwrap(),
             "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"
+        );
+    }
+
+    /// #353: the adapters map every `DpopError` onto a single
+    /// `invalid_dpop_proof` response, so before this the reason a proof was
+    /// refused existed nowhere at all. The reason is reported once at the
+    /// boundary, and this asserts it actually says which check failed.
+    ///
+    /// Installing a subscriber also makes the instrumentation genuinely run:
+    /// `tracing` skips its field expressions entirely when none is present,
+    /// so without this the fields are never evaluated by any test.
+    #[test]
+    fn a_rejected_proof_reports_which_check_failed() {
+        let proof = ProofBuilder::new().build();
+
+        let (result, logs) = crate::test_support::capture(|| {
+            // Signed for POST, presented as GET.
+            verify_dpop_proof(&proof, "GET", None, None, chrono::Duration::seconds(60))
+        });
+
+        assert!(matches!(result, Err(DpopError::WrongHtm)));
+        assert!(
+            logs.contains("DPoP proof rejected"),
+            "the rejection should be reported; got:\n{logs}"
+        );
+        // `%error` renders `DpopError`'s `Display`, so the line carries the
+        // reason in prose rather than as a variant name — which is what an
+        // operator wants, and is the whole point of logging it here.
+        assert!(
+            logs.contains("htm does not match the request method"),
+            "the log must name the check that failed, not just that one did; got:\n{logs}"
+        );
+        assert!(
+            !logs.contains(&proof),
+            "the proof is a credential and must never be logged:\n{logs}"
+        );
+    }
+
+    /// The accepting side of the same boundary.
+    #[test]
+    fn an_accepted_proof_is_logged_at_debug_without_the_proof_itself() {
+        let proof = ProofBuilder::new().build();
+
+        let (result, logs) = crate::test_support::capture(|| {
+            verify_dpop_proof(
+                &proof,
+                "POST",
+                Some("https://as.example.com/token"),
+                None,
+                chrono::Duration::seconds(60),
+            )
+        });
+
+        assert!(result.is_ok(), "the fixture must produce a valid proof");
+        assert!(
+            logs.contains("DPoP proof verified"),
+            "a successful verification should be visible at debug; got:\n{logs}"
+        );
+        assert!(
+            !logs.contains(&proof),
+            "the proof must never be logged:\n{logs}"
         );
     }
 }


### PR DESCRIPTION
Tier 1 of #353. Investigation and remaining tiers are recorded there.

## The gap

Measured against AGENTS.md's tracing DoD, `Engine::authenticate` was the worst-covered function in the workspace — **161 lines, no span, no events**, covering primary dispatch, MFA continuation and four error paths.

The contrast sits inside one file:

```
231:  pub async fn authenticate(...)                     // nothing
393:  #[tracing::instrument(skip(self, identity), ...)]
394:  pub async fn create_session(...)                   // debug + info + error
429:  #[tracing::instrument(...)]
430:  pub fn issue_token(...)                            // debug + info + error
```

A successful session emitted three events; a failed login emitted none. Backwards from what an operator needs.

## What changed

| file | tracing calls before → after |
|---|---|
| `engine.rs` | 8 → **30** |
| `auth/strategy.rs` | 0 → **8** |
| `token/dpop.rs` | 0 → **2** |

**`Engine::authenticate`** gains a span and events on every branch: which method was dispatched, why an input matched none, whether a second factor was required or skipped *and which of the two reasons applied*, and the user-mismatch rejection where a second factor verifies a different user than the continuation token names.

One thing worth calling out: the MFA token's decode error was previously thrown away by `map_err(|_| AuthError::InvalidInput)`. The caller still learns nothing beyond `InvalidInput` — expired and forged must look alike from outside — but it's now logged server-side, because *"was that token stale or unsigned?"* is the first question anyone debugging a stalled second factor asks.

**`auth/strategy.rs`** had seven public functions and no instrumentation, so each built-in strategy made an accept/reject decision with no trail. All four now report through one helper that keeps distinguishable the three cases callers collapse into one: *no credentials of my kind*, *credentials that yielded no identity*, *credentials that were rejected*. Under a first-success policy the first two both let the next strategy run, so an operator looking at a 401 needs to know which strategies declined and which actually refused something.

**`token/dpop.rs`** had fourteen error paths and no instrumentation, and the adapters map every variant onto one `invalid_dpop_proof` response — so the reason a proof failed existed nowhere at all.

Reported **once at the boundary** rather than at each of the fourteen rejections. Every `DpopError` variant already names the check that failed (`WrongHtm`, `WrongHtu`, `Stale`, `AthMismatch`, `JtiTooLong(n)`, `UnsupportedAlgorithm(alg)`), so one line carries the same information as fourteen and — the reason I preferred it — cannot drift out of step with the checks the way per-site logging does.

## Secret handling

This was the constraint throughout. `AuthInput` carries passwords and TOTP codes, so the span skips the argument rather than formatting it; the DPoP proof, the MFA token and the session cookie value are never logged. Identifiers only (`user_id`, `jti`, `htm`, `htu`, method names).

#353 records that the pre-existing instrumentation had no leaks either — worth keeping true, hence the second test below.

## Tests

Two, and I verified each by breaking the thing it protects:

| test | breaks when |
|---|---|
| `a_rejected_login_is_logged` | the rejection log is removed |
| `the_password_never_reaches_a_log_line` | `input` is dropped from the span's `skip` list |

The second is the one I care about. It doesn't just assert the password is absent — dropping `skip(input)` makes it **appear**, so the test confirms that the skip is what keeps it out rather than leaving that assumed.

They capture real subscriber output, so `tracing-subscriber` joins the dev-dependencies. Without a capturing subscriber the no-leak property is simply unassertable, and it's the one that would actually cause harm if it regressed.

## What `codecov/patch` surfaced

The first push had patch coverage of 68% — fourteen added lines uncovered. Every one sat on a path that **predated this branch**: the log lines were new, the untested branches were not. Instrumenting `authenticate` made visible that almost none of its rejection paths had ever been exercised.

So rather than suppress it, the second commit covers them — behaviour, not annotation:

**`authenticate` (8 tests)** — a token not marked `mfa_pending`, a challenge whose input is not a second factor, an unregistered second factor, a refused second factor, a second factor verifying a *different user* than the continuation token names, an input matching no primary method, a primary method registered only as step-up, plus the happy path through the same fixtures so each rejection is attributable to what its test varies.

The user-mismatch case is the one worth having: accepting it would let anyone holding a continuation token for user A finish the login with their own valid second factor.

**`auth/strategy.rs`** already had thorough tests — but **not one ever produced an `Err`**, so the strategies' rejection path (exactly what `log_outcome` exists to distinguish from a decline) was untested. Three cases added: a delegate that refuses, credentials resolving to nobody, and a header present but not ASCII.

**`token/dpop.rs`** gains tests asserting the boundary report says *which* check failed. Those install a subscriber, which matters beyond the assertion: `tracing` skips its field expressions entirely when none is present, so instrumentation is never executed by an ordinary `cargo test`. The capturing writer moved to a shared `test_support` module rather than being copied.

### One code change came out of measuring

`ath_bound = expected_ath.is_some()` inside a `tracing` field expands into regions no test can fully execute, so it read as permanently uncovered however well the function was exercised. Hoisted to a binding above the match — covered, and better anyway since it's used twice.

### Two lines remain uncovered, deliberately

The failure to mint an MFA token has no reachable failure mode to provoke (HS256, fixed 32-byte secret) and is now commented as such so nobody chases it. The other is a validator body in a test that asserts the validator is never reached — its returning `Ok(Some(..))` is precisely what makes `Ok(None)` prove non-invocation.

| file | coverage before → after |
|---|---|
| `engine.rs` | 66.18% → **73.53%** |
| `token/dpop.rs` | 96.76% → **97.26%** |
| `auth/strategy.rs` | 96.93% → **97.65%** |

Workspace total 87.24% → 87.37%.

## Deliberately not included

Tiers 2–4 from #353 stay there. Tier 4 in particular (op's 80 `warn!` against 10 `info!`) needs a stated levelling policy from you first — re-levelling 80 call sites on my judgement of what counts as operator-actionable would be the wrong call to make on your behalf.

## Semver

No behaviour or public API change. Patch-compatible.

## Verification

All five CI gates pass locally: `fmt`, `clippy`, `test`, `coverage` (87.24%), `deny`. Coverage of the touched files: `strategy.rs` 96.93%, `dpop.rs` 96.76%, `engine.rs` 66.18%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
