### PR TITLE
refactor(actix): share one callback helper instead of two copies of the CSRF check

### DIFF
--- a/crates/authkestra-actix/src/helpers/api.rs
+++ b/crates/authkestra-actix/src/helpers/api.rs
@@ -1,5 +1,6 @@
 #![allow(unused_imports)]
 use actix_web::{cookie::Cookie, http::header, web, HttpRequest, HttpResponse};
+use authkestra_engine::auth::{Identity, OAuthToken};
 pub use authkestra_engine::auth::{Session, SessionConfig, SessionStore};
 use authkestra_engine::pkce::Pkce;
 use authkestra_engine::{state::OAuth2State, Engine, ErasedOAuthFlow, OAuth2Flow};
@@ -8,6 +9,11 @@ use std::sync::Arc;
 
 #[cfg(feature = "session")]
 use super::cookie::create_actix_cookie;
+
+/// The cookie carrying the encrypted OAuth state between the authorization
+/// redirect and the callback. Named once: it was written as a literal at each
+/// of the three places that touch it.
+const STATE_COOKIE: &str = "ak_state";
 
 /// The provider name, bounded, for use in a response body.
 ///
@@ -99,9 +105,7 @@ pub fn initiate_oauth_login_erased(
         .encrypt(&config.state_encryption_key)
         .expect("Failed to encrypt OAuth state");
 
-    let cookie_name = "ak_state";
-
-    let cookie = Cookie::build(cookie_name, encrypted)
+    let cookie = Cookie::build(STATE_COOKIE, encrypted)
         .path("/")
         .http_only(true)
         .same_site(actix_web::cookie::SameSite::Lax)
@@ -148,17 +152,32 @@ where
 }
 
 #[cfg(feature = "session")]
