### PR TITLE
feat: instrument the token-validation path, and fix flaky log-capture tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "url",
  "wiremock",
 ]

--- a/crates/authkestra-actix/tests/engine_session_integration.rs
+++ b/crates/authkestra-actix/tests/engine_session_integration.rs
@@ -494,37 +494,89 @@ async fn the_login_redirect_is_a_see_other_like_axum() {
 // undecryptable one — the shape a rotated `state_encryption_key` takes — is
 // the log line.
 
-/// Accumulates emitted `tracing` output so a test can assert on it.
-#[derive(Clone, Default)]
-struct Captured(std::sync::Arc<Mutex<Vec<u8>>>);
+/// Routes each thread's `tracing` output to that thread's own buffer, and
+/// discards it on threads that are not capturing.
+///
+/// A **global** subscriber, installed once, rather than a thread-local one.
+/// `tracing` caches callsite interest globally and a thread-local subscriber
+/// does not invalidate that cache, so any test reaching a callsite while no
+/// subscriber is installed gets its interest cached as "never" — and a later
+/// thread-local capture there sees nothing. Rebuilding the cache does not fix
+/// it either, because the non-capturing tests run concurrently and re-cache
+/// "never" immediately after. Both were tried; both produced a capture that
+/// passed alone and failed in a parallel run (#353).
+mod capture {
+    use std::cell::RefCell;
+    use std::io;
+    use std::sync::{Arc, Mutex, Once};
 
-impl std::io::Write for Captured {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.lock().unwrap().extend_from_slice(buf);
-        Ok(buf.len())
+    thread_local! {
+        static SINK: RefCell<Option<Arc<Mutex<Vec<u8>>>>> = const { RefCell::new(None) };
     }
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
 
-impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Captured {
-    type Writer = Self;
-    fn make_writer(&'a self) -> Self::Writer {
-        self.clone()
+    #[derive(Clone, Copy, Default)]
+    pub struct ThreadSink;
+
+    impl io::Write for ThreadSink {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            SINK.with(|sink| {
+                if let Some(target) = sink.borrow().as_ref() {
+                    target.lock().unwrap().extend_from_slice(buf);
+                }
+            });
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for ThreadSink {
+        type Writer = Self;
+        fn make_writer(&'a self) -> Self::Writer {
+            *self
+        }
+    }
+
+    static INSTALL: Once = Once::new();
+
+    fn install() {
+        INSTALL.call_once(|| {
+            let _ = tracing_subscriber::fmt()
+                .with_writer(ThreadSink)
+                .with_max_level(tracing::Level::TRACE)
+                .without_time()
+                .try_init();
+        });
+    }
+
+    /// Starts capturing on this thread; the returned handle yields the output.
+    pub struct Handle(Arc<Mutex<Vec<u8>>>);
+
+    impl Handle {
+        pub fn contents(&self) -> String {
+            String::from_utf8_lossy(&self.0.lock().unwrap()).into_owned()
+        }
+    }
+
+    impl Drop for Handle {
+        fn drop(&mut self) {
+            SINK.with(|sink| *sink.borrow_mut() = None);
+        }
+    }
+
+    pub fn start() -> Handle {
+        install();
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        SINK.with(|sink| *sink.borrow_mut() = Some(Arc::clone(&buffer)));
+        Handle(buffer)
     }
 }
 
 /// Drives a callback carrying `state_cookie` (if any) and returns the status
 /// alongside everything logged while doing it.
 async fn callback_with_state(state_cookie: Option<&str>) -> (StatusCode, String) {
-    let captured = Captured::default();
-    let subscriber = tracing_subscriber::fmt()
-        .with_writer(captured.clone())
-        .with_max_level(tracing::Level::TRACE)
-        .without_time()
-        .finish();
-    let _guard = tracing::subscriber::set_default(subscriber);
+    let captured = capture::start();
 
     let engine = build_engine();
     let state = AppState {
@@ -546,7 +598,7 @@ async fn callback_with_state(state_cookie: Option<&str>) -> (StatusCode, String)
     let resp = test::call_service(&app, req.to_request()).await;
 
     let status = resp.status();
-    let logs = String::from_utf8_lossy(&captured.0.lock().unwrap()).into_owned();
+    let logs = captured.contents();
     (status, logs)
 }
 
@@ -621,13 +673,7 @@ async fn drive_capturing(
     engine: AkWebAppEngine,
     request: test::TestRequest,
 ) -> (StatusCode, String) {
-    let captured = Captured::default();
-    let subscriber = tracing_subscriber::fmt()
-        .with_writer(captured.clone())
-        .with_max_level(tracing::Level::TRACE)
-        .without_time()
-        .finish();
-    let _guard = tracing::subscriber::set_default(subscriber);
+    let captured = capture::start();
 
     let state = AppState {
         auth: engine.clone(),
@@ -642,7 +688,7 @@ async fn drive_capturing(
 
     let resp = test::call_service(&app, request.to_request()).await;
     let status = resp.status();
-    let logs = String::from_utf8_lossy(&captured.0.lock().unwrap()).into_owned();
+    let logs = captured.contents();
     (status, logs)
 }
 

--- a/crates/authkestra-actix/tests/engine_token_integration.rs
+++ b/crates/authkestra-actix/tests/engine_token_integration.rs
@@ -222,36 +222,88 @@ async fn protected_route_rejects_garbage_bearer_token() {
 // copies of that block — one per callback — so the stateless copy needs its
 // own tests, and would otherwise be the half that drifts.
 
-/// Accumulates emitted `tracing` output so a test can assert on it.
-#[derive(Clone, Default)]
-struct Captured(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+/// Routes each thread's `tracing` output to that thread's own buffer, and
+/// discards it on threads that are not capturing.
+///
+/// A **global** subscriber, installed once, rather than a thread-local one.
+/// `tracing` caches callsite interest globally and a thread-local subscriber
+/// does not invalidate that cache, so any test reaching a callsite while no
+/// subscriber is installed gets its interest cached as "never" — and a later
+/// thread-local capture there sees nothing. Rebuilding the cache does not fix
+/// it either, because the non-capturing tests run concurrently and re-cache
+/// "never" immediately after. Both were tried; both produced a capture that
+/// passed alone and failed in a parallel run (#353).
+mod capture {
+    use std::cell::RefCell;
+    use std::io;
+    use std::sync::{Arc, Mutex, Once};
 
-impl std::io::Write for Captured {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.lock().unwrap().extend_from_slice(buf);
-        Ok(buf.len())
+    thread_local! {
+        static SINK: RefCell<Option<Arc<Mutex<Vec<u8>>>>> = const { RefCell::new(None) };
     }
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
 
-impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Captured {
-    type Writer = Self;
-    fn make_writer(&'a self) -> Self::Writer {
-        self.clone()
+    #[derive(Clone, Copy, Default)]
+    pub struct ThreadSink;
+
+    impl io::Write for ThreadSink {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            SINK.with(|sink| {
+                if let Some(target) = sink.borrow().as_ref() {
+                    target.lock().unwrap().extend_from_slice(buf);
+                }
+            });
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for ThreadSink {
+        type Writer = Self;
+        fn make_writer(&'a self) -> Self::Writer {
+            *self
+        }
+    }
+
+    static INSTALL: Once = Once::new();
+
+    fn install() {
+        INSTALL.call_once(|| {
+            let _ = tracing_subscriber::fmt()
+                .with_writer(ThreadSink)
+                .with_max_level(tracing::Level::TRACE)
+                .without_time()
+                .try_init();
+        });
+    }
+
+    /// Starts capturing on this thread; the returned handle yields the output.
+    pub struct Handle(Arc<Mutex<Vec<u8>>>);
+
+    impl Handle {
+        pub fn contents(&self) -> String {
+            String::from_utf8_lossy(&self.0.lock().unwrap()).into_owned()
+        }
+    }
+
+    impl Drop for Handle {
+        fn drop(&mut self) {
+            SINK.with(|sink| *sink.borrow_mut() = None);
+        }
+    }
+
+    pub fn start() -> Handle {
+        install();
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        SINK.with(|sink| *sink.borrow_mut() = Some(Arc::clone(&buffer)));
+        Handle(buffer)
     }
 }
 
 /// Drives the stateless callback carrying `state_cookie` (if any).
 async fn stateless_callback_with_state(state_cookie: Option<&str>) -> (StatusCode, String) {
-    let captured = Captured::default();
-    let subscriber = tracing_subscriber::fmt()
-        .with_writer(captured.clone())
-        .with_max_level(tracing::Level::TRACE)
-        .without_time()
-        .finish();
-    let _guard = tracing::subscriber::set_default(subscriber);
+    let captured = capture::start();
 
     let engine = build_engine();
     let state = AppState {
@@ -273,7 +325,7 @@ async fn stateless_callback_with_state(state_cookie: Option<&str>) -> (StatusCod
     let resp = test::call_service(&app, req.to_request()).await;
 
     let status = resp.status();
-    let logs = String::from_utf8_lossy(&captured.0.lock().unwrap()).into_owned();
+    let logs = captured.contents();
     (status, logs)
 }
 
@@ -313,13 +365,7 @@ async fn a_stateless_callback_whose_state_cookie_will_not_decrypt_says_so() {
 /// copy of the block needs its own, which is the cost of duplicating it.
 #[actix_web::test]
 async fn a_stateless_callback_whose_code_exchange_fails_says_so() {
-    let captured = Captured::default();
-    let subscriber = tracing_subscriber::fmt()
-        .with_writer(captured.clone())
-        .with_max_level(tracing::Level::TRACE)
-        .without_time()
-        .finish();
-    let _guard = tracing::subscriber::set_default(subscriber);
+    let captured = capture::start();
 
     let engine = build_engine();
     let state = AppState {
@@ -364,7 +410,7 @@ async fn a_stateless_callback_whose_code_exchange_fails_says_so() {
     .await;
 
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-    let logs = String::from_utf8_lossy(&captured.0.lock().unwrap()).into_owned();
+    let logs = captured.contents();
     assert!(
         logs.contains("code exchange failed after state validation"),
         "a provider refusal must be distinguishable from a state failure; got:\n{logs}"

--- a/crates/authkestra-axum/tests/engine_session_integration.rs
+++ b/crates/authkestra-axum/tests/engine_session_integration.rs
@@ -512,37 +512,89 @@ async fn a_registered_provider_still_redirects() {
 // operator could not tell a browser `SameSite` problem from a rotated
 // `state_encryption_key`. These assert they now read differently.
 
-/// Accumulates emitted `tracing` output so a test can assert on it.
-#[derive(Clone, Default)]
-struct Captured(Arc<Mutex<Vec<u8>>>);
+/// Routes each thread's `tracing` output to that thread's own buffer, and
+/// discards it on threads that are not capturing.
+///
+/// A **global** subscriber, installed once, rather than a thread-local one.
+/// `tracing` caches callsite interest globally and a thread-local subscriber
+/// does not invalidate that cache, so any test reaching a callsite while no
+/// subscriber is installed gets its interest cached as "never" — and a later
+/// thread-local capture there sees nothing. Rebuilding the cache does not fix
+/// it either, because the non-capturing tests run concurrently and re-cache
+/// "never" immediately after. Both were tried; both produced a capture that
+/// passed alone and failed in a parallel run (#353).
+mod capture {
+    use std::cell::RefCell;
+    use std::io;
+    use std::sync::{Arc, Mutex, Once};
 
-impl std::io::Write for Captured {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.lock().unwrap().extend_from_slice(buf);
-        Ok(buf.len())
+    thread_local! {
+        static SINK: RefCell<Option<Arc<Mutex<Vec<u8>>>>> = const { RefCell::new(None) };
     }
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
 
-impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Captured {
-    type Writer = Self;
-    fn make_writer(&'a self) -> Self::Writer {
-        self.clone()
+    #[derive(Clone, Copy, Default)]
+    pub struct ThreadSink;
+
+    impl io::Write for ThreadSink {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            SINK.with(|sink| {
+                if let Some(target) = sink.borrow().as_ref() {
+                    target.lock().unwrap().extend_from_slice(buf);
+                }
+            });
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for ThreadSink {
+        type Writer = Self;
+        fn make_writer(&'a self) -> Self::Writer {
+            *self
+        }
+    }
+
+    static INSTALL: Once = Once::new();
+
+    fn install() {
+        INSTALL.call_once(|| {
+            let _ = tracing_subscriber::fmt()
+                .with_writer(ThreadSink)
+                .with_max_level(tracing::Level::TRACE)
+                .without_time()
+                .try_init();
+        });
+    }
+
+    /// Starts capturing on this thread; the returned handle yields the output.
+    pub struct Handle(Arc<Mutex<Vec<u8>>>);
+
+    impl Handle {
+        pub fn contents(&self) -> String {
+            String::from_utf8_lossy(&self.0.lock().unwrap()).into_owned()
+        }
+    }
+
+    impl Drop for Handle {
+        fn drop(&mut self) {
+            SINK.with(|sink| *sink.borrow_mut() = None);
+        }
+    }
+
+    pub fn start() -> Handle {
+        install();
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        SINK.with(|sink| *sink.borrow_mut() = Some(Arc::clone(&buffer)));
+        Handle(buffer)
     }
 }
 
 /// Drives a callback carrying `state_cookie` (if any) and returns the status
 /// alongside everything logged while doing it.
 async fn callback_with_state(state_cookie: Option<&str>) -> (StatusCode, String) {
-    let captured = Captured::default();
-    let subscriber = tracing_subscriber::fmt()
-        .with_writer(captured.clone())
-        .with_max_level(tracing::Level::TRACE)
-        .without_time()
-        .finish();
-    let _guard = tracing::subscriber::set_default(subscriber);
+    let captured = capture::start();
 
     let app = build_app();
     let mut request = Request::builder().uri("/auth/callback/mock?code=valid-code&state=whatever");
@@ -555,7 +607,7 @@ async fn callback_with_state(state_cookie: Option<&str>) -> (StatusCode, String)
         .unwrap();
 
     let status = resp.status();
-    let logs = String::from_utf8_lossy(&captured.0.lock().unwrap()).into_owned();
+    let logs = captured.contents();
     (status, logs)
 }
 
@@ -635,17 +687,11 @@ fn app_with_failing_store() -> Router {
 
 /// Runs `request` against `app` with logging captured.
 async fn drive_capturing(app: Router, request: Request<Body>) -> (StatusCode, String) {
-    let captured = Captured::default();
-    let subscriber = tracing_subscriber::fmt()
-        .with_writer(captured.clone())
-        .with_max_level(tracing::Level::TRACE)
-        .without_time()
-        .finish();
-    let _guard = tracing::subscriber::set_default(subscriber);
+    let captured = capture::start();
 
     let resp = app.oneshot(request).await.unwrap();
     let status = resp.status();
-    let logs = String::from_utf8_lossy(&captured.0.lock().unwrap()).into_owned();
+    let logs = captured.contents();
     (status, logs)
 }
 

--- a/crates/authkestra-engine/src/test_support.rs
+++ b/crates/authkestra-engine/src/test_support.rs
@@ -1,37 +1,26 @@
 //! Test-only helpers shared across this crate's test modules.
 
+use std::cell::RefCell;
 use std::io;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Once};
 
-/// A `MakeWriter` that accumulates everything written to it, so a test can
-/// assert on the `tracing` output actually emitted.
-///
-/// Two reasons this exists rather than each test module rolling its own.
-///
-/// The first is the property it makes assertable: instrumentation on an
-/// authentication path is handed credentials, and "the password never reaches
-/// a log line" cannot be checked without capturing what was emitted.
-///
-/// The second is subtler. `tracing` macros do not evaluate their field
-/// expressions when no subscriber is installed, so a field like
-/// `ath_bound = expected_ath.is_some()` is never executed under a plain
-/// `cargo test` and shows as uncovered however well the surrounding function
-/// is exercised. Installing a subscriber makes the instrumentation genuinely
-/// run, which is both more honest about coverage and the only way to assert
-/// that a log line says what it claims to.
-#[derive(Clone, Default)]
-pub(crate) struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
-
-impl CapturedLogs {
-    /// Everything emitted so far.
-    pub(crate) fn contents(&self) -> String {
-        String::from_utf8_lossy(&self.0.lock().unwrap()).into_owned()
-    }
+thread_local! {
+    /// Where this thread's captured output goes, when it is capturing.
+    static SINK: RefCell<Option<Arc<Mutex<Vec<u8>>>>> = const { RefCell::new(None) };
 }
 
-impl io::Write for CapturedLogs {
+/// Routes each thread's `tracing` output to that thread's own buffer, and
+/// discards it on threads that are not capturing.
+#[derive(Clone, Copy, Default)]
+struct ThreadSink;
+
+impl io::Write for ThreadSink {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.lock().unwrap().extend_from_slice(buf);
+        SINK.with(|sink| {
+            if let Some(target) = sink.borrow().as_ref() {
+                target.lock().unwrap().extend_from_slice(buf);
+            }
+        });
         Ok(buf.len())
     }
     fn flush(&mut self) -> io::Result<()> {
@@ -39,24 +28,54 @@ impl io::Write for CapturedLogs {
     }
 }
 
-impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturedLogs {
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for ThreadSink {
     type Writer = Self;
     fn make_writer(&'a self) -> Self::Writer {
-        self.clone()
+        *self
     }
 }
 
-/// Runs `body` with every `tracing` event captured, returning the output.
+static INSTALL: Once = Once::new();
+
+/// Installs one process-wide subscriber, once.
 ///
-/// The subscriber is installed for the current thread only, so this composes
-/// with `#[tokio::test]`'s default current-thread runtime.
+/// A **global** subscriber rather than a thread-local one, which is the whole
+/// point. `tracing` caches callsite interest globally and a thread-local
+/// subscriber does not invalidate that cache, so any test that reaches a
+/// callsite while no subscriber is installed gets its interest cached as
+/// "never" — and a later thread-local capture at that callsite sees nothing,
+/// however correctly it installed its subscriber.
+///
+/// Rebuilding the cache is not enough either: the tests that are not
+/// capturing run concurrently and re-cache "never" immediately afterwards.
+/// Both were tried, and both produced a capture that passed alone and failed
+/// in a parallel run.
+///
+/// Installed once at `TRACE`, interest is stable for the life of the process,
+/// and the per-thread sink decides what is kept.
+fn install() {
+    INSTALL.call_once(|| {
+        let _ = tracing_subscriber::fmt()
+            .with_writer(ThreadSink)
+            .with_max_level(tracing::Level::TRACE)
+            .without_time()
+            .try_init();
+    });
+}
+
+/// Runs `body` with this thread's `tracing` output captured.
+///
+/// Capture is per-thread, so this needs no lock and composes with `cargo
+/// test`'s parallelism. It does assume `body` emits on the calling thread,
+/// which holds for `#[tokio::test]`'s default current-thread runtime.
 pub(crate) fn capture<T>(body: impl FnOnce() -> T) -> (T, String) {
-    let captured = CapturedLogs::default();
-    let subscriber = tracing_subscriber::fmt()
-        .with_writer(captured.clone())
-        .with_max_level(tracing::Level::TRACE)
-        .without_time()
-        .finish();
-    let value = tracing::subscriber::with_default(subscriber, body);
-    (value, captured.contents())
+    install();
+
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    SINK.with(|sink| *sink.borrow_mut() = Some(Arc::clone(&buffer)));
+    let value = body();
+    SINK.with(|sink| *sink.borrow_mut() = None);
+
+    let captured = String::from_utf8_lossy(&buffer.lock().unwrap()).into_owned();
+    (value, captured)
 }

--- a/crates/authkestra-engine/src/token/jwk.rs
+++ b/crates/authkestra-engine/src/token/jwk.rs
@@ -51,6 +51,32 @@ impl Jwk {
     /// shape) and `"OKP"` with `crv: "Ed25519"` (RFC 8037). Any other `kty`,
     /// or an OKP key advertising an unsupported curve, is rejected.
     pub fn to_decoding_key(&self) -> Result<DecodingKey, AuthError> {
+        // Reported once here rather than at each of the nine rejection points
+        // inside. Every one of them builds an `AuthError::Token` whose message
+        // already names what was wrong — a missing `n`, an unsupported curve,
+        // a low-order Ed25519 point — so one line at the boundary carries the
+        // same information and cannot fall out of step with the checks.
+        //
+        // Worth having because callers collapse this: `validate_jwt_generic`
+        // turns any failure here into the same rejection as a bad signature,
+        // so "the issuer published a key this crate cannot use" was
+        // indistinguishable from "the token is forged" (#353).
+        let outcome = self.to_decoding_key_inner();
+        if let Err(error) = &outcome {
+            tracing::warn!(
+                kid = ?self.kid,
+                kty = %self.kty,
+                alg = ?self.alg,
+                %error,
+                "JWKS key could not be turned into a verification key"
+            );
+        }
+        outcome
+    }
+
+    /// The conversion itself. Split out so [`Jwk::to_decoding_key`] can report
+    /// the outcome in one place; see the comment there.
+    fn to_decoding_key_inner(&self) -> Result<DecodingKey, AuthError> {
         match self.kty.as_str() {
             "RSA" => {
                 let n = self
@@ -123,6 +149,67 @@ mod tests {
             err.to_string().contains("low-order"),
             "expected low-order point rejection, got: {}",
             err
+        );
+    }
+
+    /// #353: a key the issuer published but this crate cannot use was
+    /// indistinguishable, to a caller, from a forged token — nine rejection
+    /// branches here all collapse into the same downstream rejection. The
+    /// reason is now reported at the boundary.
+    #[test]
+    fn an_unusable_key_reports_why_and_identifies_the_key() {
+        let jwk = Jwk {
+            kid: Some("kid-1".to_string()),
+            kty: "EC".to_string(),
+            alg: Some("ES256".to_string()),
+            n: None,
+            e: None,
+            crv: Some("P-256".to_string()),
+            x: Some("irrelevant".to_string()),
+        };
+
+        let (result, logs) = crate::test_support::capture(|| jwk.to_decoding_key());
+
+        assert!(result.is_err());
+        assert!(
+            logs.contains("could not be turned into a verification key"),
+            "the failure should be reported; got:\n{logs}"
+        );
+        assert!(
+            logs.contains("kid-1") && logs.contains("EC"),
+            "and should identify which published key was unusable; got:\n{logs}"
+        );
+        assert!(
+            logs.contains("only RSA and OKP are supported"),
+            "and say what was wrong with it; got:\n{logs}"
+        );
+    }
+
+    /// A usable key logs nothing: this is a per-token hot path, and a warning
+    /// on every successful verification would be noise.
+    #[test]
+    fn a_usable_key_is_silent() {
+        // A real Ed25519 point, so the strict parse succeeds.
+        use base64::Engine as _;
+        let signing = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        let x = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(signing.verifying_key().to_bytes());
+        let jwk = Jwk {
+            kid: None,
+            kty: "OKP".to_string(),
+            alg: None,
+            n: None,
+            e: None,
+            crv: Some("Ed25519".to_string()),
+            x: Some(x),
+        };
+
+        let (result, logs) = crate::test_support::capture(|| jwk.to_decoding_key());
+
+        assert!(result.is_ok(), "the fixture must produce a usable key");
+        assert!(
+            logs.is_empty(),
+            "a successful conversion should not log on a per-token path:\n{logs}"
         );
     }
 }

--- a/crates/authkestra-engine/src/token/jwk.rs
+++ b/crates/authkestra-engine/src/token/jwk.rs
@@ -51,19 +51,26 @@ impl Jwk {
     /// shape) and `"OKP"` with `crv: "Ed25519"` (RFC 8037). Any other `kty`,
     /// or an OKP key advertising an unsupported curve, is rejected.
     pub fn to_decoding_key(&self) -> Result<DecodingKey, AuthError> {
-        // Reported once here rather than at each of the nine rejection points
-        // inside. Every one of them builds an `AuthError::Token` whose message
-        // already names what was wrong — a missing `n`, an unsupported curve,
-        // a low-order Ed25519 point — so one line at the boundary carries the
-        // same information and cannot fall out of step with the checks.
+        // Reported at one boundary rather than at each of the nine rejection
+        // points inside. Every one of them builds an `AuthError::Token` whose
+        // message already names what was wrong — a missing `n`, an
+        // unsupported curve, a low-order Ed25519 point — so one line here
+        // carries the same information and cannot fall out of step with the
+        // checks.
         //
-        // Worth having because callers collapse this: `validate_jwt_generic`
-        // turns any failure here into the same rejection as a bad signature,
-        // so "the issuer published a key this crate cannot use" was
-        // indistinguishable from "the token is forged" (#353).
+        // `debug!`, not `warn!`, and the distinction is load-bearing: this is
+        // the per-token verification path, so an issuer publishing one key
+        // shape this crate rejects would otherwise emit a warning for *every*
+        // token that resolves to it, for as long as the key stays in the
+        // JWKS. Warn-level visibility of the condition is not lost —
+        // `AuthError` propagates as `ValidationError::Discovery` and
+        // `JwtStrategy::authenticate` reports it as "could not determine
+        // whether the token is valid" — so what belongs here is the
+        // structured identification of *which* published key was unusable,
+        // which is a debugging detail rather than an alert.
         let outcome = self.to_decoding_key_inner();
         if let Err(error) = &outcome {
-            tracing::warn!(
+            tracing::debug!(
                 kid = ?self.kid,
                 kty = %self.kty,
                 alg = ?self.alg,
@@ -156,6 +163,9 @@ mod tests {
     /// indistinguishable, to a caller, from a forged token — nine rejection
     /// branches here all collapse into the same downstream rejection. The
     /// reason is now reported at the boundary.
+    ///
+    /// At `DEBUG`, asserted below: this runs per token, so a warning here
+    /// would repeat for every token resolving to an unusable key.
     #[test]
     fn an_unusable_key_reports_why_and_identifies_the_key() {
         let jwk = Jwk {
@@ -182,6 +192,11 @@ mod tests {
         assert!(
             logs.contains("only RSA and OKP are supported"),
             "and say what was wrong with it; got:\n{logs}"
+        );
+        assert!(
+            logs.contains("DEBUG") && !logs.contains("WARN"),
+            "this is a per-token path; a warning here would repeat for every \
+             token resolving to the same unusable key; got:\n{logs}"
         );
     }
 

--- a/crates/authkestra-resource/Cargo.toml
+++ b/crates/authkestra-resource/Cargo.toml
@@ -44,6 +44,10 @@ rustls-aws-lc-rs = ["authkestra-engine/rustls-aws-lc-rs"]
 rustls-no-provider = ["authkestra-engine/rustls-no-provider"]
 
 [dev-dependencies]
+# Test-only: a token that fails validation is declined with `Ok(None)`, so the
+# only record of *why* is the log line. Capturing emitted output is the only
+# way to assert it (#353).
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
 wiremock = "0.6"
 rsa = "0.9.6"
 rand = "0.8"

--- a/crates/authkestra-resource/src/jwt.rs
+++ b/crates/authkestra-resource/src/jwt.rs
@@ -212,10 +212,18 @@ impl JwksCache {
         let jwks = self.refresh().await?;
         let key = jwks.find_key(kid).cloned();
         if key.is_none() {
-            // Distinct from a fetch failure: the endpoint answered, and the
-            // key this token names is not in it. Signing key retired too
-            // early, or a token from a different issuer entirely.
-            tracing::warn!(kid, "token names a key the issuer's JWKS does not contain");
+            // Both mean "the endpoint answered and we still have no key", but
+            // they are different faults and must not share a message: with no
+            // `kid`, `find_key` falls back to the first key, so the only way
+            // to get here is an empty key set — the token named nothing.
+            match kid {
+                Some(kid) => {
+                    tracing::warn!(kid, "token names a key the issuer's JWKS does not contain")
+                }
+                None => tracing::warn!(
+                    "token carries no kid and the issuer's JWKS has no key to fall back to"
+                ),
+            }
         }
         Ok(key)
     }

--- a/crates/authkestra-resource/src/jwt.rs
+++ b/crates/authkestra-resource/src/jwt.rs
@@ -95,7 +95,22 @@ impl Jwks {
         client: &reqwest::Client,
         jwks_uri: &str,
     ) -> Result<Self, ValidationError> {
-        let jwks = client.get(jwks_uri).send().await?.json::<Jwks>().await?;
+        // An unreachable, slow or malformed JWKS endpoint is among the most
+        // common ways a resource server stops working, and this whole path
+        // was silent: the error propagated as `ValidationError::Http` and was
+        // only ever seen if some caller happened to log it.
+        tracing::debug!(jwks_uri, "fetching JWKS");
+        let jwks = match client.get(jwks_uri).send().await {
+            Ok(response) => response.json::<Jwks>().await.map_err(|e| {
+                tracing::warn!(jwks_uri, error = %e, "JWKS response was not a usable key set");
+                ValidationError::Http(e)
+            })?,
+            Err(e) => {
+                tracing::warn!(jwks_uri, error = %e, "could not reach the JWKS endpoint");
+                return Err(ValidationError::Http(e));
+            }
+        };
+        tracing::debug!(jwks_uri, keys = jwks.keys.len(), "fetched JWKS");
         Ok(jwks)
     }
 
@@ -190,8 +205,19 @@ impl JwksCache {
         }
 
         // If key not found, try refreshing once in case of rotation
+        tracing::debug!(
+            kid,
+            "no key for this token in the cached JWKS; refreshing in case of rotation"
+        );
         let jwks = self.refresh().await?;
-        Ok(jwks.find_key(kid).cloned())
+        let key = jwks.find_key(kid).cloned();
+        if key.is_none() {
+            // Distinct from a fetch failure: the endpoint answered, and the
+            // key this token names is not in it. Signing key retired too
+            // early, or a token from a different issuer entirely.
+            tracing::warn!(kid, "token names a key the issuer's JWKS does not contain");
+        }
+        Ok(key)
     }
 
     pub async fn refresh(&self) -> Result<Jwks, ValidationError> {
@@ -854,6 +880,11 @@ impl<I> AuthenticationStrategy<I> for JwtStrategy<I>
 where
     I: for<'de> Deserialize<'de> + Send + Sync + 'static,
 {
+    // `skip_all`: `parts` carries the `Authorization` header, and a derived
+    // span field would print the bearer token. The span exists so the dozen
+    // rejection events in this function can be correlated to one request,
+    // which is what having none of them under a span cost (#353).
+    #[tracing::instrument(skip_all, name = "jwt_authenticate")]
     async fn authenticate(&self, parts: &Parts) -> Result<Option<I>, AuthError> {
         if let Some(presented) = extract_presented_token(&parts.headers) {
             let token = presented.token();
@@ -1008,8 +1039,26 @@ where
                     }
                     Ok(Some(claims))
                 }
-                Err(ValidationError::InvalidToken(_)) | Err(ValidationError::Jwt(_)) => Ok(None),
-                Err(e) => Err(AuthError::Token(e.to_string())),
+                // A token that failed signature or claim validation. This
+                // returns `Ok(None)` — "declined", so another strategy may
+                // still run — and used to do so silently, which left the
+                // resource server unable to answer the one question anyone
+                // asks it: why was that token rejected? #335 is exactly that
+                // question, and answering it took reading a dependency's
+                // source. `debug!`, not `warn!`, to match the issuer-decline
+                // above: under a first-success policy a decline is ordinary.
+                Err(e @ (ValidationError::InvalidToken(_) | ValidationError::Jwt(_))) => {
+                    tracing::debug!(error = %e, "token failed validation; no identity");
+                    Ok(None)
+                }
+                // Everything else — a JWKS that could not be fetched, a key
+                // that could not be found, replay protection that could not
+                // be checked — is not "this credential is bad" but "we could
+                // not tell", and is propagated as a hard error.
+                Err(e) => {
+                    tracing::warn!(error = %e, "could not determine whether the token is valid");
+                    Err(AuthError::Token(e.to_string()))
+                }
             }
         } else {
             Ok(None)

--- a/crates/authkestra-resource/tests/jwt_test.rs
+++ b/crates/authkestra-resource/tests/jwt_test.rs
@@ -1860,3 +1860,35 @@ async fn a_token_naming_an_unknown_kid_says_the_jwks_lacks_it() {
         "and the give-up should say the JWKS lacks the key; got:\n{logs}"
     );
 }
+
+/// Review finding on #358: with no `kid`, `find_key` falls back to the first
+/// key, so the only way to reach the give-up branch is an empty key set — the
+/// token named nothing. Reporting that as "token names a key the JWKS does not
+/// contain" described a fault that had not happened.
+#[tokio::test(flavor = "current_thread")]
+async fn an_empty_jwks_does_not_claim_the_token_named_a_missing_key() {
+    let key = generate_rsa_key(None);
+    // The endpoint answers, with no keys at all.
+    let server = start_jwks_server(vec![]).await;
+    let config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .build();
+
+    let claims = TestClaims {
+        sub: "user-1".to_string(),
+        exp: future_exp(),
+        aud: None,
+    };
+    // No `kid` on the token either, which is what selects the fallback path.
+    let token = sign_token(&key.encoding_key, None, &claims);
+    let (_result, logs) = authenticate_capturing(config, &token).await;
+
+    assert!(
+        logs.contains("no kid and the issuer's JWKS has no key"),
+        "an empty key set should be reported as such; got:\n{logs}"
+    );
+    assert!(
+        !logs.contains("token names a key"),
+        "the token named no key, so it must not be blamed for one; got:\n{logs}"
+    );
+}

--- a/crates/authkestra-resource/tests/jwt_test.rs
+++ b/crates/authkestra-resource/tests/jwt_test.rs
@@ -1655,3 +1655,208 @@ async fn rejects_hmac_token_verified_against_an_rsa_jwks_key() {
         "expected the RSA key to be refused by the HMAC verifier, got: {err}"
     );
 }
+
+// --- Why a token was rejected (#353) ---
+//
+// `JwtStrategy::authenticate` declines an invalid token with `Ok(None)` so
+// another strategy may still run. That decline used to be silent, which left
+// the resource server unable to answer the question #335 was filed to ask:
+// why was this token rejected? These assert the reason is now recorded, and
+// that the credential itself still is not.
+
+/// Routes each thread's `tracing` output to that thread's own buffer, and
+/// discards it on threads that are not capturing.
+///
+/// A **global** subscriber, installed once, rather than a thread-local one.
+/// `tracing` caches callsite interest globally and a thread-local subscriber
+/// does not invalidate that cache, so any test reaching a callsite while no
+/// subscriber is installed gets its interest cached as "never" — and a later
+/// thread-local capture there sees nothing. Rebuilding the cache does not fix
+/// it either, because the non-capturing tests run concurrently and re-cache
+/// "never" immediately after. Both were tried; both produced a capture that
+/// passed alone and failed in a parallel run (#353).
+mod capture {
+    use std::cell::RefCell;
+    use std::io;
+    use std::sync::{Arc, Mutex, Once};
+
+    thread_local! {
+        static SINK: RefCell<Option<Arc<Mutex<Vec<u8>>>>> = const { RefCell::new(None) };
+    }
+
+    #[derive(Clone, Copy, Default)]
+    pub struct ThreadSink;
+
+    impl io::Write for ThreadSink {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            SINK.with(|sink| {
+                if let Some(target) = sink.borrow().as_ref() {
+                    target.lock().unwrap().extend_from_slice(buf);
+                }
+            });
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for ThreadSink {
+        type Writer = Self;
+        fn make_writer(&'a self) -> Self::Writer {
+            *self
+        }
+    }
+
+    static INSTALL: Once = Once::new();
+
+    fn install() {
+        INSTALL.call_once(|| {
+            let _ = tracing_subscriber::fmt()
+                .with_writer(ThreadSink)
+                .with_max_level(tracing::Level::TRACE)
+                .without_time()
+                .try_init();
+        });
+    }
+
+    /// Starts capturing on this thread; the returned handle yields the output.
+    pub struct Handle(Arc<Mutex<Vec<u8>>>);
+
+    impl Handle {
+        pub fn contents(&self) -> String {
+            String::from_utf8_lossy(&self.0.lock().unwrap()).into_owned()
+        }
+    }
+
+    impl Drop for Handle {
+        fn drop(&mut self) {
+            SINK.with(|sink| *sink.borrow_mut() = None);
+        }
+    }
+
+    pub fn start() -> Handle {
+        install();
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        SINK.with(|sink| *sink.borrow_mut() = Some(Arc::clone(&buffer)));
+        Handle(buffer)
+    }
+}
+
+/// Runs `strategy.authenticate` against a Bearer `token`, capturing logs.
+async fn authenticate_capturing(
+    config: ValidationConfig,
+    token: &str,
+) -> (
+    Result<Option<TestClaims>, authkestra_engine::error::AuthError>,
+    String,
+) {
+    let captured = capture::start();
+
+    let strategy: JwtStrategy<TestClaims> = JwtStrategy::new(config);
+    let request = Request::builder()
+        .header(AUTHORIZATION, format!("Bearer {token}"))
+        .body(())
+        .unwrap();
+    let (parts, _) = request.into_parts();
+
+    let result = strategy.authenticate(&parts).await;
+    let logs = captured.contents();
+    (result, logs)
+}
+
+/// An expired token is declined, and the reason is now on the record. This is
+/// #335's question — "my token looks fine, why is it refused?" — answered at
+/// the layer that refused it.
+#[tokio::test(flavor = "current_thread")]
+async fn a_token_that_fails_validation_records_why() {
+    let key = generate_rsa_key(Some("kid-1"));
+    let server = start_jwks_server(vec![key.jwk.clone()]).await;
+    let config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .leeway(0)
+        .build();
+
+    let token = expired_token(&key, 120);
+    let (result, logs) = authenticate_capturing(config, &token).await;
+
+    assert!(
+        matches!(result, Ok(None)),
+        "an invalid token is a decline, not a hard error"
+    );
+    assert!(
+        logs.contains("token failed validation"),
+        "the decline should be recorded; got:\n{logs}"
+    );
+    assert!(
+        logs.contains("ExpiredSignature"),
+        "and it should say which check failed; got:\n{logs}"
+    );
+    assert!(
+        !logs.contains(&token),
+        "the bearer token must never be logged:\n{logs}"
+    );
+}
+
+/// An unreachable JWKS endpoint is not a bad credential — it is not knowing.
+/// It surfaces as a hard error rather than a decline, and both the fetch
+/// failure and that distinction are now visible.
+#[tokio::test(flavor = "current_thread")]
+async fn an_unreachable_jwks_endpoint_is_reported_and_is_not_a_decline() {
+    let key = generate_rsa_key(Some("kid-1"));
+    // A port nothing is listening on.
+    let config = ValidationConfig::builder()
+        .jwks_url("http://127.0.0.1:1/.well-known/jwks.json")
+        .build();
+
+    let claims = TestClaims {
+        sub: "user-1".to_string(),
+        exp: future_exp(),
+        aud: None,
+    };
+    let token = sign_token(&key.encoding_key, Some("kid-1"), &claims);
+    let (result, logs) = authenticate_capturing(config, &token).await;
+
+    assert!(
+        result.is_err(),
+        "not being able to reach the JWKS is 'we cannot tell', not 'the token is bad'"
+    );
+    assert!(
+        logs.contains("could not reach the JWKS endpoint"),
+        "the fetch failure should be reported at the point it happens; got:\n{logs}"
+    );
+    assert!(
+        logs.contains("could not determine whether the token is valid"),
+        "and distinguished from a validation failure; got:\n{logs}"
+    );
+}
+
+/// A token naming a `kid` the issuer does not publish: the endpoint answered,
+/// the key is simply not there. Reported distinctly from a fetch failure,
+/// after the refresh-for-rotation retry.
+#[tokio::test(flavor = "current_thread")]
+async fn a_token_naming_an_unknown_kid_says_the_jwks_lacks_it() {
+    let served = generate_rsa_key(Some("kid-served"));
+    let other = generate_rsa_key(Some("kid-unknown"));
+    let server = start_jwks_server(vec![served.jwk.clone()]).await;
+    let config = ValidationConfig::builder()
+        .jwks_url(jwks_url(&server))
+        .build();
+
+    let claims = TestClaims {
+        sub: "user-1".to_string(),
+        exp: future_exp(),
+        aud: None,
+    };
+    let token = sign_token(&other.encoding_key, Some("kid-unknown"), &claims);
+    let (_result, logs) = authenticate_capturing(config, &token).await;
+
+    assert!(
+        logs.contains("refreshing in case of rotation"),
+        "the rotation retry should be visible; got:\n{logs}"
+    );
+    assert!(
+        logs.contains("does not contain"),
+        "and the give-up should say the JWKS lacks the key; got:\n{logs}"
+    );
+}

--- a/crates/authkestra-store-sqlx/src/lib.rs
+++ b/crates/authkestra-store-sqlx/src/lib.rs
@@ -159,11 +159,21 @@ async fn ensure_postgres_column(
     .fetch_one(pool)
     .await?;
     if exists == 0 {
+        // `info!`, not `debug!`: this alters the host application's schema.
+        // A deployment should be able to see that happen without having to
+        // turn debug logging on, and this whole path was silent.
+        tracing::info!(
+            table,
+            column,
+            "adding a missing column to the authkestra schema"
+        );
         sqlx::query(&format!(
             "ALTER TABLE authkestra.{table} ADD COLUMN IF NOT EXISTS {add_column_ddl}"
         ))
         .execute(pool)
         .await?;
+    } else {
+        tracing::debug!(table, column, "column already present; no migration needed");
     }
     Ok(())
 }
@@ -220,14 +230,30 @@ async fn ensure_sqlite_column(
         // the probe above and here; that is the *intended* end state, so it
         // is success, not a failed migration. Nothing else is tolerated —
         // see `is_sqlite_duplicate_column`.
+        tracing::info!(
+            table,
+            column,
+            "adding a missing column to the authkestra schema"
+        );
         if let Err(e) = sqlx::query(&format!("ALTER TABLE {table} ADD COLUMN {add_column_ddl}"))
             .execute(pool)
             .await
         {
             if !is_sqlite_duplicate_column(&e) {
+                tracing::error!(table, column, error = %e, "column migration failed");
                 return Err(e);
             }
+            // The intended end state, reached by somebody else. Worth a line
+            // during a rolling deploy: it says another replica won the race
+            // rather than that this one did nothing.
+            tracing::debug!(
+                table,
+                column,
+                "column was added concurrently by another process; treating as done"
+            );
         }
+    } else {
+        tracing::debug!(table, column, "column already present; no migration needed");
     }
     Ok(())
 }
@@ -257,14 +283,30 @@ async fn ensure_mysql_column(
     if exists == 0 {
         // See `ensure_sqlite_column`'s identical comment: only the losing
         // side of a check-then-ALTER race is tolerated here.
+        tracing::info!(
+            table,
+            column,
+            "adding a missing column to the authkestra schema"
+        );
         if let Err(e) = sqlx::query(&format!("ALTER TABLE {table} ADD COLUMN {add_column_ddl}"))
             .execute(pool)
             .await
         {
             if !is_mysql_duplicate_column(&e) {
+                tracing::error!(table, column, error = %e, "column migration failed");
                 return Err(e);
             }
+            // The intended end state, reached by somebody else. Worth a line
+            // during a rolling deploy: it says another replica won the race
+            // rather than that this one did nothing.
+            tracing::debug!(
+                table,
+                column,
+                "column was added concurrently by another process; treating as done"
+            );
         }
+    } else {
+        tracing::debug!(table, column, "column already present; no migration needed");
     }
     Ok(())
 }


### PR DESCRIPTION
Tier 3 of #353. All three of its claims were re-verified against the code before implementing, per the note that issue now carries after tier 2 — the counts were right this time.

## The headline gap: a silently rejected token

`JwtStrategy::authenticate` declined an invalid token with `Ok(None)` and **no log at all**:

```rust
Err(ValidationError::InvalidToken(_)) | Err(ValidationError::Jwt(_)) => Ok(None),
```

Expired, bad signature, wrong audience, wrong issuer — all silent. So a resource server could not answer the only question anyone asks it: *why was that token rejected?* **#335 is exactly that question**, and answering it took reading `jsonwebtoken`'s source.

Now recorded with the reason, at `debug!` — matching the convention already in that function, where a decline is `debug!` and "we could not tell" is `warn!`. The `Err` arm gained the latter, since a JWKS that cannot be fetched is not a bad credential; it's not knowing.

## The JWKS fetch was silent end to end

An unreachable, slow or malformed JWKS endpoint is among the most common ways a resource server stops working, and `Jwks::fetch_with` logged nothing — the error propagated as `ValidationError::Http` and surfaced only if some caller happened to log it.

Now reported where it happens, plus two conditions that previously looked identical:

| condition | previously |
|---|---|
| endpoint unreachable / malformed | silent |
| cached JWKS lacks the token's `kid`, refreshing for rotation | silent |
| endpoint answered, key genuinely absent | silent |

`authenticate` also gains a span (`skip_all` — `parts` carries the bearer token). Its twelve rejection events belonged to no span at all, so nothing tied them to a request.

## Also

**`Jwk::to_decoding_key`** had nine silent rejection branches. Callers turn any of them into the same rejection as a bad signature, so "the issuer published a key this crate cannot use" was indistinguishable from a forgery. Reported once at the boundary, as `verify_dpop_proof` already does.

**`authkestra-store-sqlx`** — tier 3's note about it was half right. It already logs an error per operation, so error visibility was fine. What was actually missing: the **schema migrations**, which alter the host application's database at startup and said nothing — not whether a column was added, was already there, or was added concurrently by another replica mid-rolling-deploy. Adding a column is now `info!`, because a deployment should see a schema change without turning debug on.

## ⚠️ The part that matters more: the capture tests from tiers 1 and 2 are flaky, and this fixes them

Writing these tests exposed it. **The log-capture tests already merged in #354 and #355 are order-dependent and fail intermittently.** actix's failed roughly half the time locally.

`tracing` caches callsite interest **globally**, and a thread-local subscriber installed by `with_default`/`set_default` does not invalidate that cache. Any test reaching a callsite while no subscriber is installed gets its interest cached as `never` — and a later capture at that callsite sees nothing, however correctly it installed its subscriber.

Two fixes were tried and **both were insufficient**, recorded in the code so nobody repeats them:

1. **Serializing captures under a mutex** — doesn't help. The tests that aren't capturing run concurrently and poison the cache.
2. **`rebuild_interest_cache()`** — doesn't help either, for the same reason: they re-poison it immediately after.

What works: **one global subscriber, installed once at `TRACE`, with a per-thread sink** deciding what is kept. Interest is then stable for the life of the process and capture needs no lock at all.

Verified over **eight consecutive full runs of all four affected crates: zero failures.**

This is why CI kept passing on #354 and #355 — it's intermittent, and they got lucky. Worth merging on that basis alone.

## Tests

Four new: the expired-token decline records why and doesn't log the token; an unreachable JWKS is a hard error rather than a decline, and both facts are visible; an unknown `kid` reports the rotation retry and the give-up; and `to_decoding_key` identifies which published key was unusable while staying silent on the hot path.

## Semver

No behaviour or public API change. Patch-compatible.

## Verification

All five gates pass locally: `fmt`, `clippy`, `test`, `coverage` (87.64%), `deny`. Touched files: `resource/src/jwt.rs` 94.12%, `token/jwk.rs` 87.50%, `store-sqlx/src/lib.rs` 91.05%.

## Remaining

Tier 4 (op's 80 `warn!` against 10 `info!`) still waits on your levelling policy — re-levelling 80 call sites on my judgement of what's operator-actionable isn't a call I should make for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)