### PR TITLE
fix(actix): log the validated callback identity on the stateless path too

### DIFF
--- a/crates/authkestra-actix/src/helpers/api.rs
+++ b/crates/authkestra-actix/src/helpers/api.rs
@@ -400,6 +400,16 @@ pub async fn handle_oauth_callback_jwt_erased(
             actix_web::error::ErrorUnauthorized(format!("Authentication failed: {e}"))
         })?;
 
+    // Also emitted by the session callback above. On `authkestra-axum` one
+    // shared `finalize_callback_erased` covers both callbacks, so it cannot
+    // be present in one and missing from the other; here it has to be
+    // written twice. It was missing from this copy until a diff of the two
+    // blocks caught it, which is the drift #356 exists to remove.
+    tracing::debug!(
+        external_id = %identity.external_id,
+        "OAuth callback validated and exchanged for an identity"
+    );
+
     let user_id = identity.external_id.clone();
     let jwt = token_manager
         .issue_user_token(identity, expires_in_secs, None, None)


### PR DESCRIPTION
Follow-up to #355, which had already merged when this was found. Refs #356.

## The divergence

While gathering evidence for #356 I diffed actix's two copies of the OAuth state-cookie block against each other. The `"OAuth callback validated and exchanged for an identity"` debug that #355 added went into the **session** copy and was missed from the **JWT** copy.

Live on `main` today: actix's session callback reports the identity it resolved, its stateless callback does not, and axum reports it on both.

## Why only actix could have this bug

`authkestra-axum` routes both callbacks through one `finalize_callback_erased`, so an event added there covers both by construction. actix keeps two copies of the block, so the same event has to be written twice — and one was missed **in the very change that introduced it**.

That is the concrete drift #356 exists to remove, and it's why that issue is a bug report rather than a maintainability note.

## Scope

One `tracing::debug!`, ten lines including the comment explaining why it exists twice. No behaviour change, no public API change.

The comment points at #356 so whoever extracts the shared helper knows this line collapses into it.

## Verification

All five gates pass locally: `fmt`, `clippy --workspace --all-features --all-targets -D warnings`, `test --workspace --all-features`, `deny`. Both adapters now emit the message on both callback paths (2 occurrences in actix's helpers, 1 in axum's shared helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)