-pub async fn handle_oauth_callback_erased(
-    req: HttpRequest,
+/// Validates the callback's state cookie and exchanges the code for an
+/// identity, shared by both callbacks.
+///
+/// Extracted for #356. This crate previously inlined the sequence twice, once
+/// per callback, while `authkestra-axum` routed both of its callbacks through
+/// a single helper of the same name. The duplicated part is the CSRF defence,
+/// and the part that legitimately differs — creating a session versus issuing
+/// a token — sat immediately after it, which is the shape that invites drift.
+///
+/// It did drift: the debug line reporting the resolved identity was added to
+/// one copy and missed from the other, in the change that introduced it
+/// (#355, corrected in #357). Sharing the block removes the possibility
+/// rather than the instance.
+///
+/// The three failure modes are reported distinctly here, so an operator can
+/// tell a browser `SameSite` problem from a rotated `state_encryption_key`
+/// from a provider refusal — all three of which are otherwise an identical
+/// 401.
+async fn finalize_callback_erased(
+    req: &HttpRequest,
     flow: &dyn ErasedOAuthFlow,
-    params: OAuthCallbackParams,
-    store: Arc<dyn SessionStore>,
-    config: SessionConfig,
-    _success_url: &str,
-) -> Result<HttpResponse, actix_web::Error> {
-    let cookie_name = "ak_state";
+    params: &OAuthCallbackParams,
+    config: &SessionConfig,
+) -> Result<(Identity, OAuthToken, OAuth2State), actix_web::Error> {
     let encrypted_state = req
-        .cookie(cookie_name)
+        .cookie(STATE_COOKIE)
         .map(|c: Cookie| c.value().to_string())
         .ok_or_else(|| {
             // No cookie at all, which is usually the browser rather than the
@@ -181,8 +200,7 @@ pub async fn handle_oauth_callback_erased(
             actix_web::error::ErrorUnauthorized(format!("Invalid state cookie: {e}"))
         })?;
 
-    // Exchange code
-    let (mut identity, token) = flow
+    let (identity, token) = flow
         .finalize_login(&params.code, &params.state, &expected_state)
         .await
         .map_err(|e| {
@@ -195,6 +213,20 @@ pub async fn handle_oauth_callback_erased(
         external_id = %identity.external_id,
         "OAuth callback validated and exchanged for an identity"
     );
+
+    Ok((identity, token, expected_state))
+}
+
+pub async fn handle_oauth_callback_erased(
+    req: HttpRequest,
+    flow: &dyn ErasedOAuthFlow,
+    params: OAuthCallbackParams,
+    store: Arc<dyn SessionStore>,
+    config: SessionConfig,
+    _success_url: &str,
+) -> Result<HttpResponse, actix_web::Error> {
+    let (mut identity, token, expected_state) =
+        finalize_callback_erased(&req, flow, &params, &config).await?;
 
     // Store tokens in identity attributes for convenience
     identity
@@ -229,7 +261,7 @@ pub async fn handle_oauth_callback_erased(
     let cookie = create_actix_cookie(&config, session.id);
 
     // Remove the flow cookie
-    let remove_cookie = Cookie::build(cookie_name, "")
+    let remove_cookie = Cookie::build(STATE_COOKIE, "")
         .path("/")
         .secure(true)
         .max_age(actix_web::cookie::time::Duration::ZERO)
@@ -364,51 +396,8 @@ pub async fn handle_oauth_callback_jwt_erased(
     expires_in_secs: u64,
     config: SessionConfig,
 ) -> Result<HttpResponse, actix_web::Error> {
-    let cookie_name = "ak_state";
-
-    let encrypted_state = req
-        .cookie(cookie_name)
-        .map(|c: Cookie| c.value().to_string())
-        .ok_or_else(|| {
-            // No cookie at all, which is usually the browser rather than the
-            // user: a `SameSite`/`Secure` mismatch, or a callback arriving
-            // after the fifteen-minute lifetime.
-            tracing::warn!("OAuth callback carries no state cookie; cannot validate CSRF");
-            actix_web::error::ErrorUnauthorized("CSRF validation failed or session expired")
-        })?;
-
-    let expected_state = OAuth2State::decrypt(&encrypted_state, &config.state_encryption_key)
-        .map_err(|e| {
-            // The cookie arrived but would not decrypt. A rotated
-            // `state_encryption_key` fails every in-flight login exactly
-            // like this, and nothing else in the system would say so.
-            tracing::warn!(
-                error = %e,
-                "OAuth state cookie could not be decrypted; if the state encryption key \
-                 was rotated, logins started before the rotation will all fail this way"
-            );
-            actix_web::error::ErrorUnauthorized(format!("Invalid state cookie: {e}"))
-        })?;
-
-    // Exchange code
-    let (identity, _token) = flow
-        .finalize_login(&params.code, &params.state, &expected_state)
-        .await
-        .map_err(|e| {
-            // The state checked out; the provider exchange is what failed.
-            tracing::warn!(error = %e, "OAuth code exchange failed after state validation");
-            actix_web::error::ErrorUnauthorized(format!("Authentication failed: {e}"))
-        })?;
-
-    // Also emitted by the session callback above. On `authkestra-axum` one
-    // shared `finalize_callback_erased` covers both callbacks, so it cannot
-    // be present in one and missing from the other; here it has to be
-    // written twice. It was missing from this copy until a diff of the two
-    // blocks caught it, which is the drift #356 exists to remove.
-    tracing::debug!(
-        external_id = %identity.external_id,
-        "OAuth callback validated and exchanged for an identity"
-    );
+    let (identity, _token, _expected_state) =
+        finalize_callback_erased(req, flow, &params, &config).await?;
 
     let user_id = identity.external_id.clone();
     let jwt = token_manager
@@ -427,7 +416,7 @@ pub async fn handle_oauth_callback_jwt_erased(
     let mut res = HttpResponse::Ok();
 
     // Remove the flow cookie
-    let remove_cookie = Cookie::build(cookie_name, "")
+    let remove_cookie = Cookie::build(STATE_COOKIE, "")
         .path("/")
         .max_age(actix_web::cookie::time::Duration::ZERO)
         .secure(true)

--- a/crates/authkestra-axum/src/helpers/api.rs
+++ b/crates/authkestra-axum/src/helpers/api.rs
@@ -37,14 +37,14 @@ pub struct OAuthLoginParams {
     pub success_url: Option<String>,
 }
 
-/// Helper to initiate the OAuth2 login flow.
-///
-/// This generates the authorization URL and sets a CSRF state cookie.
 /// The cookie carrying the encrypted OAuth state between the authorization
 /// redirect and the callback. Named once rather than repeated as a literal,
 /// matching `authkestra-actix` (#356).
 const STATE_COOKIE: &str = "ak_state";
 
+/// Helper to initiate the OAuth2 login flow.
+///
+/// This generates the authorization URL and sets a CSRF state cookie.
 pub fn initiate_oauth_login(
     flow: &dyn ErasedOAuthFlow,
     cookies: &Cookies,

--- a/crates/authkestra-axum/src/helpers/api.rs
+++ b/crates/authkestra-axum/src/helpers/api.rs
@@ -40,6 +40,11 @@ pub struct OAuthLoginParams {
 /// Helper to initiate the OAuth2 login flow.
 ///
 /// This generates the authorization URL and sets a CSRF state cookie.
+/// The cookie carrying the encrypted OAuth state between the authorization
+/// redirect and the callback. Named once rather than repeated as a literal,
+/// matching `authkestra-actix` (#356).
+const STATE_COOKIE: &str = "ak_state";
+
 pub fn initiate_oauth_login(
     flow: &dyn ErasedOAuthFlow,
     cookies: &Cookies,
@@ -57,9 +62,7 @@ pub fn initiate_oauth_login(
         .encrypt(&config.state_encryption_key)
         .expect("Failed to encrypt OAuth state");
 
-    let cookie_name = "ak_state";
-
-    let mut cookie = Cookie::new(cookie_name, encrypted);
+    let mut cookie = Cookie::new(STATE_COOKIE, encrypted);
     cookie.set_path("/");
     cookie.set_http_only(true);
     cookie.set_same_site(SameSite::Lax);
@@ -88,10 +91,8 @@ async fn finalize_callback_erased(
     params: &OAuthCallbackParams,
     config: &SessionConfig,
 ) -> Result<(Identity, OAuthToken, OAuth2State), (StatusCode, String)> {
-    let cookie_name = "ak_state";
-
     let encrypted_state = cookies
-        .get(cookie_name)
+        .get(STATE_COOKIE)
         .map(|c| c.value().to_string())
         .ok_or_else(|| {
             // No cookie at all, which is usually the browser rather than the
@@ -123,7 +124,7 @@ async fn finalize_callback_erased(
         })?;
 
     // Remove cookie after use
-    let mut remove_cookie = Cookie::new(cookie_name, "");
+    let mut remove_cookie = Cookie::new(STATE_COOKIE, "");
     remove_cookie.set_path("/");
     remove_cookie.set_secure(true);
 


### PR DESCRIPTION
Closes #356. Patch-safe — private helper, no public API touched.

## The problem

`authkestra-actix` inlined the OAuth callback's state validation **twice**, once per callback, while `authkestra-axum` routed both of its callbacks through a single `finalize_callback_erased`.

The duplicated part was the **CSRF defence** — state cookie presence, decryption, code exchange. The part that legitimately differs, creating a session versus issuing a token, sat immediately after it. That's the shape that invites drift.

## It already drifted

The debug line reporting the resolved identity was added to one copy and **missed from the other in the change that introduced it** (#355, corrected in #357).

Worse: the stateless copy's three failure paths had **no test at all** until #355. So the duplicated security check had one tested copy and one untested one.

## The fix

Extracted to a private helper of the same name and shape as axum's, called from both callbacks. **50 lines replace 61**, and the possibility of divergence is gone rather than just the instance.

## Why you can trust it's behaviour-preserving

**#355's tests pass unchanged.** All six failure-mode tests across both callbacks — no state cookie, an undecryptable one, a refused code exchange — still hold on the session *and* stateless paths.

They were written against the duplicated code and were not touched in this PR, which is precisely what makes them evidence rather than decoration. That's why #356 was worth doing now and not later: the tests to verify it already existed.

## One thing beyond the issue

`"ak_state"` was a literal at each of the three places that touch it in actix, and each of the two in axum. Both crates now use a `STATE_COOKIE` constant.

Tidying only actix would have created a *fresh* asymmetry between the adapters — one with a constant, one with literals — which is the class of problem this issue is about. Hence the 15-line axum diff in a PR named for actix.

## Semver

Patch-compatible. `finalize_callback_erased` is private; the two public callbacks keep their signatures and behaviour.

## Verification

All five gates pass locally: `fmt`, `clippy`, `test`, `coverage` (87.95%), `deny`. Helper coverage: actix 84.16%, axum 84.69%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)